### PR TITLE
Adding Tensor.TotalCount and Tensor.PeakCount

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,8 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 __API Changes:__
 
-
+Added a Sequential factory method to create Sequential from a list of anonymous submodules.
+Added TotalCount and PeakCount static properties to Tensor, useful for diagnostic purposes.
 
 __Fixed Bugs:__
 

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>95</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -232,6 +232,16 @@ namespace TorchSharp
             Assert.Equal(IntPtr.Zero, t1.Handle);
         }
 
+        [Fact(Skip="Sensitive to parallelism in the xUnit test driver")]
+        public void TestUsings()
+        {
+            var tCount = Tensor.TotalCount;
+
+            using (var t = torch.randn(5)) { }
+
+            Assert.Equal(tCount, Tensor.TotalCount);
+        }
+
         [Fact]
         public void TestDataBool()
         {

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -147,8 +147,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -157,7 +157,7 @@ namespace TorchSharp
 
                 output.backward();
 
-                optimizer.step();
+                using var _ = optimizer.step();
             }
             Assert.True(finalLoss < initialLoss);
         }


### PR DESCRIPTION
The purpose of these static properties is to help diagnosing memory management issues. The TotalCount property can be used to monitor the stability of the number of allocated tensors, which should remain steady across training epochs.