### PR TITLE
Include MultiheadAttention module in C# API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,5 @@ packages/
 .ionide
 *.bin
 /*.png
+/src/Native/out/build/x64-Debug
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -269,4 +269,3 @@ packages/
 *.bin
 /*.png
 /src/Native/out/build/x64-Debug
-.gitignore

--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -593,6 +593,33 @@ Tensor   THSNN_TransformerDecoderLayer_forward(const NNModule module, const Tens
     );
 }
 
+NNModule THSNN_MultiheadAttention_ctor(const int64_t embeded_dim, const int64_t num_heads, const double dropout, const bool bias, const bool add_bias_kv, const bool add_zero_attn, const int64_t kdim, const int64_t vdim, NNAnyModule* outAsAnyModule)
+{
+    CATCH_RETURN_NNModule(
+        auto opts = torch::nn::MultiheadAttentionOptions(embeded_dim, num_heads)
+        .dropout(dropout)
+        .bias(bias)
+        .add_bias_kv(add_bias_kv)
+        .add_zero_attn(add_zero_attn)
+        .kdim(kdim)
+        .vdim(vdim);
+
+    res = create_module<torch::nn::MultiheadAttentionImpl>(opts, outAsAnyModule);
+    );
+}
+
+void THSNN_MultiheadAttention_forward(const NNModule module, const Tensor query, const Tensor key, const Tensor value, const Tensor key_padding_mask, const bool need_weights, const Tensor attn_mask, Tensor& res1, Tensor& res2)
+{
+    CATCH_TENSORS_2((*module)->as<torch::nn::MultiheadAttention>()->forward(
+        *query,
+        *key,
+        *value,
+        (key_padding_mask ? *key_padding_mask : at::Tensor()),
+        need_weights,
+        (attn_mask ? *attn_mask : at::Tensor()))
+    );
+}
+
 NNModule THSNN_TransformerEncoder_ctor(const NNModule encoder_layer, const int64_t num_layers, NNAnyModule* outAsAnyModule)
 {
     CATCH_RETURN_NNModule(

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -267,6 +267,9 @@ EXPORT_API(NNModule) THSNN_TransformerEncoder_ctor(const NNModule encoder_layer,
 EXPORT_API(Tensor)   THSNN_TransformerEncoder_forward(const NNModule module, const Tensor src, const Tensor src_mask, const Tensor src_key_padding_mask);
 EXPORT_API(NNModule) THSNN_TransformerDecoder_ctor(const NNModule decoder_layer, const int64_t num_layers, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_TransformerDecoder_forward(const NNModule module, const Tensor tgt, const Tensor memory, const Tensor tgt_mask, const Tensor memory_mask, const Tensor tgt_key_padding_mask, const Tensor memory_key_padding_mask);
+EXPORT_API(NNModule) THSNN_MultiheadAttention_ctor(const int64_t embeded_dim, const int64_t num_heads, const double dropout, const bool bias, const bool add_bias_kv, const bool add_zero_attn, const int64_t kdim, const int64_t vdim, NNAnyModule* outAsAnyModule);
+EXPORT_API(void)     THSNN_MultiheadAttention_forward(const NNModule module, const Tensor query, const Tensor key, const Tensor value, const Tensor key_padding_mask, const bool need_weights, const Tensor attn_mask, Tensor& res1, Tensor& res2);
+
 
 // Recurrent
 

--- a/src/Native/LibTorchSharp/Utils.h
+++ b/src/Native/LibTorchSharp/Utils.h
@@ -60,6 +60,15 @@ inline Tensor ResultTensor(const at::Tensor & res)
     );  \
     return ResultTensor(res);
 
+#define CATCH_TENSORS_2(expr) \
+    at::Tensor fst = at::Tensor();  \
+    at::Tensor snd = at::Tensor();  \
+    CATCH(  \
+        std::tie(fst,snd) = expr;  \
+    );  \
+    res1 = ResultTensor(fst); \
+    res2 = ResultTensor(snd);     
+
 #define CATCH_SCALAR(expr) \
     at::Scalar res = at::Scalar(); \
     CATCH(  \

--- a/src/TorchSharp/NN/MultiheadAttention.cs
+++ b/src/TorchSharp/NN/MultiheadAttention.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation and contributors.  All Rights Reserved.  See License.txt in the project root for license information.
+using System;
+using System.Runtime.InteropServices;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+#nullable enable
+namespace TorchSharp
+{
+    using Modules;
+
+    namespace Modules
+    {
+        public class MultiheadAttention : torch.nn.Module
+        {
+            internal MultiheadAttention(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_MultiheadAttention_forward(torch.nn.Module.HType module, IntPtr query, IntPtr key, IntPtr value, IntPtr key_padding_mask, bool need_weights, IntPtr attn_mask, out IntPtr res1, out IntPtr res2);
+            /// <summary>
+            /// Applies the MultiheadAttention function element-wise.
+            /// </summary>
+            /// <param name="query">map a query and a set of key-value pairs to an output. See “Attention Is All You Need” for more details</param>
+            /// <param name="key"></param>
+            /// <param name="value"></param>
+            /// <param name="key_padding_mask">if provided, specified padding elements in the key will be ignored by the attention. When given a binary mask and a value is True, the corresponding value on the attention layer will be ignored. When given a byte mask and a value is non-zero, the corresponding value on the attention layer will be ignored</param>
+            /// <param name="need_weights">output attn_output_weights</param>
+            /// <param name="attn_mask">2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all the batches while a 3D mask allows to specify a different mask for the entries of each batch</param>
+            /// <returns>attn_output, attn_ouput_weights</returns>
+
+            public Tuple<Tensor,Tensor> forward(Tensor query, Tensor key, Tensor value, Tensor? key_padding_mask = null, bool need_weights = true, Tensor? attn_mask = null)
+            //const NNModule module, const Tensor query, const Tensor key, const Tensor value, const Tensor key_padding_mask, const bool need_weights, const Tensor attn_mask, Tensor res1, Tensor res2 )
+            {
+                //var res1 = IntPtr.Zero;
+                //var res2 = IntPtr.Zero;
+                THSNN_MultiheadAttention_forward(handle,
+                    query.Handle,
+                    key.Handle,
+                    value.Handle,
+                    key_padding_mask?.Handle ?? IntPtr.Zero,
+                    need_weights,
+                    attn_mask?.Handle ?? IntPtr.Zero,
+                    out var res1,
+                    out var res2);
+                if (res1 == IntPtr.Zero) { torch.CheckForErrors(); }
+                return Tuple.Create(new Tensor(res1), new Tensor(res2));
+            }
+        }
+    }
+
+    public static partial class torch
+    {
+        public static partial class nn
+        {
+            [DllImport("LibTorchSharp")]
+            private static extern IntPtr THSNN_MultiheadAttention_ctor(long embeded_dim, long num_heads, double dropout, bool bias, bool add_bias_kv, bool add_zero_attn, long kdim, long vdim, out IntPtr pBoxedModule);
+
+            /// <summary>
+            /// Allows the model to jointly attend to information from different representation subspaces (based on the paper “Attention Is All You Need”). 
+            /// </summary>
+            /// <param name="embeded_dim">total dimension of the model</param>
+            /// <param name="num_heads">parallel attention heads</param>
+            /// <param name="dropout">a Dropout layer on attn_output_weights. Default: 0.0</param>
+            /// <param name="bias">add bias as module parameter. Default: true</param>
+            /// <param name="add_bias_kv">add bias to the key and value sequences at dim=0</param>
+            /// <param name="add_zero_attn">add a new batch of zeros to the key and value sequences at dim=1</param>
+            /// <param name="kdim">total number of features in key</param>
+            /// <param name="vdim">total number of features in value</param>
+            /// <returns></returns>
+            static public MultiheadAttention MultiheadAttention(long embeded_dim, long num_heads, double dropout = 0.0, bool bias = true, bool add_bias_kv = false, bool add_zero_attn = false, long? kdim=null, long? vdim=null)
+            {
+                var _kdim = kdim.HasValue ? kdim.Value : embeded_dim;
+                var _vdim = vdim.HasValue ? vdim.Value : embeded_dim;
+                var res = THSNN_MultiheadAttention_ctor(embeded_dim, num_heads, dropout, bias, add_bias_kv, add_zero_attn, _kdim, _vdim, out var boxedHandle);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new MultiheadAttention(res, boxedHandle);
+            }
+        }
+    }
+}

--- a/src/TorchSharp/NN/MultiheadAttention.cs
+++ b/src/TorchSharp/NN/MultiheadAttention.cs
@@ -41,7 +41,7 @@ namespace TorchSharp
                     attn_mask?.Handle ?? IntPtr.Zero,
                     out var res1,
                     out var res2);
-                if (res1 == IntPtr.Zero) { torch.CheckForErrors(); }
+                if (res1 == IntPtr.Zero || (need_weights && res2 == IntPtr.Zero)) { torch.CheckForErrors(); }
                 return Tuple.Create(new Tensor(res1), new Tensor(res2));
             }
         }
@@ -57,7 +57,7 @@ namespace TorchSharp
             /// <summary>
             /// Allows the model to jointly attend to information from different representation subspaces (based on the paper “Attention Is All You Need”). 
             /// </summary>
-            /// <param name="embeded_dim">total dimension of the model</param>
+            /// <param name="embedded_dim">total dimension of the model</param>
             /// <param name="num_heads">parallel attention heads</param>
             /// <param name="dropout">a Dropout layer on attn_output_weights. Default: 0.0</param>
             /// <param name="bias">add bias as module parameter. Default: true</param>
@@ -66,11 +66,11 @@ namespace TorchSharp
             /// <param name="kdim">total number of features in key</param>
             /// <param name="vdim">total number of features in value</param>
             /// <returns></returns>
-            static public MultiheadAttention MultiheadAttention(long embeded_dim, long num_heads, double dropout = 0.0, bool bias = true, bool add_bias_kv = false, bool add_zero_attn = false, long? kdim=null, long? vdim=null)
+            static public MultiheadAttention MultiheadAttention(long embedded_dim, long num_heads, double dropout = 0.0, bool bias = true, bool add_bias_kv = false, bool add_zero_attn = false, long? kdim=null, long? vdim=null)
             {
-                var _kdim = kdim.HasValue ? kdim.Value : embeded_dim;
-                var _vdim = vdim.HasValue ? vdim.Value : embeded_dim;
-                var res = THSNN_MultiheadAttention_ctor(embeded_dim, num_heads, dropout, bias, add_bias_kv, add_zero_attn, _kdim, _vdim, out var boxedHandle);
+                var _kdim = kdim.HasValue ? kdim.Value : embedded_dim;
+                var _vdim = vdim.HasValue ? vdim.Value : embedded_dim;
+                var res = THSNN_MultiheadAttention_ctor(embedded_dim, num_heads, dropout, bias, add_bias_kv, add_zero_attn, _kdim, _vdim, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new MultiheadAttention(res, boxedHandle);
             }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -2040,6 +2040,52 @@ namespace TorchSharp
                 Assert.Equal(tgt.shape, output.shape);
             }
         }
+
+        [Fact]
+        public void TestMultiheadAttention()
+        {
+            var num_heads = 1;
+            var qembed_dim = 2L; // Must be divisible by the number of heads
+            var kembed_dim = 2L;
+            var vembed_dim = 2L;
+            var src_seq_len = 3L;
+            var tgt_seq_len = 3L;
+            var batch_size = 1L;
+            var dropout = 0.0; //  # This is not supported
+            var bias = false;
+            var add_bias_kv = false;
+            var add_zero_attn = false;
+
+            var q_data = new float[]{  0.3367f, 0.1288f,
+                                       0.2345f,  0.2303f,
+                                       -1.1229f, -0.1863f};
+
+            var k_data = new float[] { 2.2082f, -0.6380f,
+                                       0.4617f,  0.2674f,
+                                       0.5349f,  0.8094f};
+
+            var v_data = new float[] {1.1103f, -1.6898f,
+                                      -0.9890f,  0.9580f,
+                                       1.3221f,  0.8172f};
+
+            var attn_data = new float[] {0.342628956f, 0.3370244f, 0.3203467f,
+                                         0.336390018f, 0.333694249f, 0.329915673f,
+                                         0.296296269f, 0.314919323f, 0.388784438f};
+
+
+
+            using (var mha = MultiheadAttention(qembed_dim, num_heads, dropout: dropout, bias: bias, add_bias_kv: add_bias_kv, add_zero_attn: add_zero_attn, kdim: kembed_dim, vdim: vembed_dim))
+            using (var Q = Float32Tensor.from(q_data, tgt_seq_len, batch_size, qembed_dim))
+            using (var K = Float32Tensor.from(k_data, src_seq_len, batch_size, kembed_dim))
+            using (var V = Float32Tensor.from(v_data, src_seq_len, batch_size, vembed_dim))
+            using (var Attn = Float32Tensor.from(attn_data, batch_size, src_seq_len, src_seq_len)) {
+                mha.Eval();
+                var (att_out, att_wts) = mha.forward(Q, K, V);
+                var t = att_wts.allclose(Attn, rtol: 0.5, atol: 0.5);
+                Assert.True(t);
+            }
+        }
+
         #endregion
 
         #region Dropout


### PR DESCRIPTION
We need the MultiheadAttention module by itself for some types of models. 

Although MultiheadAttention is part of the transformer modules, it is also needed separately (i.e. outside of transformer) for some models.

