### PR TITLE
Fix Net docs

### DIFF
--- a/src/Examples/MobileNet.cs
+++ b/src/Examples/MobileNet.cs
@@ -10,10 +10,6 @@ namespace TorchSharp.Examples
     /// <summary>
     /// Modified version of MobileNet to classify CIFAR10 32x32 images.
     /// </summary>
-    /// <remarks>
-    /// With an unaugmented CIFAR-10 data set, the author of this saw training converge
-    /// at roughly 75% accuracy on the test set, over the course of 1500 epochs.
-    /// </remarks>
     class MobileNet : Module
     {
         // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/mobilenet.py

--- a/src/Examples/MobileNet.cs
+++ b/src/Examples/MobileNet.cs
@@ -10,6 +10,10 @@ namespace TorchSharp.Examples
     /// <summary>
     /// Modified version of MobileNet to classify CIFAR10 32x32 images.
     /// </summary>
+    /// <remarks>
+    /// With an unaugmented CIFAR-10 data set, the author of this saw training converge
+    /// at roughly 75% accuracy on the test set, over the course of 1500 epochs.
+    /// </remarks>
     class MobileNet : Module
     {
         // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/mobilenet.py

--- a/src/Examples/ResNet.cs
+++ b/src/Examples/ResNet.cs
@@ -10,10 +10,6 @@ namespace TorchSharp.Examples
     /// <summary>
     /// Modified version of ResNet to classify CIFAR10 32x32 images.
     /// </summary>
-    /// <remarks>
-    /// With an unaugmented CIFAR-10 data set, the author of this saw training converge
-    /// at roughly 75% accuracy on the test set, over the course of 1500 epochs.
-    /// </remarks>
     class ResNet : Module
     {
         // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/resnet.py

--- a/src/Examples/ResNet.cs
+++ b/src/Examples/ResNet.cs
@@ -8,7 +8,7 @@ using static TorchSharp.torch.nn;
 namespace TorchSharp.Examples
 {
     /// <summary>
-    /// Modified version of MobileNet to classify CIFAR10 32x32 images.
+    /// Modified version of ResNet to classify CIFAR10 32x32 images.
     /// </summary>
     /// <remarks>
     /// With an unaugmented CIFAR-10 data set, the author of this saw training converge


### PR DESCRIPTION
* Replace "MobileNet" with "ResNet" for ResNet implementation's Doc.
* Remove Remarks for MobileNet and ResNet

Hi @NiklasGustafsson, I removed the remarks from these files because it looks to me that they were copied from the VGG file (based on this [commit](https://github.com/dotnet/TorchSharp/commit/bf29b30ea4cf9917b9bf70f9674b0b010672e93c)) which later got upated [here](https://github.com/dotnet/TorchSharp/commit/25d32343ee929b828ad1c678ca60768a4489dde8). Please let me know if you wish to keep the remark sections.