### PR TITLE
Minor Optimizations for Device type checks

### DIFF
--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -54,7 +54,7 @@ namespace TorchSharp.Examples
             register_module("avg", avgPool);
             register_module("classify", classifier);
 
-            if (device != null && device.type == DeviceType.CUDA)
+            if (device.type == DeviceType.CUDA)
                 this.to(device);
         }
 

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -129,7 +129,7 @@ namespace TorchSharp.Examples
             {
                 RegisterComponents();
 
-                if (device != null && device.type == DeviceType.CUDA)
+                if (device.type == DeviceType.CUDA)
                     this.to(device);
             }
 

--- a/src/Examples/MobileNet.cs
+++ b/src/Examples/MobileNet.cs
@@ -42,7 +42,7 @@ namespace TorchSharp.Examples
 
             RegisterComponents();
 
-            if (device != null && device.type == DeviceType.CUDA)
+            if (device.type == DeviceType.CUDA)
                 this.to(device);
         }
 

--- a/src/Examples/ResNet.cs
+++ b/src/Examples/ResNet.cs
@@ -92,7 +92,7 @@ namespace TorchSharp.Examples
 
             RegisterComponents();
 
-            if (device != null && device.type == DeviceType.CUDA)
+            if (device.type == DeviceType.CUDA)
                 this.to(device);
         }
 

--- a/src/Examples/VGG.cs
+++ b/src/Examples/VGG.cs
@@ -54,7 +54,7 @@ namespace TorchSharp.Examples
 
             RegisterComponents();
 
-            if (device != null && device.type == DeviceType.CUDA)
+            if (device.type == DeviceType.CUDA)
                 this.to(device);
         }
 

--- a/src/TorchSharp/TorchVision/Normalize.cs
+++ b/src/TorchSharp/TorchVision/Normalize.cs
@@ -21,7 +21,8 @@ namespace TorchSharp.torchvision
                 this.means = this.means.to_type(dtype);
                 this.stdevs = this.stdevs.to_type(dtype);
             }
-            if (device != null) {
+
+            if (device != null && device.type != DeviceType.CPU) {
                 this.means = this.means.to(device);
                 this.stdevs = this.stdevs.to(device);
             }


### PR DESCRIPTION
* Reduce the number of device checks in Examples
* Prevent tensors in Normalize() transform from being sent to `DeviceType.CPU` if the device not set to some other non-null value 