### PR TITLE
Implement Data<T> in a way that supports non-contiguous tensors.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,29 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+### NuGet Version 0.93.5
+
+__Fixed Bugs:__
+
+#399 Data<T>() returns span that must be indexed using strides. 
+
+This was a major bug, affecting any code that pulled data out of a tensor view.
+
+__API Changes:__
+
+Tensor.Data<T>() -> Tensor.data<T>()
+Tensor.DataItem<T>() -> Tensor.item<T>()
+Tensor.Bytes() -> Tensor.bytes
+Tensor.SetBytes() -> Tensor.bytes
+
+### NuGet Version 0.93.4
+
+This release introduces a couple of new NuGet packages, which bundle the native libraries that you need:
+
+TorchSharp-cpu
+TorchSharp-cuda-linux
+TorchSharp-cuda-windows
+
 ### NuGet Version 0.93.1
 
 With this release, the native libtorch package version was updated to 1.9.0.11, and that required rebuilding this package.

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>93</MinorVersion>
-    <PatchVersion>4</PatchVersion>
+    <PatchVersion>5</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/docfx/articles/saveload.md
+++ b/docfx/articles/saveload.md
@@ -52,7 +52,7 @@ The model should be created on the CPU before loading weights, then moved to the
 
 ><br/>It is __critical__ that all submodules and buffers in a custom module or composed by a Sequential object have exactly the same name in the original and target models, since that is how persisted tensors are associated with the model into which they are loaded.<br/><br/>The CustomModule 'RegisterComponents' will automatically find all fields that are either modules or tensors, register the former as modules, and the latter as buffers. It registers all of these using the name of the field, just like the PyTorch Module base class does.<br/><br/>
 
-If the model starts out in Python, there's a simple script that allows you to use code that is very similar to the Pytorch API to save models to the TorchSharp format. Rather than placing this trivial script in a Python package and publishing it, we choose to just refer you to the script file itself, [exportsd.py](../src/Python/exportsd.py), which has all the necessary code.
+If the model starts out in Python, there's a simple script that allows you to use code that is very similar to the Pytorch API to save models to the TorchSharp format. Rather than placing this trivial script in a Python package and publishing it, we choose to just refer you to the script file itself, [exportsd.py](../../src/Python/exportsd.py), which has all the necessary code.
 
 ```Python
 f = open("model_weights.dat", "wb")

--- a/src/Examples/ImageTransforms.cs
+++ b/src/Examples/ImageTransforms.cs
@@ -46,7 +46,7 @@ namespace TorchSharp.Examples
                 var channels = image.shape[0];
 
                 using (var stream = File.OpenWrite(outputPathPrefix + n + ".png")) {
-                    var bitmap = GetBitmapFromBytes(image.Data<byte>().ToArray(), 256, 256, channels == 1 ? SKColorType.Gray8 : SKColorType.Bgra8888);
+                    var bitmap = GetBitmapFromBytes(image.data<byte>().ToArray(), 256, 256, channels == 1 ? SKColorType.Gray8 : SKColorType.Bgra8888);
                     bitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
                 }
             }
@@ -65,7 +65,7 @@ namespace TorchSharp.Examples
                 var channels = image.shape[0];
 
                 using (var stream = File.OpenWrite(outputPathPrefix + (n + first.shape[0]) + ".png")) {
-                    var bitmap = GetBitmapFromBytes(image.Data<byte>().ToArray(), 256, 256, channels == 1 ? SKColorType.Gray8 : SKColorType.Bgra8888);
+                    var bitmap = GetBitmapFromBytes(image.data<byte>().ToArray(), 256, 256, channels == 1 ? SKColorType.Gray8 : SKColorType.Bgra8888);
                     bitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
                 }
             }
@@ -105,7 +105,7 @@ namespace TorchSharp.Examples
 
                             Tensor finalized = inputTensor;
 
-                            var nz = inputTensor.count_nonzero().DataItem<long>();
+                            var nz = inputTensor.count_nonzero().item<long>();
 
                             if (bitmap.Width != width || bitmap.Height != height) {
                                 var t = inputTensor.reshape(1, channels, bitmap.Height, bitmap.Width);

--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -127,7 +127,7 @@ namespace TorchSharp.Examples
                     torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5);
                     optimizer.step();
 
-                    total_loss += loss.to(torch.CPU).DataItem<float>();
+                    total_loss += loss.to(torch.CPU).item<float>();
                 }
 
                 GC.Collect();
@@ -159,7 +159,7 @@ namespace TorchSharp.Examples
                 }
                 using (var output = model.forward(data, src_mask)) {
                     var loss = criterion(output.view(-1, ntokens), targets);
-                    total_loss += data.shape[0] * loss.to(torch.CPU).DataItem<float>();
+                    total_loss += data.shape[0] * loss.to(torch.CPU).item<float>();
                 }
 
                 data.Dispose();

--- a/src/Examples/TextClassification.cs
+++ b/src/Examples/TextClassification.cs
@@ -118,7 +118,7 @@ namespace TorchSharp.Examples
                     torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5);
                     optimizer.step();
 
-                    total_acc += (predicted_labels.argmax(1) == labels).sum().to(torch.CPU).DataItem<long>();
+                    total_acc += (predicted_labels.argmax(1) == labels).sum().to(torch.CPU).item<long>();
                     total_count += labels.size(0);
                 }
 
@@ -147,7 +147,7 @@ namespace TorchSharp.Examples
                 using (var predicted_labels = model.forward(texts, offsets)) {
                     var loss = criterion(predicted_labels, labels);
 
-                    total_acc += (predicted_labels.argmax(1) == labels).sum().to(torch.CPU).DataItem<long>();
+                    total_acc += (predicted_labels.argmax(1) == labels).sum().to(torch.CPU).item<long>();
                     total_count += labels.size(0);
                 }
             }

--- a/src/FSharp.Examples/SequenceToSequence.fs
+++ b/src/FSharp.Examples/SequenceToSequence.fs
@@ -168,7 +168,7 @@ let train epoch (model:TransformerModel) (optimizer:Optimizer) (trainData:torch.
             torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5) |> ignore
             optimizer.step() |> ignore
 
-            total_loss <- total_loss + loss.cpu().DataItem<float32>()
+            total_loss <- total_loss + loss.cpu().item<float32>()
         end 
 
         GC.Collect()
@@ -208,7 +208,7 @@ let evaluate (model:TransformerModel) (evalData:torch.Tensor) ntokens =
 
             use output = model.forward(data, src_mask)
             use loss = criterion (output.view(-1L, ntokens)) targets
-            total_loss <- total_loss + (float32 data.shape.[0]) * loss.cpu().DataItem<float32>()
+            total_loss <- total_loss + (float32 data.shape.[0]) * loss.cpu().item<float32>()
         end 
 
         GC.Collect()

--- a/src/FSharp.Examples/TextClassification.fs
+++ b/src/FSharp.Examples/TextClassification.fs
@@ -90,7 +90,7 @@ let train epoch (trainData:IEnumerable<torch.Tensor*torch.Tensor*torch.Tensor>) 
         torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5) |> ignore
         optimizer.step() |> ignore
 
-        total_acc <- total_acc + float ((predicted_labels.argmax(1L).eq(labels)).sum().cpu().DataItem<int64>())
+        total_acc <- total_acc + float ((predicted_labels.argmax(1L).eq(labels)).sum().cpu().item<int64>())
         total_count <- total_count + labels.size(0)
 
         if (batch % logInterval = 0) && (batch > 0) then
@@ -113,7 +113,7 @@ let evaluate (testData:IEnumerable<torch.Tensor*torch.Tensor*torch.Tensor>) (mod
         let predicted_labels = model.forward(texts, offsets)
         let loss = criterion predicted_labels labels
 
-        total_acc <- total_acc + float ((predicted_labels.argmax(1L).eq(labels)).sum().cpu().DataItem<int64>())
+        total_acc <- total_acc + float ((predicted_labels.argmax(1L).eq(labels)).sum().cpu().item<int64>())
         total_count <- total_count + labels.size(0)
 
     total_acc / (float total_count)

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -114,10 +114,10 @@ void THSTensor_broadcast_tensors(const Tensor* tensors, const int length, Tensor
 {
     CATCH(
         auto res = torch::broadcast_tensors(toTensors<at::Tensor>((torch::Tensor**)tensors, length));
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     );
 }
 
@@ -159,10 +159,10 @@ void THSTensor_chunk(const Tensor tensor, Tensor* (*allocator)(size_t length), c
 {
     CATCH(
         auto res = tensor->chunk(chunks, dim);
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 
@@ -237,6 +237,13 @@ Tensor THSTensor_polar(const Tensor abs, const Tensor angle)
 Tensor THSTensor_contiguous(const Tensor tensor)
 {
     CATCH_TENSOR(tensor->contiguous());
+}
+
+int THSTensor_is_contiguous(const Tensor tensor)
+{
+    bool result = false;
+    CATCH(result = tensor->is_contiguous(););
+    return result;
 }
 
 Tensor THSTensor_copysign(const Tensor input, const Tensor other)
@@ -738,8 +745,8 @@ Tensor THSTensor_load(const char* location)
 {
     CATCH_RETURN_Tensor(
         torch::Tensor tensor;
-        torch::load(tensor, location);
-        res = ResultTensor(tensor);
+    torch::load(tensor, location);
+    res = ResultTensor(tensor);
     );
 }
 
@@ -802,9 +809,9 @@ void THSTensor_max_along_dimension(const Tensor tensor, Tensor* (*allocator)(siz
 {
     CATCH(
         auto max = tensor->max(dim, keepdim);
-        Tensor * result = allocator(2);
-        result[0] = new torch::Tensor(std::get<0>(max));
-        result[1] = new torch::Tensor(std::get<1>(max));
+    Tensor * result = allocator(2);
+    result[0] = new torch::Tensor(std::get<0>(max));
+    result[1] = new torch::Tensor(std::get<1>(max));
     )
 }
 
@@ -831,10 +838,10 @@ void THSTensor_mode(const Tensor tensor, Tensor* (*allocator)(size_t length), co
 {
     CATCH(
         auto res = tensor->mode(dim, keep_dim);
-        const size_t sz = 2;
-        Tensor * result = allocator(2);
-        result[0] = new torch::Tensor(std::get<0>(res));
-        result[1] = new torch::Tensor(std::get<1>(res));
+    const size_t sz = 2;
+    Tensor * result = allocator(2);
+    result[0] = new torch::Tensor(std::get<0>(res));
+    result[1] = new torch::Tensor(std::get<1>(res));
     )
 }
 
@@ -862,9 +869,9 @@ void THSTensor_min_along_dimension(const Tensor tensor, Tensor* (*allocator)(siz
 {
     CATCH(
         auto max = tensor->min(dim, keepdim);
-        Tensor * result = allocator(2);
-        result[0] = new torch::Tensor(std::get<0>(max));
-        result[1] = new torch::Tensor(std::get<1>(max));
+    Tensor * result = allocator(2);
+    result[0] = new torch::Tensor(std::get<0>(max));
+    result[1] = new torch::Tensor(std::get<1>(max));
     )
 }
 
@@ -1151,10 +1158,10 @@ void THSTensor_split_with_size(
 {
     CATCH(
         auto res = tensor->split(split_size, dim);
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 
@@ -1167,10 +1174,10 @@ void THSTensor_split_with_sizes(
 {
     CATCH(
         auto res = tensor->split_with_sizes(at::ArrayRef<int64_t>(sizes, length), dim);
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 
@@ -1182,10 +1189,10 @@ void THSTensor_tensor_split_with_size(
 {
     CATCH(
         auto res = tensor->tensor_split(n, dim);
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 
@@ -1198,10 +1205,10 @@ void THSTensor_tensor_split_with_sizes(
 {
     CATCH(
         auto res = tensor->tensor_split(at::ArrayRef<int64_t>(sizes, length), dim);
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 
@@ -1213,10 +1220,10 @@ void THSTensor_tensor_split_with_tensor_sizes(
 {
     CATCH(
         auto res = tensor->tensor_split(*sizes, dim);
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 
@@ -1227,10 +1234,10 @@ void THSTensor_vsplit_with_size(
 {
     CATCH(
         auto res = tensor->vsplit(n);
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 
@@ -1242,10 +1249,10 @@ void THSTensor_vsplit_with_sizes(
 {
     CATCH(
         auto res = tensor->vsplit(at::ArrayRef<int64_t>(sizes, length));
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 
@@ -1326,10 +1333,10 @@ void THSTensor_strides(const Tensor tensor, int64_t* (*allocator)(size_t length)
 {
     CATCH(
         auto res = tensor->strides();
-        const size_t sz = res.size();
-        int64_t* result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = res[i];
+    const size_t sz = res.size();
+    int64_t * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = res[i];
     );
 }
 
@@ -1342,10 +1349,10 @@ void THSTensor_sizes(const Tensor tensor, int64_t* (*allocator)(size_t length))
 {
     CATCH(
         auto res = tensor->sizes();
-        const size_t sz = res.size();
-        int64_t * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = res[i];
+    const size_t sz = res.size();
+    int64_t * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = res[i];
     );
 }
 
@@ -1438,9 +1445,9 @@ void THSTensor_topk(const Tensor tensor, Tensor* (*allocator)(size_t length), co
 {
     CATCH(
         auto topk = tensor->topk(k, dim, largest, sorted);
-        Tensor * result = allocator(2);
-        result[0] = new torch::Tensor(std::get<0>(topk));
-        result[1] = new torch::Tensor(std::get<1>(topk));
+    Tensor * result = allocator(2);
+    result[0] = new torch::Tensor(std::get<0>(topk));
+    result[1] = new torch::Tensor(std::get<1>(topk));
     )
 }
 
@@ -1468,7 +1475,7 @@ Tensor THSTensor_to_device(const Tensor tensor, const int device_type, const int
 {
     CATCH_RETURN_Tensor(
         auto device = c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index);
-        res = ResultTensor(tensor->to(device)); 
+    res = ResultTensor(tensor->to(device));
     );
 }
 
@@ -1481,7 +1488,7 @@ Tensor THSTensor_to_type_and_device(const Tensor tensor, int8_t scalar_type, con
 {
     CATCH_RETURN_Tensor(
         auto device = c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index);
-        res = ResultTensor(tensor->to(device, at::ScalarType(scalar_type)));
+    res = ResultTensor(tensor->to(device, at::ScalarType(scalar_type)));
     );
 }
 
@@ -1534,10 +1541,10 @@ void THSTensor_unbind(const Tensor tensor, Tensor* (*allocator)(size_t length), 
 {
     CATCH(
         auto res = tensor->unbind(dim);
-        const size_t sz = res.size();
-        Tensor * result = allocator(sz);
-        for (size_t i = 0; i < sz; i++)
-            result[i] = new torch::Tensor(res[i]);
+    const size_t sz = res.size();
+    Tensor * result = allocator(sz);
+    for (size_t i = 0; i < sz; i++)
+        result[i] = new torch::Tensor(res[i]);
     )
 }
 

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -565,6 +565,8 @@ EXPORT_API(Tensor) THSTensor_inner(const Tensor left, const Tensor right);
 
 EXPORT_API(Tensor) THSTensor_inverse(const Tensor tensor);
 
+EXPORT_API(int) THSTensor_is_contiguous(const Tensor input);
+
 EXPORT_API(int) THSTensor_is_sparse(const Tensor tensor);
 
 EXPORT_API(Tensor) THSTensor_isclose(const Tensor tensor, const Tensor other, const double rtol, const double atol, const bool equal_nan);

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -419,7 +419,7 @@ namespace TorchSharp
                         variance = variance.view(target.shape[0], -1);
                         if (variance.shape[1] != input.shape[1] && variance.shape[1] != 1) throw new ArgumentException("variance has the wrong shape");
 
-                        if ((variance < 0).any().DataItem<bool>()) throw new ArgumentException("variance has negative entry/entries");
+                        if ((variance < 0).any().item<bool>()) throw new ArgumentException("variance has negative entry/entries");
 
                         variance = variance.clone().maximum(torch.tensor(eps));
 

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -4655,6 +4655,7 @@ namespace TorchSharp
             /// </summary>
             public Tensor slice(long dimension, long start, long finish, long step)
             {
+                if (step < 1) throw new ArgumentException($"step is {step}, but it should always be positive.");
                 var res = THSTensor_slice(handle, dimension, start, finish, step);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -291,56 +291,64 @@ namespace TorchSharp
             /// </summary>
             /// <param name="i">The index.</param>
             /// <returns></returns>
-            public double ReadCpuDouble(long i) => data<double>()[(int)i];
+            public double ReadCpuDouble(long i) => Utils.TensorAccessor<double>.ReadItemAt(this, i);
 
             /// <summary>
             /// Read the single-precision float value at the given index.
             /// </summary>
             /// <param name="i">The index.</param>
             /// <returns></returns>
-            public float ReadCpuSingle(long i) => data<float>()[(int)i];
+            public float ReadCpuSingle(long i) => Utils.TensorAccessor<float>.ReadItemAt(this, i);
 
             /// <summary>
             /// Read the 32-bit integer float value at the given index.
             /// </summary>
             /// <param name="i">The index.</param>
             /// <returns></returns>
-            public int ReadCpuInt32(long i) => data<int>()[(int)i];
+            public int ReadCpuInt32(long i) => Utils.TensorAccessor<int>.ReadItemAt(this, i);
 
             /// <summary>
             /// Read the 64-bit integer value at the given index.
             /// </summary>
             /// <param name="i">The index.</param>
             /// <returns></returns>
-            public long ReadCpuInt64(long i) => data<long>()[(int)i];
+            public long ReadCpuInt64(long i) => Utils.TensorAccessor<long>.ReadItemAt(this, i);
 
             /// <summary>
             /// Read the byte value at the given index.
             /// </summary>
             /// <param name="i">The index.</param>
             /// <returns></returns>
-            public byte ReadCpuByte(long i) => data<byte>()[(int)i];
+            public byte ReadCpuByte(long i) => Utils.TensorAccessor<byte>.ReadItemAt(this, i);
 
             /// <summary>
             /// Read the short value at the given index.
             /// </summary>
             /// <param name="i">The index.</param>
             /// <returns></returns>
-            public sbyte ReadCpuSByte(long i) => data<sbyte>()[(int)i];
+            public sbyte ReadCpuSByte(long i) => Utils.TensorAccessor<sbyte>.ReadItemAt(this, i);
 
             /// <summary>
             /// Read the int16 value at the given index.
             /// </summary>
             /// <param name="i">The index.</param>
             /// <returns></returns>
-            public short ReadCpuInt16(long i) => data<short>()[(int)i];
+            public short ReadCpuInt16(long i) => Utils.TensorAccessor<short>.ReadItemAt(this, i);
 
             /// <summary>
             /// Read the Boolean value at the given index.
             /// </summary>
             /// <param name="i">The index.</param>
             /// <returns></returns>
-            public bool ReadCpuBool(long i) => data<bool>()[(int)i];
+            public bool ReadCpuBool(long i) => Utils.TensorAccessor<bool>.ReadItemAt(this, i);
+
+            /// <summary>
+            /// Read the value at the given index.
+            /// </summary>
+            /// <typeparam name="T">The type of the element to read.</typeparam>
+            /// <param name="i">The index.</param>
+            /// <returns></returns>
+            public T ReadCpuValue<T>(long i) where T : unmanaged => Utils.TensorAccessor<T>.ReadItemAt(this, i);
 
             [DllImport("LibTorchSharp")]
             static extern float THSTensor_data_idx_float16(IntPtr handle, long i);

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -62,7 +62,7 @@ namespace TorchSharp
             writer.Encode(tensor.shape.Length); // 4 bytes
             foreach (var s in tensor.shape) writer.Encode(s); // n * 8 bytes
                                                                 // Then, the data
-            writer.Write(tensor.Bytes()); // ElementSize * NumberofElements
+            writer.Write(tensor.bytes); // ElementSize * NumberofElements
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace TorchSharp
             if (totalSize > int.MaxValue)
                 throw new NotImplementedException("Loading tensors larger than 2GB");
 
-            tensor.SetBytes(reader.ReadBytes((int)(totalSize * tensor.ElementSize)));
+            tensor.bytes = reader.ReadBytes((int)(totalSize * tensor.ElementSize));
         }
 
         /// <summary>

--- a/src/TorchSharp/TorchVision/ColorJitter.cs
+++ b/src/TorchSharp/TorchVision/ColorJitter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+using System.Linq;
 using static TorchSharp.torch;
 using static TorchSharp.TensorExtensionMethods;
 
@@ -21,7 +19,7 @@ namespace TorchSharp.torchvision
 
         public Tensor forward(Tensor image)
         {
-            var randoms = torch.rand(4, ScalarType.Float32).Data<float>().ToArray();
+            var randoms = torch.rand(4, ScalarType.Float32).data<float>().ToArray();
             var b = Adjust(randoms[0], brightness.Item1, brightness.Item2);
             var c = Adjust(randoms[1], contrast.Item1, contrast.Item2);
             var s = Adjust(randoms[2], saturation.Item1, saturation.Item2);

--- a/src/TorchSharp/TorchVision/Functional.cs
+++ b/src/TorchSharp/TorchVision/Functional.cs
@@ -929,7 +929,7 @@ namespace TorchSharp.torchvision
                 var b_str = b_matrix.ToString(true);
 
                 var res = torch.linalg.lstsq(a_matrix, b_matrix).Solution;
-                return res.Data<float>().ToArray();
+                return res.data<float>().ToArray();
             }
 
             private static Tensor EqualizeSingleImage(Tensor img)

--- a/src/TorchSharp/TorchVision/RandomChoice.cs
+++ b/src/TorchSharp/TorchVision/RandomChoice.cs
@@ -26,7 +26,7 @@ namespace TorchSharp.torchvision
         public Tensor forward(Tensor input)
         {
             using (var chance = torch.randint(transforms.Length, new long[] { 1 }, ScalarType.Int32))
-                return transforms[chance.DataItem<int>()].forward(input);
+                return transforms[chance.item<int>()].forward(input);
         }
 
         private ITransform[] transforms;

--- a/src/TorchSharp/TorchVision/RandomPerspective.cs
+++ b/src/TorchSharp/TorchVision/RandomPerspective.cs
@@ -40,7 +40,7 @@ namespace TorchSharp.torchvision
             var half_width = width / 2;
             var half_height = height / 2;
 
-            var randoms = torch.rand(8, ScalarType.Float64).Data<double>().ToArray();
+            var randoms = torch.rand(8, ScalarType.Float64).data<double>().ToArray();
 
             var topleft = new int[] {
                 Adjust(randoms[0], 0, distortion * half_width + 1),

--- a/src/TorchSharp/TorchVision/Randomizer.cs
+++ b/src/TorchSharp/TorchVision/Randomizer.cs
@@ -20,7 +20,7 @@ namespace TorchSharp.torchvision
         {
             using (var chance = torch.rand(1))
 
-                if (chance.DataItem<float>() < p) {
+                if (chance.item<float>() < p) {
                     return transform.forward(input);
                 } else {
                     return input;

--- a/src/TorchSharp/Utils/TensorAccessor.cs
+++ b/src/TorchSharp/Utils/TensorAccessor.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Linq;
+
+namespace TorchSharp.Utils
+{
+    /// <summary>
+    /// TensorAccessor is used to present the contents of a tensor or tensor view to the .NET world as an ordered collection
+    /// of values that integrates well with things like LINQ and foreach loops in the .NET world.
+    /// </summary>
+    /// <typeparam name="T">The type of the tensor elements.</typeparam>
+    public class TensorAccessor<T> : IDisposable, IEnumerable<T> where T : unmanaged
+    {
+        public TensorAccessor(torch.Tensor tensor)
+        {
+            if (tensor.device_type != DeviceType.CPU) {
+                throw new InvalidOperationException("Reading data from non-CPU memory is not supported. Move or copy the tensor to the cpu before reading.");
+            }
+
+            _shape = tensor.shape;
+            _physicalStrides = tensor.stride();
+
+            for (var i = 0; i < _physicalStrides.Length; i++) {
+                if (_physicalStrides[i] <= 0)
+                    throw new NotImplementedException($"Non-positive tensor strides are not currently supported. tensor.strides({i}) == {_physicalStrides[i]}");
+            }
+
+            // Compute the logical strides.
+
+            if (_shape.Length > 0) {
+                _logigcalStrides = new long[_shape.Length];
+                _logigcalStrides[_shape.Length - 1] = 1;
+                for (int i = _shape.Length - 2; i >= 0; i--) {
+                    _logigcalStrides[i] = _shape[i + 1] * _logigcalStrides[i + 1];
+                    if (_logigcalStrides[i] != _physicalStrides[i]) _needToTranslate = true;
+                }
+            } else {
+                // Special case -- a singleton tensor, i.e. scalar.
+                _logigcalStrides = new long[0];
+            }
+
+            Count = (int)tensor.numel();
+
+            // Get the data from native code.
+
+            unsafe {
+                var res = torch.Tensor.THSTensor_data(tensor.Handle);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                // NOTE: there is no safety here.
+                _tensor_data_ptr = res;
+            }
+
+            _tensor = tensor; // Keep the tensor alive now that everything is alright.
+        }
+
+        public long Count { get; private set; }
+
+        public bool IsReadOnly => false;
+
+        public T[] ToArray() => this.ToArray<T>();
+
+
+        /// <summary>
+        /// Translates a linear index within the span represented by the accessor to a linear index
+        /// used by the underlying tensor. The two should only be different if the tensor is a view
+        /// rather than an allocated tensor.
+        /// </summary>
+        /// <param name="idx">A linear index into the data view.</param>
+        /// <returns></returns>
+        private long TranslateIndex(long idx)
+        {
+            if (!_needToTranslate) return idx;
+
+            // First, turn the linear index into a subscript list, based on the shape, i.e. logical strides.
+            var subs = new List<long>();
+            for (var i = 0; i < _logigcalStrides.Length; i++) {
+                var s = idx / _logigcalStrides[i];
+                idx -= s * _logigcalStrides[i];
+                subs.Add(s);
+            }
+
+            // Then, use the actual (phyiscal) strides and the logical subscripts to determine the output index.
+
+            long result = 0;
+            for (var i = 0; i < _physicalStrides.Length; i++) {
+                result += subs[i] * _physicalStrides[i];
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Access elements of the underlying tensor / tensor view.
+        /// </summary>
+        /// <param name="index">A linear index into the data.</param>
+        /// <returns></returns>
+        public T this[long index] {
+            get {
+                if (index >= Count) throw new IndexOutOfRangeException();
+                unsafe {
+                    T* ptr = (T*)_tensor_data_ptr;
+                    return ptr[TranslateIndex(index)];
+                }
+            }
+            set {
+                if (index >= Count) throw new IndexOutOfRangeException();
+                unsafe {
+                    T* ptr = (T*)_tensor_data_ptr;
+                    ptr[TranslateIndex(index)] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Compare two tensors element-wise. 
+        /// </summary>
+        /// <param name="left">A tensor</param>
+        /// <param name="right">Another tensor</param>
+        /// <returns></returns>
+        public static bool operator ==(TensorAccessor<T> left, TensorAccessor<T> right)
+        {
+            if (left._tensor_data_ptr == right._tensor_data_ptr) return true;
+            if (left.Count != right.Count) return false;
+            for (long i = 0; i < left.Count; i++) {
+                if (!left[i].Equals(right[i])) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Compare two tensors element-wise. 
+        /// </summary>
+        /// <param name="left">A tensor</param>
+        /// <param name="right">Another tensor</param>
+        /// <returns></returns>
+        public static bool operator !=(TensorAccessor<T> left, TensorAccessor<T> right)
+        {
+            if (left._tensor_data_ptr == right._tensor_data_ptr) return false;
+            if (left.Count != right.Count) return true;
+            for (long i = 0; i < left.Count; i++) {
+                if (left[i].Equals(right[i])) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Compare two tensors element-wise. 
+        /// </summary>
+        /// <param name="obj">Another tensor</param>
+        /// <returns></returns>
+        public override bool Equals(object obj)
+        {
+            var left = this;
+            var right = obj as TensorAccessor<T>;
+            if (right == null) return false;
+
+            if (left._tensor_data_ptr == right._tensor_data_ptr) return true;
+            if (left.Count != right.Count) return false;
+            for (long i = 0; i < left.Count; i++) {
+                if (!left[i].Equals(right[i])) return false;
+            }
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return ToArray().GetHashCode();
+        }
+
+        public void CopyTo(T[] array, int arrayIndex = 0, long tensorIndex = 0)
+        {
+            for (int i = 0; i + arrayIndex < array.Length && i + tensorIndex < Count; i++) {
+                array[i + arrayIndex] = this[i + tensorIndex];
+            }
+        }
+
+        public void CopyFrom(T[] array, int arrayIndex = 0, long tensorIndex = 0)
+        {
+            for (int i = 0; i + arrayIndex < array.Length && i + tensorIndex < Count; i++) {
+                this[i + tensorIndex] = array[i + arrayIndex];
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return new TensorAccessorEnumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Dispose()
+        {
+            // Clear the tensor we've been keeping alive.
+            _tensor = null;
+        }
+
+        private torch.Tensor _tensor;   // Keeping it alive.
+        private IntPtr _tensor_data_ptr;
+        private long[] _shape;
+        private long[] _physicalStrides;
+        private long[] _logigcalStrides;
+        private bool _needToTranslate = false;
+
+        private class TensorAccessorEnumerator : IEnumerator<T>
+        {
+            public TensorAccessorEnumerator(TensorAccessor<T> span)
+            {
+                _currentIdx = -1;
+                _span = span;
+            }
+
+            public T Current => _span[_currentIdx];
+
+            object IEnumerator.Current => _span[_currentIdx];
+
+            public void Dispose()
+            {
+                // Just clear the span field.
+                _span = null;
+            }
+
+            public bool MoveNext()
+            {
+                _currentIdx += 1;
+                return _currentIdx < _span.Count;
+            }
+
+            public void Reset()
+            {
+                _currentIdx = -1;
+            }
+
+            private long _currentIdx;
+            private TensorAccessor<T> _span;
+        }
+    }
+}

--- a/src/TorchSharp/Utils/TensorAccessor.cs
+++ b/src/TorchSharp/Utils/TensorAccessor.cs
@@ -71,7 +71,7 @@ namespace TorchSharp.Utils
         /// <returns></returns>
         private long TranslateIndex(long idx)
         {
-            if (!_needToTranslate) return idx;
+            if (!_needToTranslate || idx == 0) return idx;
 
             // First, turn the linear index into a subscript list, based on the shape, i.e. logical strides.
             var subs = new List<long>();

--- a/src/TorchSharp/Utils/TensorAccessor.cs
+++ b/src/TorchSharp/Utils/TensorAccessor.cs
@@ -23,8 +23,8 @@ namespace TorchSharp.Utils
             _physicalStrides = tensor.stride();
 
             for (var i = 0; i < _physicalStrides.Length; i++) {
-                if (_physicalStrides[i] <= 0)
-                    throw new NotImplementedException($"Non-positive tensor strides are not currently supported. tensor.strides({i}) == {_physicalStrides[i]}");
+                if (_physicalStrides[i] < 0)
+                    throw new NotImplementedException($"Negative tensor strides are not currently supported. tensor.strides({i}) == {_physicalStrides[i]}");
             }
 
             // Compute the logical strides.

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -112,7 +112,7 @@ namespace TorchSharp
             Assert.Equal(forward.shape[1], matmul.shape[1]);
 
             for (int i = 0; i < 100; i++) {
-                Assert.InRange(forward.Data<float>()[i], matmul.Data<float>()[i] - 10e5f, matmul.Data<float>()[i] + 10e5f);
+                Assert.InRange(forward.data<float>()[i], matmul.data<float>()[i] - 10e5f, matmul.data<float>()[i] + 10e5f);
             }
         }
 
@@ -145,7 +145,7 @@ namespace TorchSharp
             Assert.Equal(forward.shape[1], matmul.shape[1]);
 
             for (int i = 0; i < 100; i++) {
-                Assert.Equal(forward.Data<float>()[i], matmul.Data<float>()[i]);
+                Assert.Equal(forward.data<float>()[i], matmul.data<float>()[i]);
             }
         }
 
@@ -158,7 +158,7 @@ namespace TorchSharp
             var output = lin.forward(input);
 
             for (int i = 0; i < 1000; i++) {
-                Assert.Equal(input.Data<float>()[i], output.Data<float>()[i]);
+                Assert.Equal(input.data<float>()[i], output.data<float>()[i]);
             }
         }
 
@@ -170,7 +170,7 @@ namespace TorchSharp
             lin.Bias = bias;
 
             for (int i = 0; i < 100; i++) {
-                Assert.Equal(lin.Bias.Data<float>()[i], bias.Data<float>()[i]);
+                Assert.Equal(lin.Bias.data<float>()[i], bias.data<float>()[i]);
             }
         }
 
@@ -189,7 +189,7 @@ namespace TorchSharp
             Assert.Equal(lin.Weight.shape[1], weights.shape[1]);
 
             for (int i = 0; i < 100; i++) {
-                Assert.Equal(lin.Bias.Data<float>()[i], bias.Data<float>()[i]);
+                Assert.Equal(lin.Bias.data<float>()[i], bias.data<float>()[i]);
             }
         }
 
@@ -225,7 +225,7 @@ namespace TorchSharp
             var rel = ReLU();
             var input = torch.randn(new long[] { 64, 8 });
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= 0.0));
         }
@@ -236,7 +236,7 @@ namespace TorchSharp
             var rel = ReLU6();
             var input = torch.randn(new long[] { 64, 8 }) * 25.0;
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= 0.0 && val <= 6.0));
         }
@@ -247,7 +247,7 @@ namespace TorchSharp
             var rel = LeakyReLU();
             var input = torch.randn(new long[] { 64, 8 });
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
         }
 
@@ -257,7 +257,7 @@ namespace TorchSharp
             var rel = Mish();
             var input = torch.randn(new long[] { 64, 8 });
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
         }
 
@@ -267,7 +267,7 @@ namespace TorchSharp
             var rel = RReLU();
             var input = torch.randn(new long[] { 64, 8 });
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
         }
 
@@ -277,7 +277,7 @@ namespace TorchSharp
             var rel = CELU();
             var input = torch.randn(new long[] { 64, 8 });
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= -1.0));
         }
@@ -288,7 +288,7 @@ namespace TorchSharp
             var rel = ELU();
             var input = torch.randn(new long[] { 64, 8 });
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= -1.0));
         }
@@ -299,7 +299,7 @@ namespace TorchSharp
             var rel = SELU();
             var input = torch.randn(new long[] { 64, 8 });
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= -1.76));
         }
@@ -310,7 +310,7 @@ namespace TorchSharp
             var rel = GELU();
             var input = torch.randn(new long[] { 64, 8 }) * 25.0;
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= -0.2));
         }
@@ -321,7 +321,7 @@ namespace TorchSharp
             var rel = Sigmoid();
             var input = torch.randn(new long[] { 64, 8 }) * 25.0;
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= 0.0 && val <= 1.0));
         }
@@ -332,7 +332,7 @@ namespace TorchSharp
             var rel = SiLU();
             var input = torch.randn(new long[] { 64, 8 }) * 25.0;
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= -1.0));
         }
@@ -343,7 +343,7 @@ namespace TorchSharp
             var rel = Softmax2d();
             var input = torch.randn(new long[] { 64, 3, 8, 8 }) * 25.0;
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= 0.0 && val <= 1.0));
         }
@@ -354,7 +354,7 @@ namespace TorchSharp
             var rel = Tanh();
             var input = torch.randn(new long[] { 64, 3, 8, 8 }) * 25.0;
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= -1.0 && val <= 1.0));
         }
@@ -365,7 +365,7 @@ namespace TorchSharp
             var rel = Softmax(1);
             var input = torch.randn(new long[] { 64, 8 }) * 25.0;
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= 0.0 && val <= 1.0));
         }
@@ -376,7 +376,7 @@ namespace TorchSharp
             var rel = Softmax(1);
             var input = torch.randn(new long[] { 64, 8 }) * 25.0;
             var output = rel.forward(input);
-            var values = output.Data<float>().ToArray();
+            var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
             Assert.All(values, val => Assert.True(val >= 0.0 && val <= 1.0));
         }
@@ -465,7 +465,7 @@ namespace TorchSharp
             using (Tensor input = torch.rand(new long[] { 5, 2 }))
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
                 var outTensor = poisson_loss(true, true)(input, target);
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -477,7 +477,7 @@ namespace TorchSharp
             using (Tensor input = torch.rand(new long[] { 5, 12 }))
             using (Tensor target = torch.randint(12, new long[] { 5 }, torch.int64)) {
                 var outTensor = cross_entropy_loss()(input, target);
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -489,7 +489,7 @@ namespace TorchSharp
             using (Tensor input = torch.rand(new long[] { 5, 2 }))
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
                 var outTensor = l1_loss()(input, target);
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -502,7 +502,7 @@ namespace TorchSharp
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = binary_cross_entropy_loss()(m.forward(input), target);
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -514,7 +514,7 @@ namespace TorchSharp
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = binary_cross_entropy_with_logits_loss()(input, target);
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -526,7 +526,7 @@ namespace TorchSharp
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = kl_div_loss()(input, target);
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -538,7 +538,7 @@ namespace TorchSharp
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = smooth_l1_loss()(input, target);
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -550,7 +550,7 @@ namespace TorchSharp
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = soft_margin_loss()(input, target);
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -565,7 +565,7 @@ namespace TorchSharp
                 var outTensor = gaussian_nll_loss()(input, target, variance);
                 outTensor.backward();
 
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -575,7 +575,7 @@ namespace TorchSharp
                 var outTensor = gaussian_nll_loss()(input, target, variance);
                 outTensor.backward();
 
-                var values = outTensor.Data<float>().ToArray();
+                var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -590,7 +590,7 @@ namespace TorchSharp
                 var outTensor = gaussian_nll_loss()(input, target, variance);
                 outTensor.backward();
 
-                var values = outTensor.Data<double>().ToArray();
+                var values = outTensor.data<double>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -600,7 +600,7 @@ namespace TorchSharp
                 var outTensor = gaussian_nll_loss()(input, target, variance);
                 outTensor.backward();
 
-                var values = outTensor.Data<double>().ToArray();
+                var values = outTensor.data<double>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
             }
@@ -968,7 +968,7 @@ namespace TorchSharp
                     sum.backward();
                     var grad = x.grad();
                     Assert.False(grad is null || grad.Handle == IntPtr.Zero);
-                    var data = grad is not null ?  grad.Data<float>() : new float[] { };
+                    var data = grad is not null ?  grad.data<float>().ToArray() : new float[] { };
                     for (int i = 0; i < 2 * 3; i++) {
                         Assert.Equal(1.0, data[i]);
                     }
@@ -1017,7 +1017,7 @@ namespace TorchSharp
             Assert.Equal(new long[] { 64, 3, 3 }, weight.shape);
 
             for (int i = 0; i < 64; i++) {
-                Assert.Equal(conv.Bias.Data<float>()[i], bias.Data<float>()[i]);
+                Assert.Equal(conv.Bias.data<float>()[i], bias.data<float>()[i]);
             }
         }
 
@@ -1099,7 +1099,7 @@ namespace TorchSharp
             Assert.Equal(new long[] { 64, 3, 3, 3 }, weight.shape);
 
             for (int i = 0; i < 64; i++) {
-                Assert.Equal(conv.Bias.Data<float>()[i], bias.Data<float>()[i]);
+                Assert.Equal(conv.Bias.data<float>()[i], bias.data<float>()[i]);
             }
         }
 
@@ -1185,7 +1185,7 @@ namespace TorchSharp
             Assert.Equal(new long[] { 64, 3, 3, 3, 3 }, weight.shape);
 
             for (int i = 0; i < 64; i++) {
-                Assert.Equal(conv.Bias.Data<float>()[i], bias.Data<float>()[i]);
+                Assert.Equal(conv.Bias.data<float>()[i], bias.data<float>()[i]);
             }
         }
 
@@ -1994,7 +1994,7 @@ namespace TorchSharp
         {
             var ones = torch.tensor(new long[] { 1, 2, 0, 0, 3, 4, 2, 2 });
             var env = one_hot(ones, 5);
-            var values = env.Data<long>().ToArray();
+            var values = env.data<long>().ToArray();
             Assert.Equal(ones.shape[0], env.shape[0]);
             Assert.Equal(5, env.shape[1]);
         }
@@ -2004,7 +2004,7 @@ namespace TorchSharp
         {
             var ones = torch.tensor(new long[] { 1, 2, 0, 5, 3, 4, 2, 2 });
             var env = one_hot(ones);
-            var values = env.Data<long>().ToArray();
+            var values = env.data<long>().ToArray();
             Assert.Equal(ones.shape[0], env.shape[0]);
             Assert.Equal(6, env.shape[1]);
         }
@@ -2191,8 +2191,8 @@ namespace TorchSharp
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
 
-            var dataVal = data.Data<float>().ToArray();
-            var outVal = output.Data<float>().ToArray();
+            var dataVal = data.data<float>().ToArray();
+            var outVal = output.data<float>().ToArray();
             Assert.NotEqual(outVal, dataVal);
         }
 
@@ -2204,8 +2204,8 @@ namespace TorchSharp
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
 
-            var dataVal = data.Data<float>().ToArray();
-            var outVal = output.Data<float>().ToArray();
+            var dataVal = data.data<float>().ToArray();
+            var outVal = output.data<float>().ToArray();
             Assert.Equal(outVal, dataVal);
         }
 
@@ -2217,8 +2217,8 @@ namespace TorchSharp
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
 
-            var dataVal = data.Data<float>().ToArray();
-            var outVal = output.Data<float>().ToArray();
+            var dataVal = data.data<float>().ToArray();
+            var outVal = output.data<float>().ToArray();
             Assert.NotEqual(outVal, dataVal);
         }
 
@@ -2230,8 +2230,8 @@ namespace TorchSharp
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
 
-            var dataVal = data.Data<float>().ToArray();
-            var outVal = output.Data<float>().ToArray();
+            var dataVal = data.data<float>().ToArray();
+            var outVal = output.data<float>().ToArray();
             Assert.Equal(outVal, dataVal);
         }
 
@@ -2243,8 +2243,8 @@ namespace TorchSharp
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
 
-            var dataVal = data.Data<float>().ToArray();
-            var outVal = output.Data<float>().ToArray();
+            var dataVal = data.data<float>().ToArray();
+            var outVal = output.data<float>().ToArray();
             Assert.NotEqual(outVal, dataVal);
         }
 
@@ -2256,8 +2256,8 @@ namespace TorchSharp
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
 
-            var dataVal = data.Data<float>().ToArray();
-            var outVal = output.Data<float>().ToArray();
+            var dataVal = data.data<float>().ToArray();
+            var outVal = output.data<float>().ToArray();
             Assert.Equal(outVal, dataVal);
         }
 
@@ -2269,8 +2269,8 @@ namespace TorchSharp
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
 
-            var dataVal = data.Data<float>().ToArray();
-            var outVal = output.Data<float>().ToArray();
+            var dataVal = data.data<float>().ToArray();
+            var outVal = output.data<float>().ToArray();
             Assert.NotEqual(outVal, dataVal);
         }
         #endregion
@@ -2364,7 +2364,7 @@ namespace TorchSharp
             using (var pad = ReflectionPad1d(3)) {
                 var output = pad.forward(data);
                 Assert.Equal(new long[] { 32, 3, 10 }, output.shape);
-                var values = output.Data<float>().ToArray();
+                var values = output.data<float>().ToArray();
                 Assert.Equal(values[6], values[0]);
                 Assert.Equal(values[5], values[1]);
                 Assert.Equal(values[4], values[2]);
@@ -2382,7 +2382,7 @@ namespace TorchSharp
             using (var pad = ReflectionPad2d(3)) {
                 var output = pad.forward(data);
                 Assert.Equal(new long[] { 32, 3, 10, 10 }, output.shape);
-                var values = output.Data<float>().ToArray();
+                var values = output.data<float>().ToArray();
                 Assert.Equal(values[6], values[0]);
                 Assert.Equal(values[5], values[1]);
                 Assert.Equal(values[4], values[2]);
@@ -2397,7 +2397,7 @@ namespace TorchSharp
             using (var pad = ReplicationPad1d(3)) {
                 var output = pad.forward(data);
                 Assert.Equal(new long[] { 32, 3, 10 }, output.shape);
-                var values = output.Data<float>().ToArray();
+                var values = output.data<float>().ToArray();
                 Assert.Equal(values[3], values[0]);
                 Assert.Equal(values[3], values[1]);
                 Assert.Equal(values[3], values[3]);
@@ -2415,7 +2415,7 @@ namespace TorchSharp
             using (var pad = ReplicationPad2d(3)) {
                 var output = pad.forward(data);
                 Assert.Equal(new long[] { 32, 3, 10, 10 }, output.shape);
-                var values = output.Data<float>().ToArray();
+                var values = output.data<float>().ToArray();
                 Assert.Equal(values[3], values[0]);
                 Assert.Equal(values[3], values[1]);
                 Assert.Equal(values[3], values[3]);
@@ -2430,7 +2430,7 @@ namespace TorchSharp
             using (var pad = ReplicationPad3d(3)) {
                 var output = pad.forward(data);
                 Assert.Equal(new long[] { 32, 3, 10, 10, 10 }, output.shape);
-                var values = output.Data<float>().ToArray();
+                var values = output.data<float>().ToArray();
                 Assert.Equal(values[3], values[0]);
                 Assert.Equal(values[3], values[1]);
                 Assert.Equal(values[3], values[3]);

--- a/test/TorchSharpTest/TestDistributions.cs
+++ b/test/TorchSharpTest/TestDistributions.cs
@@ -29,13 +29,13 @@ namespace TorchSharp
                 var sample = dist.sample(2,3);
 
                 Assert.Equal(new long[] { 2, 3 }, sample.shape);
-                Assert.All<double>(sample.Data<double>().ToArray(), d => Assert.True(d >= 0 && d < 3.5));
+                Assert.All<double>(sample.data<double>().ToArray(), d => Assert.True(d >= 0 && d < 3.5));
             }
             {
                 var sample = dist.expand(new long[] { 3, 4 }).sample(2, 3);
 
                 Assert.Equal(new long[] { 2, 3, 3, 4 }, sample.shape);
-                Assert.All<double>(sample.Data<double>().ToArray(), d => Assert.True(d >= 0 && d < 3.5));
+                Assert.All<double>(sample.data<double>().ToArray(), d => Assert.True(d >= 0 && d < 3.5));
             }
         }
 
@@ -89,19 +89,19 @@ namespace TorchSharp
                 var sample = dist.sample();
 
                 Assert.Single(sample.shape);
-                Assert.All<double>(sample.Data<double>().ToArray(), d => Assert.True(d == 0 || d == 1));
+                Assert.All<double>(sample.data<double>().ToArray(), d => Assert.True(d == 0 || d == 1));
             }
             {
                 var sample = dist.sample(2, 3);
 
                 Assert.Equal(new long[] { 2, 3, 3 }, sample.shape);
-                Assert.All<double>(sample.Data<double>().ToArray(), d => Assert.True(d == 0 || d == 1));
+                Assert.All<double>(sample.data<double>().ToArray(), d => Assert.True(d == 0 || d == 1));
             }
             {
                 var sample = dist.expand(new long[] { 3, 3 }).sample(2, 3);
 
                 Assert.Equal(new long[] { 2, 3, 3, 3 }, sample.shape);
-                Assert.All<double>(sample.Data<double>().ToArray(), d => Assert.True(d == 0 || d == 1));
+                Assert.All<double>(sample.data<double>().ToArray(), d => Assert.True(d == 0 || d == 1));
             }
         }
 
@@ -136,19 +136,19 @@ namespace TorchSharp
                 var sample = dist.sample();
 
                 Assert.Single(sample.shape);
-                Assert.All<double>(sample.Data<double>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
+                Assert.All<double>(sample.data<double>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
             }
             {
                 var sample = dist.sample(2, 3);
 
                 Assert.Equal(new long[] { 2, 3, 3 }, sample.shape);
-                Assert.All<double>(sample.Data<double>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
+                Assert.All<double>(sample.data<double>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
             }
             {
                 var sample = dist.expand(new long[] { 3, 3 }).sample(2, 3);
 
                 Assert.Equal(new long[] { 2, 3, 3, 3 }, sample.shape);
-                Assert.All<double>(sample.Data<double>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
+                Assert.All<double>(sample.data<double>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
             }
         }
 
@@ -163,13 +163,13 @@ namespace TorchSharp
 
                 Assert.Single(sample.shape);
                 Assert.Equal(3, sample.shape[0]);
-                Assert.All<long>(sample.Data<long>().ToArray(), l => Assert.True(l >= 0 && l < categories));
+                Assert.All<long>(sample.data<long>().ToArray(), l => Assert.True(l >= 0 && l < categories));
             }
             {
                 var sample = dist.sample(2, 3);
 
                 Assert.Equal(new long[] { 2, 3, 3 }, sample.shape);
-                Assert.All<long>(sample.Data<long>().ToArray(), l => Assert.True(l >= 0 && l < categories));
+                Assert.All<long>(sample.data<long>().ToArray(), l => Assert.True(l >= 0 && l < categories));
             }
         }
 
@@ -340,19 +340,19 @@ namespace TorchSharp
                 var sample = dist.sample();
 
                 Assert.Equal(new long[] { 3, categories }, sample.shape);
-                Assert.All<float>(sample.Data<float>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
+                Assert.All<float>(sample.data<float>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
             }
             {
                 var sample = dist.sample(2, 3);
 
                 Assert.Equal(new long[] { 2, 3, 3, categories }, sample.shape);
-                Assert.All<float>(sample.Data<float>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
+                Assert.All<float>(sample.data<float>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
             }
             {
                 var sample = dist.expand(new long[] { 3, 3 }).sample(2, 3);
 
                 Assert.Equal(new long[] { 2, 3, 3, 3, categories }, sample.shape);
-                Assert.All<float>(sample.Data<float>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
+                Assert.All<float>(sample.data<float>().ToArray(), d => Assert.True(d >= 0 && d <= 100));
             }
         }
     }

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -77,7 +77,7 @@ namespace TorchSharp
 
                     Assert.Equal(data.shape, new long[] { 16, 3, 32, 32 });
                     Assert.Equal(target.shape, new long[] { 16 });
-                    Assert.True(target.Data<int>().ToArray().Where(x => x >= 0 && x < 10).Count() == 16);
+                    Assert.True(target.data<int>().ToArray().Where(x => x >= 0 && x < 10).Count() == 16);
 
                     data.Dispose();
                     target.Dispose();

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -206,256 +206,256 @@ namespace TorchSharp
         public void TestDataBool()
         {
             var x = torch.ones(5, torch.@bool);
-            Assert.Throws<System.ArgumentException>(() => x.Data<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<short>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<int>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<long>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<float>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<double>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<System.Numerics.Complex>());
-            x.Data<bool>();
+            Assert.Throws<System.ArgumentException>(() => x.data<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<short>());
+            Assert.Throws<System.ArgumentException>(() => x.data<int>());
+            Assert.Throws<System.ArgumentException>(() => x.data<long>());
+            Assert.Throws<System.ArgumentException>(() => x.data<float>());
+            Assert.Throws<System.ArgumentException>(() => x.data<double>());
+            Assert.Throws<System.ArgumentException>(() => x.data<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.data<System.Numerics.Complex>());
+            x.data<bool>();
         }
 
         [Fact]
         public void TestDataByte()
         {
             var x = torch.ones(5, torch.uint8);
-            Assert.Throws<System.ArgumentException>(() => x.Data<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<short>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<int>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<long>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<float>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<double>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<System.Numerics.Complex>());
-            x.Data<byte>();
+            Assert.Throws<System.ArgumentException>(() => x.data<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.data<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<short>());
+            Assert.Throws<System.ArgumentException>(() => x.data<int>());
+            Assert.Throws<System.ArgumentException>(() => x.data<long>());
+            Assert.Throws<System.ArgumentException>(() => x.data<float>());
+            Assert.Throws<System.ArgumentException>(() => x.data<double>());
+            Assert.Throws<System.ArgumentException>(() => x.data<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.data<System.Numerics.Complex>());
+            x.data<byte>();
         }
 
         [Fact]
         public void TestDataInt8()
         {
             var x = torch.ones(5, torch.int8);
-            Assert.Throws<System.ArgumentException>(() => x.Data<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<short>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<int>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<long>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<float>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<double>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<System.Numerics.Complex>());
-            x.Data<sbyte>();
+            Assert.Throws<System.ArgumentException>(() => x.data<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.data<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<short>());
+            Assert.Throws<System.ArgumentException>(() => x.data<int>());
+            Assert.Throws<System.ArgumentException>(() => x.data<long>());
+            Assert.Throws<System.ArgumentException>(() => x.data<float>());
+            Assert.Throws<System.ArgumentException>(() => x.data<double>());
+            Assert.Throws<System.ArgumentException>(() => x.data<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.data<System.Numerics.Complex>());
+            x.data<sbyte>();
         }
 
         [Fact]
         public void TestDataInt16()
         {
             var x = torch.ones(5, torch.int16);
-            Assert.Throws<System.ArgumentException>(() => x.Data<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<int>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<long>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<float>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<double>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<System.Numerics.Complex>());
-            x.Data<short>();
+            Assert.Throws<System.ArgumentException>(() => x.data<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.data<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<int>());
+            Assert.Throws<System.ArgumentException>(() => x.data<long>());
+            Assert.Throws<System.ArgumentException>(() => x.data<float>());
+            Assert.Throws<System.ArgumentException>(() => x.data<double>());
+            Assert.Throws<System.ArgumentException>(() => x.data<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.data<System.Numerics.Complex>());
+            x.data<short>();
         }
 
         [Fact]
         public void TestDataInt32()
         {
             var x = torch.ones(5, torch.int32);
-            Assert.Throws<System.ArgumentException>(() => x.Data<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<short>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<long>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<float>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<double>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<System.Numerics.Complex>());
-            x.Data<int>();
+            Assert.Throws<System.ArgumentException>(() => x.data<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.data<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<short>());
+            Assert.Throws<System.ArgumentException>(() => x.data<long>());
+            Assert.Throws<System.ArgumentException>(() => x.data<float>());
+            Assert.Throws<System.ArgumentException>(() => x.data<double>());
+            Assert.Throws<System.ArgumentException>(() => x.data<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.data<System.Numerics.Complex>());
+            x.data<int>();
         }
 
         [Fact]
         public void TestDataInt64()
         {
             var x = torch.ones(5, torch.int64);
-            Assert.Throws<System.ArgumentException>(() => x.Data<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<short>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<int>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<float>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<double>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<System.Numerics.Complex>());
-            x.Data<long>();
+            Assert.Throws<System.ArgumentException>(() => x.data<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.data<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<short>());
+            Assert.Throws<System.ArgumentException>(() => x.data<int>());
+            Assert.Throws<System.ArgumentException>(() => x.data<float>());
+            Assert.Throws<System.ArgumentException>(() => x.data<double>());
+            Assert.Throws<System.ArgumentException>(() => x.data<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.data<System.Numerics.Complex>());
+            x.data<long>();
         }
 
         [Fact]
         public void TestDataFloat32()
         {
             var x = torch.ones(5, torch.float32);
-            Assert.Throws<System.ArgumentException>(() => x.Data<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<short>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<int>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<long>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<double>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<System.Numerics.Complex>());
-            x.Data<float>();
+            Assert.Throws<System.ArgumentException>(() => x.data<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.data<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<short>());
+            Assert.Throws<System.ArgumentException>(() => x.data<int>());
+            Assert.Throws<System.ArgumentException>(() => x.data<long>());
+            Assert.Throws<System.ArgumentException>(() => x.data<double>());
+            Assert.Throws<System.ArgumentException>(() => x.data<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.data<System.Numerics.Complex>());
+            x.data<float>();
         }
 
         [Fact]
         public void TestDataFloat64()
         {
             var x = torch.ones(5, torch.float64);
-            Assert.Throws<System.ArgumentException>(() => x.Data<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<short>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<int>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<long>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<float>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<(float,float)>());
-            Assert.Throws<System.ArgumentException>(() => x.Data<System.Numerics.Complex>());
-            x.Data<double>();
+            Assert.Throws<System.ArgumentException>(() => x.data<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.data<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.data<short>());
+            Assert.Throws<System.ArgumentException>(() => x.data<int>());
+            Assert.Throws<System.ArgumentException>(() => x.data<long>());
+            Assert.Throws<System.ArgumentException>(() => x.data<float>());
+            Assert.Throws<System.ArgumentException>(() => x.data<(float,float)>());
+            Assert.Throws<System.ArgumentException>(() => x.data<System.Numerics.Complex>());
+            x.data<double>();
         }
 
         [Fact]
         public void TestDataItemBool()
         {
             var x = torch.ones(1, torch.@bool);
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<short>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<int>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<long>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<float>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<double>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<System.Numerics.Complex>());
-            x.DataItem<bool>();
+            Assert.Throws<System.ArgumentException>(() => x.item<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<short>());
+            Assert.Throws<System.ArgumentException>(() => x.item<int>());
+            Assert.Throws<System.ArgumentException>(() => x.item<long>());
+            Assert.Throws<System.ArgumentException>(() => x.item<float>());
+            Assert.Throws<System.ArgumentException>(() => x.item<double>());
+            Assert.Throws<System.ArgumentException>(() => x.item<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.item<System.Numerics.Complex>());
+            x.item<bool>();
         }
 
         [Fact]
         public void TestDataItemByte()
         {
             var x = torch.ones(1, torch.uint8);
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<short>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<int>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<long>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<float>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<double>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<System.Numerics.Complex>());
-            x.DataItem<byte>();
+            Assert.Throws<System.ArgumentException>(() => x.item<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.item<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<short>());
+            Assert.Throws<System.ArgumentException>(() => x.item<int>());
+            Assert.Throws<System.ArgumentException>(() => x.item<long>());
+            Assert.Throws<System.ArgumentException>(() => x.item<float>());
+            Assert.Throws<System.ArgumentException>(() => x.item<double>());
+            Assert.Throws<System.ArgumentException>(() => x.item<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.item<System.Numerics.Complex>());
+            x.item<byte>();
         }
 
         [Fact]
         public void TestDataItemInt8()
         {
             var x = torch.ones(1, torch.int8);
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<short>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<int>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<long>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<float>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<double>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<System.Numerics.Complex>());
-            x.DataItem<sbyte>();
+            Assert.Throws<System.ArgumentException>(() => x.item<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.item<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<short>());
+            Assert.Throws<System.ArgumentException>(() => x.item<int>());
+            Assert.Throws<System.ArgumentException>(() => x.item<long>());
+            Assert.Throws<System.ArgumentException>(() => x.item<float>());
+            Assert.Throws<System.ArgumentException>(() => x.item<double>());
+            Assert.Throws<System.ArgumentException>(() => x.item<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.item<System.Numerics.Complex>());
+            x.item<sbyte>();
         }
 
         [Fact]
         public void TestDataItemInt16()
         {
             var x = torch.ones(1, torch.int16);
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<int>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<long>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<float>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<double>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<System.Numerics.Complex>());
-            x.DataItem<short>();
+            Assert.Throws<System.ArgumentException>(() => x.item<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.item<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<int>());
+            Assert.Throws<System.ArgumentException>(() => x.item<long>());
+            Assert.Throws<System.ArgumentException>(() => x.item<float>());
+            Assert.Throws<System.ArgumentException>(() => x.item<double>());
+            Assert.Throws<System.ArgumentException>(() => x.item<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.item<System.Numerics.Complex>());
+            x.item<short>();
         }
 
         [Fact]
         public void TestDataItemInt32()
         {
             var x = torch.ones(1, torch.int32);
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<short>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<long>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<float>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<double>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<System.Numerics.Complex>());
-            x.DataItem<int>();
+            Assert.Throws<System.ArgumentException>(() => x.item<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.item<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<short>());
+            Assert.Throws<System.ArgumentException>(() => x.item<long>());
+            Assert.Throws<System.ArgumentException>(() => x.item<float>());
+            Assert.Throws<System.ArgumentException>(() => x.item<double>());
+            Assert.Throws<System.ArgumentException>(() => x.item<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.item<System.Numerics.Complex>());
+            x.item<int>();
         }
 
         [Fact]
         public void TestDataItemInt64()
         {
             var x = torch.ones(1, torch.int64);
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<short>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<int>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<float>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<double>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<System.Numerics.Complex>());
-            x.DataItem<long>();
+            Assert.Throws<System.ArgumentException>(() => x.item<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.item<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<short>());
+            Assert.Throws<System.ArgumentException>(() => x.item<int>());
+            Assert.Throws<System.ArgumentException>(() => x.item<float>());
+            Assert.Throws<System.ArgumentException>(() => x.item<double>());
+            Assert.Throws<System.ArgumentException>(() => x.item<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.item<System.Numerics.Complex>());
+            x.item<long>();
         }
 
         [Fact]
         public void TestDataItemFloat32()
         {
             var x = torch.ones(1, torch.float32);
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<short>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<int>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<long>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<double>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<System.Numerics.Complex>());
-            x.DataItem<float>();
+            Assert.Throws<System.ArgumentException>(() => x.item<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.item<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<short>());
+            Assert.Throws<System.ArgumentException>(() => x.item<int>());
+            Assert.Throws<System.ArgumentException>(() => x.item<long>());
+            Assert.Throws<System.ArgumentException>(() => x.item<double>());
+            Assert.Throws<System.ArgumentException>(() => x.item<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.item<System.Numerics.Complex>());
+            x.item<float>();
         }
 
         [Fact]
         public void TestDataItemFloat64()
         {
             var x = torch.ones(1, torch.float64);
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<bool>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<byte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<sbyte>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<short>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<int>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<long>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<float>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<(float, float)>());
-            Assert.Throws<System.ArgumentException>(() => x.DataItem<System.Numerics.Complex>());
-            x.DataItem<double>();
+            Assert.Throws<System.ArgumentException>(() => x.item<bool>());
+            Assert.Throws<System.ArgumentException>(() => x.item<byte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<sbyte>());
+            Assert.Throws<System.ArgumentException>(() => x.item<short>());
+            Assert.Throws<System.ArgumentException>(() => x.item<int>());
+            Assert.Throws<System.ArgumentException>(() => x.item<long>());
+            Assert.Throws<System.ArgumentException>(() => x.item<float>());
+            Assert.Throws<System.ArgumentException>(() => x.item<(float, float)>());
+            Assert.Throws<System.ArgumentException>(() => x.item<System.Numerics.Complex>());
+            x.item<double>();
         }
 
 
@@ -798,7 +798,7 @@ namespace TorchSharp
 
             Tensor t = torch.zeros(shape, torch.complex64);
             Assert.Equal(shape, t.shape);
-            var v3 = t.Data<(float Real, float Imaginary)>().ToArray();
+            var v3 = t.data<(float Real, float Imaginary)>().ToArray();
             for (var i = 0; i < v3.Length; i++) {
                 Assert.Equal(0.0f, v3[i].Real);
                 Assert.Equal(0.0f, v3[i].Imaginary);
@@ -812,7 +812,7 @@ namespace TorchSharp
 
             Tensor t = torch.ones(shape, torch.complex64);
             Assert.Equal(shape, t.shape);
-            var v3 = t.Data<(float Real, float Imaginary)>().ToArray();
+            var v3 = t.data<(float Real, float Imaginary)>().ToArray();
             for (var i = 0; i < v3.Length; i++) {
                 Assert.Equal(1.0f, v3[i].Real);
                 Assert.Equal(0.0f, v3[i].Imaginary);
@@ -889,7 +889,7 @@ namespace TorchSharp
             var shape = new long[] { 2, 2 };
             Tensor t = torch.rand(shape, torch.complex64);
             Assert.Equal(shape, t.shape);
-            var v3 = t.Data<(float Real, float Imaginary)>().ToArray();
+            var v3 = t.data<(float Real, float Imaginary)>().ToArray();
             Assert.All(v3, t => Assert.True(t.Real >= 0.0f && t.Real < 1.0f && t.Imaginary >= 0.0f && t.Imaginary < 1.0f));
         }
 
@@ -899,7 +899,7 @@ namespace TorchSharp
             var shape = new long[] { 2, 2 };
             Tensor t = torch.randn(shape, torch.complex64);
             Assert.Equal(shape, t.shape);
-            var v3 = t.Data<(float Real, float Imaginary)>().ToArray();
+            var v3 = t.data<(float Real, float Imaginary)>().ToArray();
         }
 
         [Fact]
@@ -909,7 +909,7 @@ namespace TorchSharp
 
             Tensor t = torch.zeros(shape, complex128);
             Assert.Equal(shape, t.shape);
-            var v3 = t.Data<System.Numerics.Complex>().ToArray();
+            var v3 = t.data<System.Numerics.Complex>().ToArray();
             for (var i = 0; i < v3.Length; i++) {
                 Assert.Equal(0.0, v3[i].Real);
                 Assert.Equal(0.0, v3[i].Imaginary);
@@ -923,7 +923,7 @@ namespace TorchSharp
 
             Tensor t = torch.ones(shape, complex128);
             Assert.Equal(shape, t.shape);
-            var v3 = t.Data<System.Numerics.Complex>().ToArray();
+            var v3 = t.data<System.Numerics.Complex>().ToArray();
             for (var i = 0; i < v3.Length; i++) {
                 Assert.Equal(1.0, v3[i].Real);
                 Assert.Equal(0.0, v3[i].Imaginary);
@@ -947,7 +947,7 @@ namespace TorchSharp
         public void CreateFloat32TensorOnesCheckData()
         {
             var ones = torch.ones(new long[] { 2, 2 });
-            var data = ones.Data<float>();
+            var data = ones.data<float>();
 
             for (int i = 0; i < 4; i++) {
                 Assert.Equal(1.0, data[i]);
@@ -958,7 +958,7 @@ namespace TorchSharp
         public void CreateFloat32TensorZerosCheckData()
         {
             var zeros = torch.zeros(new long[] { 2, 2 });
-            var data = zeros.Data<float>();
+            var data = zeros.data<float>();
 
             for (int i = 0; i < 4; i++) {
                 Assert.Equal(0, data[i]);
@@ -969,7 +969,7 @@ namespace TorchSharp
         public void CreateInt32TensorOnesCheckData()
         {
             var ones = torch.ones(new long[] { 2, 2 }, int32);
-            var data = ones.Data<int>();
+            var data = ones.data<int>();
 
             for (int i = 0; i < 4; i++) {
                 Assert.Equal(1, data[i]);
@@ -1066,7 +1066,7 @@ namespace TorchSharp
             data[100] = 1;
 
             using (var tensor = torch.tensor(data, new long[] { 100, 10 })) {
-                Assert.Equal(1, tensor.Data<float>()[100]);
+                Assert.Equal(1, tensor.data<float>()[100]);
             }
         }
 
@@ -1077,7 +1077,7 @@ namespace TorchSharp
             data[100] = 1;
 
             using (var tensor = torch.tensor(data, new long[] { 100, 10 })) {
-                Assert.Equal(1, tensor.Data<float>()[100]);
+                Assert.Equal(1, tensor.data<float>()[100]);
             }
 
             Assert.Equal(1, data[100]);
@@ -1089,7 +1089,7 @@ namespace TorchSharp
             var data = new float[1000];
 
             using (var tensor = data.ToTensor(new long[] { 10, 100 })) {
-                Assert.Equal(default(float), tensor.Data<float>()[100]);
+                Assert.Equal(default(float), tensor.data<float>()[100]);
             }
         }
 
@@ -1250,7 +1250,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float32, t2.dtype);
-            Assert.All(t2.Data<float>().ToArray(), t => Assert.True(t == 1.0f));
+            Assert.All(t2.data<float>().ToArray(), t => Assert.True(t == 1.0f));
         }
 
         [Fact]
@@ -1265,7 +1265,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float64, t2.dtype);
-            Assert.All(t2.Data<double>().ToArray(), t => Assert.True(t == 1.0));
+            Assert.All(t2.data<double>().ToArray(), t => Assert.True(t == 1.0));
         }
 
         [Fact]
@@ -1280,7 +1280,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float32, t2.dtype);
-            Assert.All(t2.Data<float>().ToArray(), t => Assert.True(t == 0.0f));
+            Assert.All(t2.data<float>().ToArray(), t => Assert.True(t == 0.0f));
         }
 
         [Fact]
@@ -1295,7 +1295,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float64, t2.dtype);
-            Assert.All(t2.Data<double>().ToArray(), t => Assert.True(t == 0.0));
+            Assert.All(t2.data<double>().ToArray(), t => Assert.True(t == 0.0));
         }
 
         [Fact]
@@ -1339,7 +1339,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float32, t2.dtype);
-            Assert.All(t2.Data<float>().ToArray(), t => Assert.True(t == 3.14f));
+            Assert.All(t2.data<float>().ToArray(), t => Assert.True(t == 3.14f));
         }
 
         [Fact]
@@ -1355,7 +1355,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float64, t2.dtype);
-            Assert.All(t2.Data<double>().ToArray(), t => Assert.True(t == 3.14));
+            Assert.All(t2.data<double>().ToArray(), t => Assert.True(t == 3.14));
         }
 
         [Fact]
@@ -1370,7 +1370,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float32, t2.dtype);
-            Assert.All(t2.Data<float>().ToArray(), t => Assert.True(t >= 0.0f && t < 1.0f));
+            Assert.All(t2.data<float>().ToArray(), t => Assert.True(t >= 0.0f && t < 1.0f));
         }
 
         [Fact]
@@ -1385,7 +1385,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float64, t2.dtype);
-            Assert.All(t2.Data<double>().ToArray(), t => Assert.True(t >= 0.0 && t < 1.0));
+            Assert.All(t2.data<double>().ToArray(), t => Assert.True(t >= 0.0 && t < 1.0));
         }
 
         [Fact]
@@ -1484,7 +1484,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float32, t2.dtype);
-            Assert.All(t2.Data<float>().ToArray(), t => Assert.True(t >= 5.0f && t < 15.0f));
+            Assert.All(t2.data<float>().ToArray(), t => Assert.True(t >= 5.0f && t < 15.0f));
         }
 
         [Fact]
@@ -1499,14 +1499,14 @@ namespace TorchSharp
             Assert.Equal(ScalarType.Float32, t1.dtype);
             Assert.Equal(t1.shape, t2.shape);
             Assert.Equal(ScalarType.Float64, t2.dtype);
-            Assert.All(t2.Data<double>().ToArray(), t => Assert.True(t >= 5.0 && t < 15.0));
+            Assert.All(t2.data<double>().ToArray(), t => Assert.True(t >= 5.0 && t < 15.0));
         }
 
         [Fact]
         public void Float32Mean()
         {
             using (var tensor = torch.arange(1, 100, float32)) {
-                var mean = tensor.mean().DataItem<float>();
+                var mean = tensor.mean().item<float>();
                 Assert.Equal(50.0f, mean);
             }
         }
@@ -1517,8 +1517,8 @@ namespace TorchSharp
         {
             using (var tensor = torch.tensor(new int[] { 1, 5, 4, 5, 3, 3, 5, 5 })) {
                 var mode = tensor.mode();
-                Assert.Equal(new int[] { 5 }, mode.values.Data<int>().ToArray());
-                Assert.Equal(new long[] { 7 }, mode.indices.Data<long>().ToArray());
+                Assert.Equal(new int[] { 5 }, mode.values.data<int>().ToArray());
+                Assert.Equal(new long[] { 7 }, mode.indices.data<long>().ToArray());
             }
         }
 
@@ -1714,16 +1714,16 @@ namespace TorchSharp
         {
             using (Tensor tensor = torch.empty(new long[] { 2, 2 })) {
                 tensor.fill_(Single.PositiveInfinity);
-                Assert.True(tensor.isposinf().Data<bool>().ToArray().All(b => b));
-                Assert.True(tensor.isinf().Data<bool>().ToArray().All(b => b));
-                Assert.False(tensor.isneginf().Data<bool>().ToArray().All(b => b));
-                Assert.False(tensor.isfinite().Data<bool>().ToArray().All(b => b));
+                Assert.True(tensor.isposinf().data<bool>().ToArray().All(b => b));
+                Assert.True(tensor.isinf().data<bool>().ToArray().All(b => b));
+                Assert.False(tensor.isneginf().data<bool>().ToArray().All(b => b));
+                Assert.False(tensor.isfinite().data<bool>().ToArray().All(b => b));
 
                 tensor.fill_(Single.NegativeInfinity);
-                Assert.True(tensor.isneginf().Data<bool>().ToArray().All(b => b));
-                Assert.True(tensor.isinf().Data<bool>().ToArray().All(b => b));
-                Assert.False(tensor.isposinf().Data<bool>().ToArray().All(b => b));
-                Assert.False(tensor.isfinite().Data<bool>().ToArray().All(b => b));
+                Assert.True(tensor.isneginf().data<bool>().ToArray().All(b => b));
+                Assert.True(tensor.isinf().data<bool>().ToArray().All(b => b));
+                Assert.False(tensor.isposinf().data<bool>().ToArray().All(b => b));
+                Assert.False(tensor.isfinite().data<bool>().ToArray().All(b => b));
             }
         }
 
@@ -1987,8 +1987,8 @@ namespace TorchSharp
                 Assert.True(sparse.is_sparse);
                 Assert.False(i.is_sparse);
                 Assert.False(v.is_sparse);
-                Assert.Equal(sparse.SparseIndices.Data<long>().ToArray(), new long[] { 0, 1, 1, 2, 0, 2 });
-                Assert.Equal(sparse.SparseValues.Data<float>().ToArray(), new float[] { 3, 4, 5 });
+                Assert.Equal(sparse.SparseIndices.data<long>().ToArray(), new long[] { 0, 1, 1, 2, 0, 2 });
+                Assert.Equal(sparse.SparseValues.data<float>().ToArray(), new float[] { 3, 4, 5 });
             }
         }
 
@@ -2125,7 +2125,7 @@ namespace TorchSharp
                 // Copy back to CPU to inspect the elements
                 var cpu2 = cuda.cpu();
                 Assert.Equal("cpu", cpu2.device.ToString());
-                var data = cpu.Data<float>();
+                var data = cpu.data<float>();
                 for (int i = 0; i < 4; i++) {
                     Assert.Equal(1, data[i]);
                 }
@@ -2145,7 +2145,7 @@ namespace TorchSharp
                 var cpu = cuda.cpu();
                 Assert.Equal("cpu", cpu.device.ToString());
 
-                var data = cpu.Data<float>();
+                var data = cpu.data<float>();
                 for (int i = 0; i < 4; i++) {
                     Assert.Equal(1, data[i]);
                 }
@@ -2303,12 +2303,12 @@ namespace TorchSharp
             mask[2, 3] = tTrue;
 
             var res = input.masked_scatter(mask, torch.tensor(new float[] { 3.14f, 2 * 3.14f }));
-            Assert.Equal(3.14f, res[0, 1].DataItem<float>());
-            Assert.Equal(2 * 3.14f, res[2, 3].DataItem<float>());
+            Assert.Equal(3.14f, res[0, 1].item<float>());
+            Assert.Equal(2 * 3.14f, res[2, 3].item<float>());
 
             input.masked_scatter_(mask, torch.tensor(new float[] { 3.14f, 2 * 3.14f }));
-            Assert.Equal(3.14f, input[0, 1].DataItem<float>());
-            Assert.Equal(2 * 3.14f, input[2, 3].DataItem<float>());
+            Assert.Equal(3.14f, input[0, 1].item<float>());
+            Assert.Equal(2 * 3.14f, input[2, 3].item<float>());
         }
 
         [Fact]
@@ -2368,7 +2368,7 @@ namespace TorchSharp
 
             var res = input.diag();
             Assert.Equal(2, res.Dimensions);
-            Assert.Equal(expected, res.Data<long>().ToArray());
+            Assert.Equal(expected, res.data<long>().ToArray());
         }
 
         [Fact]
@@ -2383,7 +2383,7 @@ namespace TorchSharp
 
             var res = input.diag();
             Assert.Equal(1, res.Dimensions);
-            Assert.Equal(expected, res.Data<long>().ToArray());
+            Assert.Equal(expected, res.data<long>().ToArray());
         }
 
 
@@ -2395,7 +2395,7 @@ namespace TorchSharp
 
             var res = input.diagflat();
             Assert.Equal(2, res.Dimensions);
-            Assert.Equal(expected, res.Data<long>().ToArray());
+            Assert.Equal(expected, res.data<long>().ToArray());
         }
 
         [Fact]
@@ -2407,7 +2407,7 @@ namespace TorchSharp
 
             var res = input.diagflat();
             Assert.Equal(2, res.Dimensions);
-            Assert.Equal(expected, res.Data<long>().ToArray());
+            Assert.Equal(expected, res.data<long>().ToArray());
         }
 
         [Fact]
@@ -2631,7 +2631,7 @@ namespace TorchSharp
                     sum.backward();
                     var grad = x.grad();
                     Assert.False(grad is null || grad.Handle == IntPtr.Zero);
-                    var data = grad is not null ? grad.Data<float>() : new float[] { };
+                    var data = grad is not null ? grad.data<float>().ToArray() : new float[] { };
                     for (int i = 0; i < 2 * 3; i++) {
                         Assert.Equal(1.0, data[i]);
                     }
@@ -2650,7 +2650,7 @@ namespace TorchSharp
                     sum.backward();
                     var grad = x.grad();
                     Assert.False(grad is not null && grad.Handle == IntPtr.Zero);
-                    var data = grad is not null ? grad.Data<float>() : new float[] { };
+                    var data = grad is not null ? grad.data<float>().ToArray() : new float[] { };
                     for (int i = 0; i < 2 * 3; i++) {
                         Assert.Equal(1.0, data[i]);
                     }
@@ -2666,7 +2666,7 @@ namespace TorchSharp
 
             x.sub_(y);
 
-            var xdata = x.Data<int>();
+            var xdata = x.data<int>();
 
             for (int i = 0; i < 100; i++) {
                 for (int j = 0; j < 100; j++) {
@@ -3111,7 +3111,7 @@ namespace TorchSharp
             Tensor c3,
             Func<Tensor, long, long, Tin> getFuncIn,
             Func<Tensor, Tensor, Tensor> tensorFunc,
-            Func<Tin, Tin, Tin> scalarFunc)
+            Func<Tin, Tin, Tin> scalarFunc) where Tin : unmanaged
         {
 
             var x = c1 * c3;
@@ -3121,9 +3121,9 @@ namespace TorchSharp
             var z = tensorFunc(x, y);
 
             if (x.device_type == DeviceType.CPU) {
-                var xData = x.Data<Tin>();
-                var yData = y.Data<Tin>();
-                var zData = z.Data<Tin>();
+                var xData = x.data<Tin>();
+                var yData = y.data<Tin>();
+                var zData = z.data<Tin>();
 
                 Assert.True(xData == zData);
             }
@@ -3147,8 +3147,8 @@ namespace TorchSharp
 
             var y = x.mul(0.5f.ToScalar());
 
-            var ydata = y.Data<float>();
-            var xdata = x.Data<float>();
+            var ydata = y.data<float>();
+            var xdata = x.data<float>();
 
             for (int i = 0; i < 100; i++) {
                 for (int j = 0; j < 100; j++) {
@@ -3165,7 +3165,7 @@ namespace TorchSharp
 
                 var y = x1.mm(x2).to(DeviceType.CPU);
 
-                var ydata = y.Data<float>();
+                var ydata = y.data<float>();
 
                 Assert.Equal(2.0f, ydata[0]);
             }
@@ -3176,7 +3176,7 @@ namespace TorchSharp
 
                 var y = x1.mm(x2).to(DeviceType.CPU);
 
-                var ydata = y.Data<long>();
+                var ydata = y.data<long>();
 
                 Assert.Equal(2L, ydata[0]);
             }
@@ -3269,7 +3269,7 @@ namespace TorchSharp
             var a = torch.randn(25, 25);
             var b = a.positive();
 
-            Assert.Equal(a.Data<float>().ToArray(), b.Data<float>().ToArray());
+            Assert.Equal(a.data<float>().ToArray(), b.data<float>().ToArray());
 
             var c = torch.ones(25, 25, @bool);
             Assert.Throws<ArgumentException>(() => c.positive());
@@ -3281,8 +3281,8 @@ namespace TorchSharp
             var x = torch.arange(9, float32);
             var r = x.frexp();
 
-            Assert.Equal(new float[] { 0.0000f, 0.5000f, 0.5000f, 0.7500f, 0.5000f, 0.6250f, 0.7500f, 0.8750f, 0.5000f }, r.Mantissa.Data<float>().ToArray());
-            Assert.Equal(new int[] { 0, 1, 2, 2, 3, 3, 3, 3, 4 }, r.Exponent.Data<int>().ToArray());
+            Assert.Equal(new float[] { 0.0000f, 0.5000f, 0.5000f, 0.7500f, 0.5000f, 0.6250f, 0.7500f, 0.8750f, 0.5000f }, r.Mantissa.data<float>().ToArray());
+            Assert.Equal(new int[] { 0, 1, 2, 2, 3, 3, 3, 3, 4 }, r.Exponent.data<int>().ToArray());
         }
 
         [Fact]
@@ -3314,7 +3314,7 @@ namespace TorchSharp
             var data = torch.rand(3, 3, 3) * 10;
             var cl = data.clamp(1, 5);
 
-            Assert.All(cl.Data<float>().ToArray(), d => Assert.True(d >= 1.0f && d <= 5.0f));
+            Assert.All(cl.data<float>().ToArray(), d => Assert.True(d >= 1.0f && d <= 5.0f));
         }
 
         [Fact]
@@ -3323,7 +3323,7 @@ namespace TorchSharp
             var data = torch.rand(3, 3, 3) * 10;
             var cl = data.clamp(torch.ones(3,3,3), torch.ones(3,3,3) * 5);
 
-            Assert.All(cl.Data<float>().ToArray(), d => Assert.True(d >= 1.0f && d <= 5.0f));
+            Assert.All(cl.data<float>().ToArray(), d => Assert.True(d >= 1.0f && d <= 5.0f));
         }
 
         [Fact]
@@ -3332,7 +3332,7 @@ namespace TorchSharp
             var data = torch.rand(3, 3, 3) * 10;
             var cl = torch.clamp(data, 1, 5);
 
-            Assert.All(cl.Data<float>().ToArray(), d => Assert.True(d >= 1.0f && d <= 5.0f));
+            Assert.All(cl.data<float>().ToArray(), d => Assert.True(d >= 1.0f && d <= 5.0f));
         }
 
         [Fact]
@@ -3341,7 +3341,7 @@ namespace TorchSharp
             var data = torch.rand(3, 3, 3) * 10;
             var cl = torch.clamp(data, torch.ones(3, 3, 3), torch.ones(3, 3, 3) * 5);
 
-            Assert.All(cl.Data<float>().ToArray(), d => Assert.True(d >= 1.0f && d <= 5.0f));
+            Assert.All(cl.data<float>().ToArray(), d => Assert.True(d >= 1.0f && d <= 5.0f));
         }
 
         [Fact]
@@ -3357,7 +3357,7 @@ namespace TorchSharp
         public void AbsTest()
         {
             var data = torch.arange(-10.0f, 10.0f, 1.0f);
-            var expected = data.Data<float>().ToArray().Select(MathF.Abs).ToArray();
+            var expected = data.data<float>().ToArray().Select(MathF.Abs).ToArray();
             var res = data.abs();
             Assert.True(res.allclose(torch.tensor(expected)));
         }
@@ -3366,7 +3366,7 @@ namespace TorchSharp
         public void AbsTestC32()
         {
             var data = torch.rand(new long[] { 25 }, complex64);
-            var expected = data.Data<(float R, float I)>().ToArray().Select(c => MathF.Sqrt(c.R * c.R + c.I * c.I)).ToArray();
+            var expected = data.data<(float R, float I)>().ToArray().Select(c => MathF.Sqrt(c.R * c.R + c.I * c.I)).ToArray();
             var res = data.abs();
             Assert.True(res.allclose(torch.tensor(expected)));
         }
@@ -3375,7 +3375,7 @@ namespace TorchSharp
         public void AbsTestC64()
         {
             var data = torch.rand(new long[] { 25 }, complex128);
-            var expected = data.Data<System.Numerics.Complex>().ToArray().Select(c => Math.Sqrt(c.Real * c.Real + c.Imaginary * c.Imaginary)).ToArray<double>();
+            var expected = data.data<System.Numerics.Complex>().ToArray().Select(c => Math.Sqrt(c.Real * c.Real + c.Imaginary * c.Imaginary)).ToArray<double>();
             var res = data.abs();
             Assert.True(res.allclose(torch.tensor(expected, float64)));
         }
@@ -3384,7 +3384,7 @@ namespace TorchSharp
         public void AngleTestC32()
         {
             var data = torch.randn(new long[] { 25 }, complex64);
-            var expected = data.Data<(float R, float I)>().ToArray().Select(c => {
+            var expected = data.data<(float R, float I)>().ToArray().Select(c => {
                 var x = c.R;
                 var y = c.I;
                 return (x > 0 || y != 0) ? 2 * MathF.Atan(y / (MathF.Sqrt(x * x + y * y) + x)) : (x < 0 && y == 0) ? MathF.PI : 0;
@@ -3397,7 +3397,7 @@ namespace TorchSharp
         public void AngleTestC64()
         {
             var data = torch.randn(new long[] { 25 }, complex128);
-            var expected = data.Data<System.Numerics.Complex>().ToArray().Select(c => {
+            var expected = data.data<System.Numerics.Complex>().ToArray().Select(c => {
                 var x = c.Real;
                 var y = c.Imaginary;
                 return (x > 0 || y != 0) ? 2 * Math.Atan(y / (Math.Sqrt(x * x + y * y) + x)) : (x < 0 && y == 0) ? Math.PI : 0;
@@ -3578,7 +3578,7 @@ namespace TorchSharp
             var data = new float[] { 1.0f, 2.0f, 3.0f };
             var expected = data.Select(MathF.Cosh).ToArray();
             var res = torch.tensor(data).cosh();
-            var tmp = res.Data<Single>();
+            var tmp = res.data<Single>();
             Assert.True(res.allclose(torch.tensor(expected)));
         }
 
@@ -3748,11 +3748,11 @@ namespace TorchSharp
             x.fill_(4.0f);
             var y = x.reciprocal();
 
-            Assert.All(x.Data<float>().ToArray(), a => Assert.Equal(4.0f, a));
-            Assert.All(y.Data<float>().ToArray(), a => Assert.Equal(0.25f, a));
+            Assert.All(x.data<float>().ToArray(), a => Assert.Equal(4.0f, a));
+            Assert.All(y.data<float>().ToArray(), a => Assert.Equal(0.25f, a));
 
             x.reciprocal_();
-            Assert.All(x.Data<float>().ToArray(), a => Assert.Equal(0.25f, a));
+            Assert.All(x.data<float>().ToArray(), a => Assert.Equal(0.25f, a));
         }
 
         [Fact]
@@ -3792,7 +3792,7 @@ namespace TorchSharp
         public void TruncTest()
         {
             var input = torch.randn(new long[] { 25 });
-            var expected = input.Data<float>().ToArray().Select(MathF.Truncate).ToArray();
+            var expected = input.data<float>().ToArray().Select(MathF.Truncate).ToArray();
             var res = input.trunc();
             Assert.True(res.allclose(torch.tensor(expected)));
 
@@ -4341,8 +4341,8 @@ namespace TorchSharp
             var x = t.take_along_dim(max_idx);
             var y = t.take_along_dim(sort_idx, dimension: 1);
 
-            Assert.Equal(60, x.DataItem<int>());
-            Assert.Equal(new int[] { 10, 20, 30, 40, 50, 60 }, y.Data<int>().ToArray());
+            Assert.Equal(60, x.item<int>());
+            Assert.Equal(new int[] { 10, 20, 30, 40, 50, 60 }, y.data<int>().ToArray());
         }
 
         [Fact]
@@ -4632,7 +4632,7 @@ namespace TorchSharp
                      {{1.5215f, 1.3946f, 2.1327f},
                       {1.0732f, 1.3014f, 2.0696f}}};
             {
-                var data = t3p2d3.Data<float>();
+                var data = t3p2d3.data<float>();
                 for (int i = 0; i < 3; i++)
                     for (int j = 0; j < 2; j++)
                         for (int k = 0; k < 3; k++) {
@@ -4845,8 +4845,8 @@ namespace TorchSharp
                 var b = linalg.matrix_norm(a);
                 var c = linalg.matrix_norm(a, ord: -1);
 
-                Assert.Equal(14.282857f, b.DataItem<float>());
-                Assert.Equal(9.0f, c.DataItem<float>());
+                Assert.Equal(14.282857f, b.item<float>());
+                Assert.Equal(9.0f, c.item<float>());
             }
         }
 
@@ -4861,8 +4861,8 @@ namespace TorchSharp
                 var b = linalg.vector_norm(a, ord: 3.5);
                 var c = linalg.vector_norm(a.view(3, 3), ord: 3.5);
 
-                Assert.Equal(5.4344883f, b.DataItem<float>());
-                Assert.Equal(5.4344883f, c.DataItem<float>());
+                Assert.Equal(5.4344883f, b.item<float>());
+                Assert.Equal(5.4344883f, c.item<float>());
             }
         }
 
@@ -4996,7 +4996,7 @@ namespace TorchSharp
         public void TestSpecialExpit()
         {
             var a = torch.randn(new long[] { 10 });
-            var expected = torch.tensor(a.Data<float>().ToArray().Select(x => 1.0f / (1.0f + MathF.Exp(-x))).ToArray());
+            var expected = torch.tensor(a.data<float>().ToArray().Select(x => 1.0f / (1.0f + MathF.Exp(-x))).ToArray());
             var b = torch.special.expit(a);
             Assert.True(b.allclose(expected, rtol: 1e-04, atol: 1e-07));
         }
@@ -5005,7 +5005,7 @@ namespace TorchSharp
         public void TestSpecialExpm1()
         {
             var a = torch.randn(new long[] { 10 });
-            var expected = torch.tensor(a.Data<float>().ToArray().Select(x => MathF.Exp(x) - 1.0f).ToArray());
+            var expected = torch.tensor(a.data<float>().ToArray().Select(x => MathF.Exp(x) - 1.0f).ToArray());
             var b = torch.special.expm1(a);
             Assert.True(b.allclose(expected, rtol: 1e-04, atol: 1e-07));
         }
@@ -5014,7 +5014,7 @@ namespace TorchSharp
         public void TestSpecialExp2()
         {
             var a = torch.randn(new long[] { 10 });
-            var expected = torch.tensor(a.Data<float>().ToArray().Select(x => MathF.Pow(2.0f, x)).ToArray());
+            var expected = torch.tensor(a.data<float>().ToArray().Select(x => MathF.Pow(2.0f, x)).ToArray());
             var b = torch.special.exp2(a);
             Assert.True(b.allclose(expected, rtol: 1e-04, atol: 1e-07));
         }
@@ -5677,10 +5677,10 @@ namespace TorchSharp
         {
             {
                 using (var input = torch.rand(25)) {
-                    var iData = input.Data<float>().ToArray();
+                    var iData = input.data<float>();
 
                     var poster = torchvision.transforms.Invert().forward(input);
-                    var pData = poster.Data<float>().ToArray();
+                    var pData = poster.data<float>();
 
                     Assert.Equal(new long[] { 25 }, poster.shape);
                     for (int i = 0; i < poster.shape[0]; i++) {
@@ -5706,7 +5706,7 @@ namespace TorchSharp
                     var poster = torchvision.transforms.Posterize(4).forward(input);
 
                     Assert.Equal(new long[] { 25 }, poster.shape);
-                    Assert.All(poster.Data<byte>().ToArray(), b => Assert.Equal(0, b & 0xf));
+                    Assert.All(poster.data<byte>().ToArray(), b => Assert.Equal(0, b & 0xf));
                 }
             }
         }
@@ -5849,7 +5849,7 @@ namespace TorchSharp
                     var poster = torchvision.transforms.Solarize(0.55).forward(input);
 
                     Assert.Equal(new long[] { 25 }, poster.shape);
-                    Assert.All(poster.Data<float>().ToArray(), f => Assert.True(f < 0.55f));
+                    Assert.All(poster.data<float>().ToArray(), f => Assert.True(f < 0.55f));
                 }
             }
         }

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -286,5 +286,28 @@ namespace TorchSharp
             Assert.True(flipped.is_contiguous());
             Assert.Equal<int>(flipped.contiguous().data<int>(), flipped.data<int>());
         }
+
+        [Fact]
+        public void ValidateIssue399_5()
+        {
+            using var contig = torch.arange(12, int32).reshape(3, 4).contiguous();
+            using var strided = contig.as_strided(new long[] { 3, 2, 4 }, new long[] { 4, 0, 1 });
+
+            Assert.False(strided.is_contiguous());
+            Assert.Equal<int>(strided.contiguous().data<int>(), strided.data<int>());
+            Assert.Equal(new long[] { 3, 2, 4 }, strided.shape);
+        }
+
+
+        [Fact]
+        public void ValidateIssue399_6()
+        {
+            using var contig = torch.arange(3, int32).reshape(3, 1).contiguous();
+            using var strided = contig.expand(3, 4);
+
+            Assert.False(strided.is_contiguous());
+            Assert.Equal<int>(strided.contiguous().data<int>(), strided.data<int>());
+            Assert.Equal(new long[] { 3, 4 }, strided.shape);
+        }
     }
 }


### PR DESCRIPTION
Addresses bug #399 by supporting non-contiguous tensors, and #398 by renaming Data<T> and DataItem<T> 