### PR TITLE
Use xlogy instead of y.log()*x for log_prob in Dirichlet and Poisson

### DIFF
--- a/src/TorchSharp/Distributions/Dirichlet.cs
+++ b/src/TorchSharp/Distributions/Dirichlet.cs
@@ -43,7 +43,7 @@ namespace TorchSharp
 
             public override Tensor log_prob(Tensor value)
             {
-                return (value.log() * (concentration - 1)).sum(-1) + torch.lgamma(concentration.sum(-1)) - torch.lgamma(concentration).sum(-1);
+                return (concentration - 1).xlogy(value).sum(-1) + torch.lgamma(concentration.sum(-1)) - torch.lgamma(concentration).sum(-1);
             }
 
             public override Tensor entropy()

--- a/src/TorchSharp/Distributions/Poisson.cs
+++ b/src/TorchSharp/Distributions/Poisson.cs
@@ -40,7 +40,7 @@ namespace TorchSharp
                 var bcast = torch.broadcast_tensors(rate, value);
                 var r = bcast[0];
                 var v = bcast[1];
-                return r.log() * value - r - (value + 1).lgamma();
+                return value.xlogy(r) - r - (value + 1).lgamma();
             }
 
             public override Tensor cdf(Tensor value)


### PR DESCRIPTION
`xlogy` is more numerically stable than explicit maths.

See https://github.com/pytorch/pytorch/blob/f596aa8b77d6c57dd82f33a45926fad95ab2a21e/torch/distributions/poisson.py#L63 for example.