### PR TITLE
Improve Transform Docs

### DIFF
--- a/src/TorchSharp/TorchVision/CenterCrop.cs
+++ b/src/TorchSharp/TorchVision/CenterCrop.cs
@@ -29,6 +29,8 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Crop the center of the image.
         /// </summary>
+        /// <param name="height">Desired output height of the crop</param>
+        /// <param name="width">Desired output width of the crop</param>
         static public ITransform CenterCrop(int height, int width)
         {
             return new CenterCrop(height, width);
@@ -37,6 +39,7 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Crop the center of the image.
         /// </summary>
+        /// <param name="size">Desired output size of the crop</param>
         static public ITransform CenterCrop(int size)
         {
             return new CenterCrop(size, size);

--- a/src/TorchSharp/TorchVision/ConvertImageDType.cs
+++ b/src/TorchSharp/TorchVision/ConvertImageDType.cs
@@ -29,6 +29,7 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Convert a tensor image to the given dtype and scale the values accordingly
         /// </summary>
+        /// <param name="dtype">Desired data type of the output</param>
         static public ITransform ConvertImageDType(ScalarType dtype)
         {
             return new ConvertImageDType(dtype);

--- a/src/TorchSharp/TorchVision/Functional.cs
+++ b/src/TorchSharp/TorchVision/Functional.cs
@@ -593,7 +593,6 @@ namespace TorchSharp.torchvision
                     throw new NotImplementedException("Interpolation mode != 'Nearest'");
                 }
 
-
                 var img = SqueezeIn(input, new ScalarType[] { ScalarType.Float32, ScalarType.Float64 }, out var needCast, out var needSqueeze, out var dtype);
 
                 img = torch.nn.functional.interpolate(img, new long[] { h, w }, mode: interpolation, align_corners: null);

--- a/src/TorchSharp/TorchVision/GaussianBlur.cs
+++ b/src/TorchSharp/TorchVision/GaussianBlur.cs
@@ -32,8 +32,8 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Apply a Gaussian blur effect to the image.
         /// </summary>
-        /// <param name="kernelSize"></param>
-        /// <param name="sigma"></param>
+        /// <param name="kernelSize">Gaussian kernel size</param>
+        /// <param name="sigma">Gaussian kernel standard deviation</param>
         /// <returns></returns>
         static public ITransform GaussianBlur(IList<long> kernelSize, float sigma)
         {
@@ -43,6 +43,9 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Apply a Gaussian blur effect to the image.
         /// </summary>
+        /// <param name="kernelSize">Gaussian kernel size</param>
+        /// <param name="min">minimum value of the range for the uniform distribution from which the Gaussian kernel standard deviation will sampled</param>
+        /// <param name="max">maximum value of the range for the uniform distribution from which the Gaussian kernel standard deviation will sampled</param>
         static public ITransform GaussianBlur(IList<long> kernelSize, float min = 0.1f, float max = 2.0f)
         {
             return new GaussianBlur(kernelSize, min, max);
@@ -51,6 +54,8 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Apply a Gaussian blur effect to the image.
         /// </summary>
+        /// <param name="kernelSize">Gaussian kernel size</param>
+        /// <param name="sigma">Gaussian kernel standard deviation</param>
         static public ITransform GaussianBlur(long kernelSize, float sigma)
         {
             return new GaussianBlur(new long[] { kernelSize, kernelSize }, sigma, sigma);
@@ -59,6 +64,9 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Apply a Gaussian blur effect to the image.
         /// </summary>
+        /// <param name="kernelSize">Gaussian kernel size</param>
+        /// <param name="min">minimum value of the range for the uniform distribution from which the Gaussian kernel standard deviation will sampled</param>
+        /// <param name="max">maximum value of the range for the uniform distribution from which the Gaussian kernel standard deviation will sampled</param>
         static public ITransform GaussianBlur(long kernelSize, float min = 0.1f, float max = 2.0f)
         {
             return new GaussianBlur(new long[] { kernelSize, kernelSize }, min, max);
@@ -67,6 +75,9 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Apply a Gaussian blur effect to the image.
         /// </summary>
+        /// <param name="kernelHeight">Gaussian kernel height</param>
+        /// <param name="kernelWidth">Gaussian kernel width</param>
+        /// <param name="sigma">Gaussian kernel standard deviation</param>
         static public ITransform GaussianBlur(long kernelHeight, long kernelWidth, float sigma)
         {
             return new GaussianBlur(new long[] { kernelHeight, kernelWidth }, sigma, sigma);
@@ -75,6 +86,10 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Apply a Gaussian blur effect to the image.
         /// </summary>
+        /// <param name="kernelHeight">Gaussian kernel height</param>
+        /// <param name="kernelWidth">Gaussian kernel width</param>
+        /// <param name="min">minimum value of the range for the uniform distribution from which the Gaussian kernel standard deviation will sampled</param>
+        /// <param name="max">minimum value of the range for the uniform distribution from which the Gaussian kernel standard deviation will sampled</param>
         static public ITransform GaussianBlur(long kernelHeight, long kernelWidth, float min = 0.1f, float max = 2.0f)
         {
             return new GaussianBlur(new long[] { kernelHeight, kernelWidth }, min, max);

--- a/src/TorchSharp/TorchVision/Normalize.cs
+++ b/src/TorchSharp/TorchVision/Normalize.cs
@@ -70,7 +70,6 @@ namespace TorchSharp.torchvision
         /// <param name="dtype">Bool to make this operation inplace.</param>
         /// <param name="device">The device to place the output tensor on.</param>
         /// <returns></returns>
-
         static public ITransform Normalize(double[] means, double[] stdevs, ScalarType dtype = ScalarType.Float32, torch.Device device = null)
         {
             return new Normalize(means, stdevs, dtype, device);

--- a/src/TorchSharp/TorchVision/RandomPerspective.cs
+++ b/src/TorchSharp/TorchVision/RandomPerspective.cs
@@ -75,8 +75,8 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Performs a random perspective transformation of the given image with a given probability.
         /// </summary>
-        /// <param name="distortion"></param>
-        /// <param name="p"></param>
+        /// <param name="distortion">argument to control the degree of distortion and ranges from 0 to 1. Default is 0.5.</param>
+        /// <param name="p">probability of the image being transformed. Default is 0.5.</param>
         /// <returns></returns>
         /// <remarks>The application and perspectives are all stochastic.</remarks>
         static public ITransform RandomPerspective(double distortion = 0.5, double p = 0.5)

--- a/src/TorchSharp/TorchVision/RandomResizedCrop.cs
+++ b/src/TorchSharp/TorchVision/RandomResizedCrop.cs
@@ -55,6 +55,12 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Crop a random portion of image and resize it to a given size. 
         /// </summary>
+        /// <param name="height">expected output height of the crop</param>
+        /// <param name="width">expected output width of the crop</param>
+        /// <param name="scaleMin">lower bounds for the random area of the crop</param>
+        /// <param name="scaleMax">upper bounds for the random area of the crop</param>
+        /// <param name="ratioMin">lower bounds for the random aspect ratio of the crop</param>
+        /// <param name="ratioMax">upper bounds for the random aspect ratio of the crop</param>
         static public ITransform RandomResizedCrop(int height, int width, double scaleMin = 0.08, double scaleMax = 1.0, double ratioMin = 0.75, double ratioMax = 1.3333333333333)
         {
             return new RandomResizedCrop(height, width, scaleMin, scaleMax, ratioMin, ratioMax);
@@ -63,6 +69,11 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Crop a random portion of image and resize it to a given size. 
         /// </summary>
+        /// <param name="size">expected output size of the crop</param>
+        /// <param name="scaleMin">lower for the random area of the crop</param>
+        /// <param name="scaleMax">upper bounds for the random area of the crop</param>
+        /// <param name="ratioMin">lower bounds for the random aspect ratio of the crop</param>
+        /// <param name="ratioMax">upper bounds for the random aspect ratio of the crop</param>
         static public ITransform RandomResizedCrop(int size, double scaleMin = 0.08, double scaleMax = 1.0, double ratioMin = 0.75, double ratioMax = 1.3333333333333)
         {
             return RandomResizedCrop(size, size, scaleMin, scaleMax, ratioMin, ratioMax);

--- a/src/TorchSharp/TorchVision/RandomRotation.cs
+++ b/src/TorchSharp/TorchVision/RandomRotation.cs
@@ -9,10 +9,10 @@ namespace TorchSharp.torchvision
 {
     internal class RandomRotation : ITransform
     {
-        public RandomRotation((double, double) degrees, InterpolationMode mode = InterpolationMode.Nearest, bool expand = false, (int, int)? center = null, IList<float> fill = null)
+        public RandomRotation((double, double) degrees, InterpolationMode interpolation = InterpolationMode.Nearest, bool expand = false, (int, int)? center = null, IList<float> fill = null)
         {
             this.degrees = degrees;
-            this.mode = mode;
+            this.interpolation = interpolation;
             this.center = center;
             this.expand = expand;
             this.fill = fill;
@@ -23,7 +23,7 @@ namespace TorchSharp.torchvision
             var random = new Random();
             var angle = random.NextDouble() * (degrees.Item2 - degrees.Item1) + degrees.Item1;
 
-            var rotate = torchvision.transforms.Rotate((float)angle, mode, expand, center, fill);
+            var rotate = torchvision.transforms.Rotate((float)angle, interpolation, expand, center, fill);
             return rotate.forward(input);
         }
 
@@ -31,7 +31,7 @@ namespace TorchSharp.torchvision
         private bool expand;
         private (int, int)? center;
         private IList<float> fill;
-        private InterpolationMode mode;
+        private InterpolationMode interpolation;
     }
 
     public static partial class transforms
@@ -39,17 +39,27 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Rotate the image by a random angle. 
         /// </summary>
-        static public ITransform RandomRotation(double degrees, InterpolationMode mode = InterpolationMode.Nearest, bool expand = false, (int, int)? center = null, IList<float> fill = null)
+        /// <param name="degrees">Range of degrees to select from (-degrees, +degrees).</param>
+        /// <param name="interpolation">Desired interpolation enum. Default is `InterpolationMode.NEAREST`.</param>
+        /// <param name="expand">If true, expands the output to make it large enough to hold the entire rotated image. If false or omitted, make the output image the same size as the input image. Note that the expand flag assumes rotation around the center and no translation.</param>
+        /// <param name="center">center of rotation, (x, y). Origin is the upper left corner.</param>
+        /// <param name="fill">Pixel fill value for the area outside the rotated. If given a number, the value is used for all bands respectively.</param>
+        static public ITransform RandomRotation(double degrees, InterpolationMode interpolation = InterpolationMode.Nearest, bool expand = false, (int, int)? center = null, IList<float> fill = null)
         {
-            return new RandomRotation((-degrees, degrees), mode, expand, center, fill);
+            return new RandomRotation((-degrees, degrees), interpolation, expand, center, fill);
         }
 
         /// <summary>
         ///Rotate the image by a random angle.  
         /// </summary>
-        static public ITransform RandomRotation((double, double) degrees, InterpolationMode mode = InterpolationMode.Nearest, bool expand = false, (int, int)? center = null, IList<float> fill = null)
+        /// <param name="degrees">Range of degrees to select from</param>
+        /// <param name="interpolation">Desired interpolation enum. Default is `InterpolationMode.NEAREST`.</param>
+        /// <param name="expand">If true, expands the output to make it large enough to hold the entire rotated image. If false or omitted, make the output image the same size as the input image. Note that the expand flag assumes rotation around the center and no translation.</param>
+        /// <param name="center">center of rotation, (x, y). Origin is the upper left corner.</param>
+        /// <param name="fill">Pixel fill value for the area outside the rotated. If given a number, the value is used for all bands respectively.</param>
+        static public ITransform RandomRotation((double, double) degrees, InterpolationMode interpolation = InterpolationMode.Nearest, bool expand = false, (int, int)? center = null, IList<float> fill = null)
         {
-            return RandomRotation(degrees, mode, expand, center, fill);
+            return RandomRotation(degrees, interpolation, expand, center, fill);
         }
     }
 }

--- a/src/TorchSharp/TorchVision/Resize.cs
+++ b/src/TorchSharp/TorchVision/Resize.cs
@@ -63,8 +63,8 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Resize the input image to the given size.
         /// </summary>
-        /// <param name="height"></param>
-        /// <param name="width"></param>
+        /// <param name="height">Desired output height</param>
+        /// <param name="width">Desired output width</param>
         /// <returns></returns>
         static public ITransform Resize(int height, int width)
         {
@@ -74,8 +74,8 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Resize the input image to the given size.
         /// </summary>
-        /// <param name="size"></param>
-        /// <param name="maxSize"></param>
+        /// <param name="size">Desired output size</param>
+        /// <param name="maxSize">max size</param>
         static public ITransform Resize(int size, int? maxSize = null)
         {
             return new Resize(size, -1, maxSize);

--- a/src/TorchSharp/TorchVision/ResizedCrop.cs
+++ b/src/TorchSharp/TorchVision/ResizedCrop.cs
@@ -35,7 +35,6 @@ namespace TorchSharp.torchvision
         /// <param name="width">Width of the crop box.</param>
         /// <param name="newHeight">New height.</param>
         /// <param name="newWidth">New width.</param>
-
         static public ITransform ResizedCrop(int top, int left, int height, int width, int newHeight, int newWidth)
         {
             return new ResizedCrop(top, left, height, width, newHeight, newWidth);

--- a/src/TorchSharp/TorchVision/Rotate.cs
+++ b/src/TorchSharp/TorchVision/Rotate.cs
@@ -34,6 +34,11 @@ namespace TorchSharp.torchvision
         /// <summary>
         /// Rotate the image by angle, counter-clockwise.
         /// </summary>
+        /// <param name="angle">Angle by which to rotate.</param>
+        /// <param name="interpolation">Desired interpolation enum. Default is `InterpolationMode.NEAREST`.</param>
+        /// <param name="expand">If true, expands the output to make it large enough to hold the entire rotated image. If false or omitted, make the output image the same size as the input image. Note that the expand flag assumes rotation around the center and no translation.</param>
+        /// <param name="center">center of rotation, (x, y). Origin is the upper left corner.</param>
+        /// <param name="fill">Pixel fill value for the area outside the rotated. If given a number, the value is used for all bands respectively.</param>
         static public ITransform Rotate(float angle, InterpolationMode interpolation = InterpolationMode.Nearest, bool expand = false, (int, int)? center = null, IList<float> fill = null)
         {
             return new Rotate(angle, interpolation, expand, center, fill);


### PR DESCRIPTION
* Add params to Transform docs
* rename `mode` param in RandomRotation to `interpolation` similar to [Pytorch](https://github.com/pytorch/vision/blob/b1ef19639ee845902ecf60930757d028f1e1491c/torchvision/transforms/transforms.py#L1267)