### PR TITLE
 Make able to declare sequential without name of module 

### DIFF
--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using TorchSharp.torchvision;
 using static TorchSharp.torch;
 
 namespace TorchSharp
@@ -35,6 +36,9 @@ namespace TorchSharp
                 _modules.Add(submodule);
                 _names.Add(name);
             }
+
+            public void Add(torch.nn.Module module)
+                => Add(new Random().NextDouble().ToString()[2..], module);
 
             internal Sequential(IntPtr handle) : base(handle, IntPtr.Zero)
             {
@@ -86,6 +90,18 @@ namespace TorchSharp
             extern static IntPtr THSNN_Sequential_ctor();
 
             /// <summary>
+            /// Get empty sequential
+            /// </summary>
+            /// <returns></returns>
+            static public Sequential Sequential()
+            {
+                var handle = THSNN_Sequential_ctor();
+                if(handle == IntPtr.Zero) {torch.CheckForErrors();}
+
+                return new Sequential(handle);
+            }
+
+            /// <summary>
             /// A sequential container. Modules will be added to it in the order they are passed in the constructor.
             /// Alternatively, an OrderedDict of modules can be passed in. The forward() method of Sequential accepts any input and forwards it to the first module it contains.
             /// It then “chains” outputs to inputs sequentially for each subsequent module, finally returning the output of the last module.
@@ -96,11 +112,25 @@ namespace TorchSharp
             /// <returns></returns>
             static public Sequential Sequential(params (string name, torch.nn.Module submodule)[] modules)
             {
-                var handle = THSNN_Sequential_ctor();
-                if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
-                var res = new Sequential(handle);
+                var res = Sequential();
                 foreach (var module in modules)
                     res.Add(module.name, module.submodule);
+                return res;
+            }
+
+            /// <summary>
+            /// A sequential container. Modules will be added to it in the order they are passed in the constructor.
+            /// It then “chains” outputs to inputs sequentially for each subsequent module, finally returning the output of the last module.
+            /// The value a Sequential provides over manually calling a sequence of modules is that it allows treating the whole container as a single module,
+            /// such that performing a transformation on the Sequential applies to each of the modules it stores (which are each a registered submodule of the Sequential).
+            /// </summary>
+            /// <param name="modules">An ordered list of the contained modules.</param>
+            /// <returns></returns>
+            static public Sequential Sequential(params torch.nn.Module[] modules)
+            {
+                var res = Sequential();
+                foreach(var m in modules)
+                    res.Add(new Random().NextDouble().ToString()[2..], m);
                 return res;
             }
 
@@ -114,15 +144,27 @@ namespace TorchSharp
             /// <param name="modules">An ordered list of the contained modules.</param>
             static public Sequential Sequential(IEnumerable<(string name, torch.nn.Module submodule)> modules)
             {
-                var handle = THSNN_Sequential_ctor();
-                if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
-                var res = new Sequential(handle);
+                var res = Sequential();
                 foreach (var module in modules)
                     res.Add(module.name, module.submodule);
                 return res;
             }
 
+            /// <summary>
+            /// A sequential container. Modules will be added to it in the order they are passed in the constructor.
+            /// It then “chains” outputs to inputs sequentially for each subsequent module, finally returning the output of the last module.
+            /// The value a Sequential provides over manually calling a sequence of modules is that it allows treating the whole container as a single module,
+            /// such that performing a transformation on the Sequential applies to each of the modules it stores (which are each a registered submodule of the Sequential).
+            /// </summary>
+            /// <param name="modules">An ordered list of the contained modules.</param>
+            /// <returns></returns>
+            static public Sequential Sequential(IEnumerable<torch.nn.Module> modules)
+            {
+                var res = Sequential();
+                foreach(var module in modules)
+                    res.Add(new Random().NextDouble().ToString()[2..], module);
+                return res;
+            }
         }
-
     }
 }

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using TorchSharp.torchvision;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp
@@ -38,7 +38,14 @@ namespace TorchSharp
             }
 
             public void Add(torch.nn.Module module)
-                => Add(new Random().NextDouble().ToString()[2..], module);
+            {
+                //if (module.GetType() == typeof(nn.Module)) throw new Exception(module.GetType().ToString());
+                //throw new Exception(module.GetType().ToString());
+
+                var type = module.GetType().ToString().Split('.')[^1].TrimEnd(Enumerable.Range('0', 10).Select(x => (char)x).ToArray()).ToLower().Replace('+', '_');
+                //throw new Exception(type + (_countType.ContainsKey(type) ? ++_countType[type] : _countType[type] = 1));
+                Add(type + (_countType.ContainsKey(type) ? ++_countType[type] : _countType[type] = 1), module);
+            }
 
             internal Sequential(IntPtr handle) : base(handle, IntPtr.Zero)
             {
@@ -78,6 +85,7 @@ namespace TorchSharp
 
             private List<torch.nn.Module> _modules = new List<nn.Module>();
             private List<string> _names = new List<string>();
+            private Dictionary<string, int> _countType = new Dictionary<string, int>();
         }
     }
 
@@ -130,7 +138,7 @@ namespace TorchSharp
             {
                 var res = Sequential();
                 foreach(var m in modules)
-                    res.Add(new Random().NextDouble().ToString()[2..], m);
+                    res.Add(m);
                 return res;
             }
 
@@ -162,7 +170,7 @@ namespace TorchSharp
             {
                 var res = Sequential();
                 foreach(var module in modules)
-                    res.Add(new Random().NextDouble().ToString()[2..], module);
+                    res.Add(module);
                 return res;
             }
         }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1412,6 +1412,24 @@ namespace TorchSharp
             Assert.True(seq.has_parameter("test.dict.second"));
         }
 
+        [Fact]
+        public void TestCustomModule4()
+        {
+            var module = new TestModule1(torch.randn(new long[] { 2, 2 }), true);
+
+            var seq = Sequential(module);
+
+            Assert.True(module.has_parameter("test"));
+            Assert.True(module.has_parameter("list.0"));
+            Assert.True(module.has_parameter("dict.first"));
+            Assert.True(module.has_parameter("dict.second"));
+
+            Assert.True(seq.has_parameter("testnn_testmodule1.test"));
+            Assert.True(seq.has_parameter("testnn_testmodule1.list.0"));
+            Assert.True(seq.has_parameter("testnn_testmodule1.dict.first"));
+            Assert.True(seq.has_parameter("testnn_testmodule1.dict.second"));
+        }
+
         private class TestModule1 : Module
         {
             public TestModule1(Tensor tensor, bool withGrad)

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -444,6 +444,58 @@ namespace TorchSharp
 
             var result = output.ToSingle();
         }
+
+        [Fact]
+        public void EvalSequence2()
+        {
+            var lin1 = Linear(1000, 100);
+            var lin2 = Linear(100, 10);
+            var seq = Sequential(
+                lin1,
+                ReLU(),
+                lin2);
+
+            var x = torch.randn(new long[] { 64, 1000 }, requiresGrad: true);
+            var eval = seq.forward(x);
+        }
+
+        [Fact]
+        public void CreateSequence2()
+        {
+            var lin1 = Linear(1000, 100);
+            var lin2 = Linear(100, 10);
+            var seq = Sequential(
+                lin1,
+                ReLU(),
+                lin2);
+            var parameters = seq.parameters();
+            var parametersCount = parameters.Count();
+            Assert.Equal(4, parametersCount);
+
+            var namedParams = seq.parameters();
+            var namedParamsCount = namedParams.Count();
+            Assert.Equal(4, namedParamsCount);
+        }
+
+        [Fact]
+        public void EvalLossSequence2()
+        {
+            var lin1 = Linear(1000, 100);
+            var lin2 = Linear(100, 10);
+            var seq = Sequential(
+                lin1,
+                ReLU(),
+                lin2);
+
+            var x = torch.randn(new long[] { 64, 1000 });
+            var y = torch.randn(new long[] { 64, 10 });
+
+            var eval = seq.forward(x);
+            var loss = mse_loss(Reduction.Sum);
+            var output = loss(eval, y);
+
+            var result = output.ToSingle();
+        }
         #endregion
 
         #region Loss Functions

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -45,6 +45,21 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestSaveLoadSequential()
+        {
+            if (File.Exists(".model.ts")) File.Delete(".model.ts");
+            var conv = Sequential(Conv2d(100, 10, 5));
+            var params0 = conv.parameters();
+            conv.save(".model.ts");
+            var loaded = Sequential(Conv2d(100, 10, 5));
+            loaded.load(".model.ts");
+            var params1 = loaded.parameters();
+            File.Delete(".model.ts");
+
+            Assert.Equal(params0, params1);
+        }
+
+        [Fact]
         public void TestSaveLoadCustomWithParameters()
         {
             if (File.Exists(".model.ts")) File.Delete(".model.ts");


### PR DESCRIPTION
In pytorch, there are two ways for declare sequential.
```
model = nn.Sequential(
          nn.Conv2d(1,20,5),
          nn.ReLU(),
          nn.Conv2d(20,64,5),
          nn.ReLU()
        )

# Using Sequential with OrderedDict. This is functionally the same as the above code
model = nn.Sequential(OrderedDict([
          ('conv1', nn.Conv2d(1,20,5)),
          ('relu1', nn.ReLU()),
          ('conv2', nn.Conv2d(20,64,5)),
          ('relu2', nn.ReLU())
        ]))
```
But torchsharp only has second way. So I added first way.

```cs
var model = nn.Sequential(
    nn.Conv2d(1, 20, 5),
    nn.ReLU(),
    nn.Conv2d(20, 64, 5),
    nn.ReLU()
);
```

This works same with first python code.

In my commit, when using first way, It will set name by type name of module. And I add test for new sequential(Save and loading, nn in sequential)

I think `using torch.torchvision` in #433 was just mistake :D

Thanks for NiklasGustafsson, he(or she) helped me for solving that my commit has crushing on F#, This is difference between #435.