### PR TITLE
Torchvision memory management

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
-### NuGet Version 0.95.2
+### NuGet Version 0.95.3
 
 __API Changes:__
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,18 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 __API Changes:__
 
+The previously unused Tensor.free() method was renamed 'DecoupleFromNativeHandle()' and is meant to be used in native interop scenarios.
+Tensor.Handle will now validate that the internal handle is not 'Zero', and throw an exception when it is. This will catch situations where a disposed tensor is accessed.
+
+__Fixed Bugs:__
+
+There were a number of functions in torchvision, as well as a number of optimizers, that did not properly dispose of temporary and intermediate tensor values, leading to "memory leaks" in the absence of explicit GC.Collect() calls.
+A couple of randint() overloads caused infinite recursion, crashing the process.
+
+### NuGet Version 0.95.2
+
+__API Changes:__
+
 Added a Sequential factory method to create Sequential from a list of anonymous submodules.
 Added TotalCount and PeakCount static properties to Tensor, useful for diagnostic purposes.
 

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>95</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>3</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Native/LibTorchSharp/THSVision.cpp
+++ b/src/Native/LibTorchSharp/THSVision.cpp
@@ -3,78 +3,310 @@
 
 #include <torch/nn/init.h>
 
-// The RGB / HSV conversion code was ported from the Python implmentation found in:
+// The image processing code was ported from the Python implmentation found in:
 //
 // https://github.com/pytorch/vision/blob/main/torchvision/transforms/functional_tensor.py
 
-Tensor THSVision_RGBtoHSV(const Tensor img, Tensor* saturation, Tensor* value)
+void _rgb_to_hsv(at::Tensor& img, at::Tensor& h, at::Tensor& saturation, at::Tensor& value)
 {
-    CATCH(
-        auto RGB = img->unbind(-3);
-        auto r = RGB[0];
-        auto g = RGB[1];
-        auto b = RGB[2];
+    auto RGB = img.unbind(-3);
+    auto r = RGB[0];
+    auto g = RGB[1];
+    auto b = RGB[2];
 
-        auto maxc = std::get<0>(img->max(-3));
-        auto minc = std::get<0>(img->min(-3));
+    auto maxc = std::get<0>(img.max(-3));
+    auto minc = std::get<0>(img.min(-3));
 
-        auto eqc = maxc == minc;
-        auto cr = maxc - minc;
+    auto eqc = maxc == minc;
+    auto cr = maxc - minc;
 
-        auto options = at::TensorOptions()
-            .dtype(maxc.dtype())
-            .device(maxc.device())
-            .requires_grad(maxc.requires_grad());
+    auto options = at::TensorOptions()
+        .dtype(maxc.dtype())
+        .device(maxc.device())
+        .requires_grad(maxc.requires_grad());
 
-        auto ones = torch::ones_like(maxc, options);
+    auto ones = torch::ones_like(maxc, options);
 
-        auto s = cr / torch::where(eqc, ones, maxc);
-        auto cr_divisor = torch::where(eqc, ones, cr);
+    auto s = cr / torch::where(eqc, ones, maxc);
+    auto cr_divisor = torch::where(eqc, ones, cr);
 
-        auto rc = (maxc - r) / cr_divisor;
-        auto gc = (maxc - g) / cr_divisor;
-        auto bc = (maxc - b) / cr_divisor;
+    auto rc = (maxc - r) / cr_divisor;
+    auto gc = (maxc - g) / cr_divisor;
+    auto bc = (maxc - b) / cr_divisor;
 
-        auto hr = (maxc == r) * (bc - gc);
-        auto hg = ((maxc == g) & (maxc != r)) * (2.0 + rc - bc);
-        auto hb = ((maxc != g) & (maxc != r)) * (4.0 + gc - rc);
+    auto hr = (maxc == r) * (bc - gc);
+    auto hg = ((maxc == g) & (maxc != r)) * (2.0 + rc - bc);
+    auto hb = ((maxc != g) & (maxc != r)) * (4.0 + gc - rc);
 
-        auto h = (hr + hg + hb);
-        h = torch::fmod((h / 6.0 + 1.0), 1.0);
+    h = (hr + hg + hb);
+    h = torch::fmod((h / 6.0 + 1.0), 1.0);
 
-        *saturation = ResultTensor(s);
-        *value = ResultTensor(maxc);
-        return ResultTensor(h);
-    );
+    saturation = s;
+    value = maxc;
+}
+
+void _hsv_to_rgb(at::Tensor& h, at::Tensor& s, at::Tensor& v, at::Tensor& img)
+{
+    auto h6 = h * 6.0f;
+    auto i = torch::floor(h6);
+    auto f = h6 - i;
+    i = i.to(at::ScalarType::Int) % 6;
+
+    auto p = torch::clamp((v * (1.0f - s)), 0.0, 1.0);
+    auto q = torch::clamp((v * (1.0 - s * f)), 0.0, 1.0);
+    auto t = torch::clamp((v * (1.0 - s * (1.0 - f))), 0.0, 1.0);
+
+    auto iunsq = i.unsqueeze(-3);
+
+    auto mask = iunsq == torch::arange(6, at::TensorOptions(i.device())).view({ -1, 1, 1 });
+
+    auto a1 = torch::stack({ v, q, p, p, t, v }, -3);
+    auto a2 = torch::stack({ t, v, v, q, p, p }, -3);
+    auto a3 = torch::stack({ p, p, t, v, v, q }, -3);
+    auto a4 = torch::stack({ a1, a2, a3 }, -4);
+
+    img = torch::einsum("...ijk,...xijk ->...xjk", { mask.to(h.dtype()), a4 });
+}
+
+Tensor THSVision_AdjustHue(const Tensor i, const double hue_factor)
+{
+    try {
+        torch_last_err = 0;
+
+        auto img = *i;
+
+        auto orig_dtype = img.scalar_type();
+
+        if (!torch::isFloatingType(orig_dtype)) {
+            img = img.to(c10::ScalarType::Float) / 255.0;
+        }
+
+        at::Tensor h;
+        at::Tensor s;
+        at::Tensor v;
+
+        _rgb_to_hsv(img, h, s, v);
+
+        h = (h + hue_factor) % 1.0;
+
+        at::Tensor img_hue_adj;
+
+        _hsv_to_rgb(h, s, v, img_hue_adj);
+
+        if (!torch::isFloatingType(orig_dtype)) {
+            img_hue_adj = (img_hue_adj * 255.0).to(orig_dtype);
+        }
+
+        return ResultTensor(img_hue_adj);
+    }
+    catch (const c10::Error e) {
+        torch_last_err = strdup(e.what());
+    }
+    catch (const std::runtime_error e) {
+        torch_last_err = strdup(e.what());
+    }
 
     return nullptr;
 }
 
-Tensor THSVision_HSVtoRGB(const Tensor h, const Tensor s, const Tensor v)
+Tensor THSVision_GenerateAffineGrid(Tensor theta, const int64_t w, const int64_t h, const int64_t ow, const int64_t oh)
 {
-    CATCH(
-        auto h6 = (*h) * 6.0f;
-        auto i = torch::floor(h6);
-        auto f = h6 - i;
-        i = i.to(at::ScalarType::Int) % 6;
+    try {
+        torch_last_err = 0;
 
-        auto p = torch::clamp((*v * (1.0f - *s)), 0.0, 1.0);
-        auto q = torch::clamp((*v * (1.0 - *s * f)), 0.0, 1.0);
-        auto t = torch::clamp((*v * (1.0 - *s * (1.0 - f))), 0.0, 1.0);
+        auto d = 0.5;
 
-        auto iunsq = i.unsqueeze(-3);
+        auto thetaOptions = at::TensorOptions().dtype(theta->dtype()).device(theta->device());
+        auto thetaDevice = at::TensorOptions().device(theta->device());
 
-        auto mask = iunsq == torch::arange(6, at::TensorOptions(i.device())).view({ -1, 1, 1 });
+        auto base_grid = torch::empty({ 1, oh, ow, 3 }, thetaOptions);
 
-        auto a1 = torch::stack({ *v, q, p, p, t, *v }, -3);
-        auto a2 = torch::stack({ t, *v, *v, q, p, p }, -3);
-        auto a3 = torch::stack({ p, p, t, *v, *v, q }, -3);
-        auto a4 = torch::stack({ a1, a2, a3 }, -4);
+        auto x_grid = torch::linspace(-ow * 0.5 + d, ow * 0.5 + d - 1, ow, thetaDevice);
+        base_grid.index({ at::indexing::Ellipsis, 0 }).copy_(x_grid);
 
-        auto img = torch::einsum("...ijk,...xijk ->...xjk", { mask.to(h->dtype()), a4 });
+        auto y_grid = torch::linspace(-oh * 0.5 + d, oh * 0.5 + d - 1, oh, thetaDevice).unsqueeze_(-1);
+        base_grid.index({ at::indexing::Ellipsis, 1 }).copy_(y_grid);
+        base_grid.index({ at::indexing::Ellipsis, 2 }).fill_(1);
+
+        auto rescaled_theta = theta->transpose(1, 2) / torch::tensor({ 0.5f * w, 0.5f * h }, thetaOptions);
+        auto output_grid = base_grid.view({ 1, oh * ow, 3 }).bmm(rescaled_theta);
+
+        return ResultTensor(output_grid.view({ 1, oh, ow, 2 }));
+    }
+    catch (const c10::Error e) {
+        torch_last_err = strdup(e.what());
+    }
+    catch (const std::runtime_error e) {
+        torch_last_err = strdup(e.what());
+    }
+
+    return nullptr;
+}
+
+Tensor THSVision_ApplyGridTransform(Tensor i, Tensor g, const int8_t m, const float* fill, const int64_t fill_length)
+{
+    try {
+        torch_last_err = 0;
+
+        auto img = *i;
+        auto grid = *g;
+
+        auto imgOptions = at::TensorOptions().dtype(img.dtype()).device(img.device());
+
+        if (img.size(0) > 1) {
+            grid = grid.expand({ img.size(0), grid.size(1), grid.size(2), grid.size(3) });
+        }
+
+        if (fill != nullptr) {
+            auto dummy = torch::ones({ img.size(0), 1, img.size(2), img.size(3) }, imgOptions);
+            img = torch::cat({ img, dummy }, 1);
+        }
+
+        const torch::nn::functional::GridSampleFuncOptions::mode_t mode =
+            (m == 0)
+            ? (torch::nn::functional::GridSampleFuncOptions::mode_t)torch::kNearest
+            : (torch::nn::functional::GridSampleFuncOptions::mode_t)torch::kBilinear;
+        auto sampleOpts = torch::nn::functional::GridSampleFuncOptions().padding_mode(torch::kZeros).mode(mode);
+
+        img = torch::nn::functional::grid_sample(img, grid, sampleOpts);
+
+
+        if (fill != nullptr) {
+
+            auto COLON = at::indexing::Slice();
+
+            auto mask = img.index({ COLON, at::indexing::Slice(-1, c10::nullopt), COLON,  COLON });
+            img = img.index({ COLON, at::indexing::Slice(c10::nullopt, -1), COLON, COLON });
+            mask = mask.expand_as(img);
+
+            auto fill_img = torch::tensor(at::ArrayRef<float>(fill, fill_length), imgOptions).view({ 1, fill_length, 1, 1 }).expand_as(img);
+
+            if (m == 0) {
+                mask = mask < 0.5;
+                img[mask] = fill_img[mask];
+            }
+            else {
+                img = img * mask + (-mask + 1.0) * fill_img;
+            }
+        }
 
         return ResultTensor(img);
-    );
+    }
+    catch (const c10::Error e) {
+        torch_last_err = strdup(e.what());
+    }
+    catch (const std::runtime_error e) {
+        torch_last_err = strdup(e.what());
+    }
+
+    return nullptr;
+}
+
+Tensor THSVision_ScaleChannel(Tensor ic)
+{
+    try {
+        torch_last_err = 0;
+        auto img_chan = *ic;
+
+        auto hist = img_chan.is_cuda()
+            ? torch::histc(img_chan.to(at::ScalarType::Float), 256, 0, 255)
+            : torch::bincount(img_chan.view(-1), {}, 256);
+
+        auto nonzero_hist = hist.index({ hist != 0 });
+
+        auto step = torch::div(nonzero_hist.index({ at::indexing::Slice(c10::nullopt, -1) }).sum(), 255, "floor");
+        auto count = step.count_nonzero();
+
+        if (count.item<int>() == 0)
+        {
+            return ResultTensor(img_chan);
+        }
+
+        auto lut = torch::div(torch::cumsum(hist, 0) + torch::div(step, 2, "floor"), step, "floor");
+
+        auto padOptions = torch::nn::functional::PadFuncOptions({ 1, 0 });
+        lut = torch::nn::functional::pad(lut, padOptions).index({ at::indexing::Slice(c10::nullopt, -1) }).clamp(0, 255);
+
+        return ResultTensor(lut.index({ img_chan.to(c10::ScalarType::Long) }).to(c10::ScalarType::Byte));
+    }
+    catch (const c10::Error e) {
+        torch_last_err = strdup(e.what());
+    }
+    catch (const std::runtime_error e) {
+        torch_last_err = strdup(e.what());
+    }
+
+    return nullptr;
+}
+
+void THSVision_ComputeOutputSize(const float* matrix, const int64_t matrix_length, const int64_t w, const int64_t h, int32_t* first, int32_t* second)
+{
+    try {
+        torch_last_err = 0;
+
+        auto pts = torch::tensor({ -0.5f * w, -0.5f * h, 1.0f, -0.5f * w, 0.5f * h, 1.0f, 0.5f * w, 0.5f * h, 1.0f, 0.5f * w, -0.5f * h, 1.0f }).reshape({ 4,3 });
+        auto theta = torch::tensor(c10::ArrayRef<float>(matrix, matrix_length), c10::TensorOptions().dtype(c10::ScalarType::Float)).reshape({ 1, 2, 3 });
+        auto new_pts = pts.view({ 1, 4, 3 }).bmm(theta.transpose(1, 2)).view({ 4, 2 });
+
+        auto min_vals = std::get<0>(new_pts.min(0));
+        auto max_vals = std::get<0>(new_pts.max(0));
+
+        float tol = 1e-4;
+        auto cmax = torch::ceil((max_vals / tol).trunc_() * tol);
+        auto cmin = torch::floor((min_vals / tol).trunc_() * tol);
+
+        auto size = cmax - cmin;
+
+        *first = size[0].item<int>();
+        *second = size[1].item<int>();
+    }
+    catch (const c10::Error e) {
+        torch_last_err = strdup(e.what());
+    }
+    catch (const std::runtime_error e) {
+        torch_last_err = strdup(e.what());
+    }
+}
+
+Tensor THSVision_PerspectiveGrid(const float* c, const int64_t c_length, const int64_t ow, const int64_t oh, const int8_t scalar_type, const int device_type, const int device_index)
+{
+    try {
+        torch_last_err = 0;
+
+        auto fullOptions = at::TensorOptions()
+            .dtype(at::ScalarType(scalar_type))
+            .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index));
+        auto devOptions = at::TensorOptions()
+            .device(c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index));
+
+        auto coeffs = c10::ArrayRef<float>(c, c_length);
+
+        auto theta1 = torch::tensor({ coeffs[0], coeffs[1], coeffs[2], coeffs[3], coeffs[4], coeffs[5] }, fullOptions).view({ 1, 2, 3 });
+        auto theta2 = torch::tensor({ coeffs[6], coeffs[7], 1.0f, coeffs[6], coeffs[7], 1.0f }, fullOptions).view({ 1, 2, 3 });
+
+        auto d = 0.5f;
+        auto base_grid = torch::empty({ 1, oh, ow, 3 }, fullOptions);
+        auto x_grid = torch::linspace(d, ow * 1.0 + d - 1.0, ow, devOptions);
+        base_grid.index({ at::indexing::Ellipsis, 0 }).copy_(x_grid);
+
+        auto y_grid = torch::linspace(d, oh * 1.0 + d - 1.0, oh, devOptions).unsqueeze_(-1);
+        base_grid.index({ at::indexing::Ellipsis, 1 }).copy_(y_grid);
+        base_grid.index({ at::indexing::Ellipsis, 2 }).fill_(1);
+
+        auto rescaled_theta1 = theta1.transpose(1, 2) / torch::tensor({ 0.5f * ow, 0.5f * oh }, fullOptions);
+
+        auto output_grid1 = base_grid.view({ 1, oh * ow, 3 }).bmm(rescaled_theta1);
+        auto output_grid2 = base_grid.view({ 1, oh * ow, 3 }).bmm(theta2.transpose(1, 2));
+        auto output_grid = output_grid1 / output_grid2 - 1.0f;
+
+        return ResultTensor(output_grid.view({ 1, oh, ow, 2 }));
+    }
+    catch (const c10::Error e) {
+        torch_last_err = strdup(e.what());
+    }
+    catch (const std::runtime_error e) {
+        torch_last_err = strdup(e.what());
+    }
 
     return nullptr;
 }

--- a/src/Native/LibTorchSharp/THSVision.h
+++ b/src/Native/LibTorchSharp/THSVision.h
@@ -9,5 +9,13 @@
 
 // API
 
-EXPORT_API(Tensor) THSVision_RGBtoHSV(const Tensor img, Tensor* s, Tensor *v);
-EXPORT_API(Tensor) THSVision_HSVtoRGB(const Tensor h, const Tensor s, const Tensor v);
+EXPORT_API(Tensor) THSVision_AdjustHue(const Tensor img, const double hue_factor);
+
+EXPORT_API(Tensor) THSVision_GenerateAffineGrid(Tensor theta, const int64_t w, const int64_t h, const int64_t ow, const int64_t oh);
+EXPORT_API(Tensor) THSVision_ApplyGridTransform(Tensor i, Tensor g, const int8_t m, const float* fill, const int64_t fill_length);
+
+EXPORT_API(Tensor) THSVision_PerspectiveGrid(const float* coeffs, const int64_t coeffs_length, const int64_t ow, const int64_t oh, const int8_t scalar_type, const int device_type, const int device_index);
+
+EXPORT_API(Tensor) THSVision_ScaleChannel(Tensor ic);
+
+EXPORT_API(void) THSVision_ComputeOutputSize(const float* matrix, const int64_t matrix_length, const int64_t w, const int64_t h);

--- a/src/TorchSharp/LinearAlgebra.cs
+++ b/src/TorchSharp/LinearAlgebra.cs
@@ -510,7 +510,7 @@ namespace TorchSharp
             /// <returns></returns>
             public static Tensor solve(Tensor input, Tensor other)
             {
-                var res = THSLinalg_solve(input.Handle, other.handle);
+                var res = THSLinalg_solve(input.Handle, other.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);

--- a/src/TorchSharp/NN/Functional.cs
+++ b/src/TorchSharp/NN/Functional.cs
@@ -47,7 +47,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pstrides = strides, ppadding = paddingArray, pdilation = dilationArray) {
                             var res =
-                                THSTensor_conv1d(input.handle, weight.Handle, biasHandle,
+                                THSTensor_conv1d(input.Handle, weight.Handle, biasHandle,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, paddingArray.Length,
                                     (IntPtr)pdilation, dilationArray.Length,
@@ -90,7 +90,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pstrides = strides, ppadding = padding, pdilation = dilation) {
                             var res =
-                                THSTensor_conv2d(input.handle, weight.Handle, biasHandle,
+                                THSTensor_conv2d(input.Handle, weight.Handle, biasHandle,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, padding.Length,
                                     (IntPtr)pdilation, dilation.Length,
@@ -132,7 +132,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pstrides = strides, ppadding = padding, pdilation = dilation) {
                             var res =
-                                THSTensor_conv3d(input.handle, weight.Handle, biasHandle,
+                                THSTensor_conv3d(input.Handle, weight.Handle, biasHandle,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, padding.Length,
                                     (IntPtr)pdilation, dilation.Length,
@@ -178,7 +178,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pstrides = strides, ppadding = paddings, poutputPadding = outputPaddings, pdilation = dilations) {
                             var res =
-                                THSTensor_conv_transpose1d(input.handle, weight.Handle, biasHandle,
+                                THSTensor_conv_transpose1d(input.Handle, weight.Handle, biasHandle,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, paddings.Length,
                                     (IntPtr)poutputPadding, outputPaddings.Length,
@@ -225,7 +225,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pstrides = strides, ppadding = padding, poutputPadding = outputPadding, pdilation = dilation) {
                             var res =
-                                THSTensor_conv_transpose2d(input.handle, weight.Handle, biasHandle,
+                                THSTensor_conv_transpose2d(input.Handle, weight.Handle, biasHandle,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, padding.Length,
                                     (IntPtr)poutputPadding, outputPadding.Length,
@@ -272,7 +272,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pstrides = strides, ppadding = padding, poutputPadding = outputPadding, pdilation = dilation) {
                             var res =
-                                THSTensor_conv_transpose3d(input.handle, weight.Handle, biasHandle,
+                                THSTensor_conv_transpose3d(input.Handle, weight.Handle, biasHandle,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, padding.Length,
                                     (IntPtr)poutputPadding, outputPadding.Length,
@@ -312,7 +312,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings, pdilation = dilations) {
                             var res =
-                                THSTensor_max_pool1d(input.handle,
+                                THSTensor_max_pool1d(input.Handle,
                                     (IntPtr)pkernelSize, kernelSizes.Length,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, paddings.Length,
@@ -354,7 +354,7 @@ namespace TorchSharp
                     using (var pa = new PinnedArray<IntPtr>()) {
                         unsafe {
                             fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings, pdilation = dilations) {
-                                THSTensor_max_pool1d_with_indices(input.handle,
+                                THSTensor_max_pool1d_with_indices(input.Handle,
                                     pa.CreateArray,
                                     (IntPtr)pkernelSize, kernelSizes.Length,
                                     (IntPtr)pstrides, strides.Length,
@@ -396,7 +396,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pkernelSize = kernelSize, pstrides = strides, ppadding = padding, pdilation = dilation) {
                             var res =
-                                THSTensor_max_pool2d(input.handle,
+                                THSTensor_max_pool2d(input.Handle,
                                     (IntPtr)pkernelSize, kernelSize.Length,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, padding.Length,
@@ -437,7 +437,7 @@ namespace TorchSharp
                     using (var pa = new PinnedArray<IntPtr>()) {
                         unsafe {
                             fixed (long* pkernelSize = kernelSize, pstrides = strides, ppadding = padding, pdilation = dilation) {
-                                THSTensor_max_pool2d_with_indices(input.handle,
+                                THSTensor_max_pool2d_with_indices(input.Handle,
                                     pa.CreateArray,
                                     (IntPtr)pkernelSize, kernelSize.Length,
                                     (IntPtr)pstrides, strides.Length,
@@ -479,7 +479,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pkernelSize = kernelSize, pstrides = strides, ppadding = padding, pdilation = dilation) {
                             var res =
-                                THSTensor_max_pool3d(input.handle,
+                                THSTensor_max_pool3d(input.Handle,
                                     (IntPtr)pkernelSize, kernelSize.Length,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, padding.Length,
@@ -520,7 +520,7 @@ namespace TorchSharp
                     using (var pa = new PinnedArray<IntPtr>()) {
                         unsafe {
                             fixed (long* pkernelSize = kernelSize, pstrides = strides, ppadding = padding, pdilation = dilation) {
-                                THSTensor_max_pool3d_with_indices(input.handle,
+                                THSTensor_max_pool3d_with_indices(input.Handle,
                                     pa.CreateArray,
                                     (IntPtr)pkernelSize, kernelSize.Length,
                                     (IntPtr)pstrides, strides.Length,
@@ -549,7 +549,7 @@ namespace TorchSharp
                 {
                     unsafe {
                         fixed (long* poutputSize = outputSize) {
-                            var res = THSTensor_maxunpool2d(input.handle, indices.Handle,
+                            var res = THSTensor_maxunpool2d(input.Handle, indices.Handle,
                                 (IntPtr)poutputSize, outputSize.Length);
                             if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                             return new Tensor(res);
@@ -574,7 +574,7 @@ namespace TorchSharp
                 {
                     unsafe {
                         fixed (long* poutputSize = outputSize, pstrides = strides, ppadding = padding) {
-                            var res = THSTensor_maxunpool3d(input.handle, indices.Handle,
+                            var res = THSTensor_maxunpool3d(input.Handle, indices.Handle,
                                 (IntPtr)poutputSize, outputSize.Length,
                                 (IntPtr)pstrides, strides.Length,
                                 (IntPtr)ppadding, padding.Length);
@@ -611,7 +611,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings) {
                             var res =
-                                THSTensor_avg_pool1d(input.handle,
+                                THSTensor_avg_pool1d(input.Handle,
                                     (IntPtr)pkernelSize, kernelSizes.Length,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, paddings.Length,
@@ -652,7 +652,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings) {
                             var res =
-                                THSTensor_avg_pool2d(input.handle,
+                                THSTensor_avg_pool2d(input.Handle,
                                     (IntPtr)pkernelSize, kernelSizes.Length,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, paddings.Length,
@@ -693,7 +693,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings) {
                             var res =
-                                THSTensor_avg_pool3d(input.handle,
+                                THSTensor_avg_pool3d(input.Handle,
                                     (IntPtr)pkernelSize, kernelSizes.Length,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, paddings.Length,
@@ -727,7 +727,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings) {
                             var res =
-                                THSTensor_avg_pool2d_backward(input.handle, originalInput.Handle,
+                                THSTensor_avg_pool2d_backward(input.Handle, originalInput.Handle,
                                     (IntPtr)pkernelSize, kernelSizes.Length,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, paddings.Length,
@@ -762,7 +762,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings) {
                             var res =
-                                THSTensor_avg_pool3d_backward(input.handle, originalInput.Handle,
+                                THSTensor_avg_pool3d_backward(input.Handle, originalInput.Handle,
                                     (IntPtr)pkernelSize, kernelSizes.Length,
                                     (IntPtr)pstrides, strides.Length,
                                     (IntPtr)ppadding, paddings.Length,
@@ -791,7 +791,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* poutputSize = outputSizes) {
                             var res =
-                                THSTensor_adaptive_avg_pool1d(input.handle, (IntPtr)poutputSize, outputSizes.Length);
+                                THSTensor_adaptive_avg_pool1d(input.Handle, (IntPtr)poutputSize, outputSizes.Length);
                             if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                             return new Tensor(res);
                         }
@@ -813,7 +813,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* poutputSize = outputSizes) {
                             var res =
-                                THSTensor_adaptive_avg_pool2d(input.handle, (IntPtr)poutputSize, outputSizes.Length);
+                                THSTensor_adaptive_avg_pool2d(input.Handle, (IntPtr)poutputSize, outputSizes.Length);
                             if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                             return new Tensor(res);
                         }
@@ -834,7 +834,7 @@ namespace TorchSharp
                     unsafe {
                         fixed (long* poutputSize = outputSizes) {
                             var res =
-                                THSTensor_adaptive_avg_pool3d(input.handle, (IntPtr)poutputSize, outputSizes.Length);
+                                THSTensor_adaptive_avg_pool3d(input.Handle, (IntPtr)poutputSize, outputSizes.Length);
                             if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                             return new Tensor(res);
                         }
@@ -873,7 +873,7 @@ namespace TorchSharp
                         fixed (long* poutputSizes = outputSizes) {
                             fixed (double* pscaleFactors = scaleFactors) {
                                 var res =
-                                    THSTensor_upsample_nearest1d(input.handle,
+                                    THSTensor_upsample_nearest1d(input.Handle,
                                         (IntPtr)poutputSizes, outputSizesLength,
                                         (IntPtr)pscaleFactors, scaleFactorsLength);
                                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -900,7 +900,7 @@ namespace TorchSharp
                         fixed (long* poutputSizes = outputSizes, pinputSizes = inputSizes) {
                             fixed (double* pscaleFactors = scaleFactors) {
                                 var res =
-                                    THSTensor_upsample_nearest1d_backward(grad_output.handle,
+                                    THSTensor_upsample_nearest1d_backward(grad_output.Handle,
                                         (IntPtr)poutputSizes, outputSizesLength,
                                         (IntPtr)pinputSizes, inputSizes.Length,
                                         (IntPtr)pscaleFactors, scaleFactorsLength);
@@ -931,7 +931,7 @@ namespace TorchSharp
                         fixed (long* poutputSizes = outputSizes) {
                             fixed (double* pscaleFactors = scaleFactors) {
                                 var res =
-                                    THSTensor_upsample_nearest2d(input.handle,
+                                    THSTensor_upsample_nearest2d(input.Handle,
                                         (IntPtr)poutputSizes, outputSizesLength,
                                         (IntPtr)pscaleFactors, scaleFactorsLength);
                                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -955,7 +955,7 @@ namespace TorchSharp
                         fixed (long* poutputSizes = outputSizes, pinputSizes = inputSizes) {
                             fixed (double* pscaleFactors = scaleFactors) {
                                 var res =
-                                    THSTensor_upsample_nearest2d_backward(grad_output.handle,
+                                    THSTensor_upsample_nearest2d_backward(grad_output.Handle,
                                         (IntPtr)poutputSizes, outputSizesLength,
                                         (IntPtr)pinputSizes, inputSizes.Length,
                                         (IntPtr)pscaleFactors, scaleFactorsLength);
@@ -980,7 +980,7 @@ namespace TorchSharp
                         fixed (long* poutputSizes = outputSizes, pinputSizes = inputSizes) {
                             fixed (double* pscaleFactors = scaleFactors) {
                                 var res =
-                                    THSTensor_upsample_nearest3d_backward(grad_output.handle,
+                                    THSTensor_upsample_nearest3d_backward(grad_output.Handle,
                                         (IntPtr)poutputSizes, outputSizesLength,
                                         (IntPtr)pinputSizes, inputSizes.Length,
                                         (IntPtr)pscaleFactors, scaleFactorsLength);
@@ -1011,7 +1011,7 @@ namespace TorchSharp
                         fixed (long* poutputSizes = outputSizes) {
                             fixed (double* pscaleFactors = scaleFactors) {
                                 var res =
-                                    THSTensor_upsample_nearest3d(input.handle,
+                                    THSTensor_upsample_nearest3d(input.Handle,
                                         (IntPtr)poutputSizes, outputSizesLength,
                                         (IntPtr)pscaleFactors, scaleFactorsLength);
                                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -78,8 +78,6 @@ namespace TorchSharp
                 {
                     this.handle = new HType(handle, ownsHandle);
                     this.boxedModule = boxedHandle.HasValue ? new BoxedModule(boxedHandle.Value) : null;
-                    //Debug.Assert (!this.handle.IsInvalid);
-                    //Debug.Assert (!this.boxedHandle.IsInvalid);
                 }
 
                 ~Module()

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -590,17 +590,12 @@ namespace TorchSharp
                         var input = new Tensor(t);
                         var output = forward(input);
 
-                        // handles must live on - we don't own them
-                        GC.SuppressFinalize(input);
+                        // handles must live on - we don't own them, but
+                        // the managed objects should go away.
 
-                        // TODO: Figure out what do do here:
-                        //
-                        // Suppressing the output finalization leads to a memory leak, since the
-                        // native handle is never destroyed. Ideally, we could decrement the ref
-                        // count and then suppress finalization.
-                        //GC.SuppressFinalize(output);
+                        input.DecoupleFromNativeHandle();
 
-                        return output.Handle;
+                        return output.DecoupleFromNativeHandle();
                     };
 
                     var res = THSNN_custom_module(name, forwardNative, out var boxedHandle);

--- a/src/TorchSharp/NN/Optimizer.cs
+++ b/src/TorchSharp/NN/Optimizer.cs
@@ -104,9 +104,7 @@ namespace TorchSharp
                     IntPtr res = (closure == null) ?
                         THSNN_Optimizer_step(handle, null) :
                         THSNN_Optimizer_step(handle, () => {
-                            var res = closure();
-                            GC.SuppressFinalize(res);
-                            return res.Handle;
+                            return closure().DecoupleFromNativeHandle();
                         });
 
                     if (res == IntPtr.Zero)

--- a/src/TorchSharp/NN/Optimizer.cs
+++ b/src/TorchSharp/NN/Optimizer.cs
@@ -106,7 +106,7 @@ namespace TorchSharp
                         THSNN_Optimizer_step(handle, () => {
                             var res = closure();
                             GC.SuppressFinalize(res);
-                            return res.handle;
+                            return res.Handle;
                         });
 
                     if (res == IntPtr.Zero)

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -665,6 +665,9 @@ namespace TorchSharp
                 dtype = get_default_dtype();
             }
 
+            ValidateIntegerRange(low, dtype.Value, nameof(low));
+            ValidateIntegerRange(high - 1, dtype.Value, nameof(high));
+
             var genHandle = (generator is null) ? IntPtr.Zero : generator.Handle; 
 
             if (dtype == ScalarType.ComplexFloat32) {
@@ -732,7 +735,7 @@ namespace TorchSharp
         ///          Once implicit conversion support is broadly available, some of these overloads can be removed.</remarks>
         static public Tensor randint(long low, long high, long[] size, torch.ScalarType? dtype = null, torch.Device device = null, bool requiresGrad = false, torch.Generator generator = null)
         {
-            return randint(low, high, size, dtype, device, requiresGrad, generator);
+            return randint(low, high, new Size(size), dtype, device, requiresGrad, generator);
         }
 
         /// <summary>
@@ -749,7 +752,7 @@ namespace TorchSharp
         ///          Once implicit conversion support is broadly available, some of these overloads can be removed.</remarks>
         static public Tensor randint(int low, int high, int[] size, torch.ScalarType? dtype = null, torch.Device device = null, bool requiresGrad = false, torch.Generator generator = null)
         {
-            return randint(low, high, size, dtype, device, requiresGrad, generator);
+            return randint(low, high, new Size(size), dtype, device, requiresGrad, generator);
         }
 
         /// <summary>
@@ -763,7 +766,7 @@ namespace TorchSharp
         /// <param name="generator">An optional random number genertor object.</param>
         static public Tensor randint(int high, int[] size, torch.ScalarType? dtype = null, torch.Device device = null, bool requiresGrad = false, torch.Generator generator = null)
         {
-            return randint(0, high, size, dtype, device, requiresGrad, generator);
+            return randint(0, high, new Size(size), dtype, device, requiresGrad, generator);
         }
 
         /// <summary>
@@ -2264,6 +2267,30 @@ namespace TorchSharp
             }
             if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
             return new Tensor(handle);
+        }
+
+        private static void ValidateIntegerRange(long value, ScalarType dtype, string argument)
+        {
+            switch (dtype) {
+            case ScalarType.Byte:
+                if (value < byte.MinValue || value > byte.MaxValue)
+                    throw new ArgumentOutOfRangeException(argument, value, $"The value is outside the range of {dtype}");
+                break;
+            case ScalarType.Int8:
+                if (value < sbyte.MinValue || value > sbyte.MaxValue)
+                    throw new ArgumentOutOfRangeException(argument, value, $"The value is outside the range of {dtype}");
+                break;
+            case ScalarType.Int16:
+                if (value < short.MinValue || value > short.MaxValue)
+                    throw new ArgumentOutOfRangeException(argument, value, $"The value is outside the range of {dtype}");
+                break;
+            case ScalarType.Int32:
+                if (value < int.MinValue || value > int.MaxValue)
+                    throw new ArgumentOutOfRangeException(argument, value, $"The value is outside the range of {dtype}");
+                break;
+            default:
+                break;
+            }
         }
 
         [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
+++ b/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
@@ -24,7 +24,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cholesky(bool upper = false)
             {
-                var res = THSTensor_cholesky(handle, upper);
+                var res = THSTensor_cholesky(Handle, upper);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -39,7 +39,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cholesky_inverse(bool upper = false)
             {
-                var res = THSTensor_cholesky_inverse(handle, upper);
+                var res = THSTensor_cholesky_inverse(Handle, upper);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -55,7 +55,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cholesky_solve(Tensor input2, bool upper = false)
             {
-                var res = THSTensor_cholesky_solve(handle, input2.Handle, upper);
+                var res = THSTensor_cholesky_solve(Handle, input2.Handle, upper);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -69,7 +69,7 @@ namespace TorchSharp
             /// </summary>
             public Tensor cross(Scalar other, long dim)
             {
-                var res = THSTensor_cross(handle, other.Handle, dim);
+                var res = THSTensor_cross(Handle, other.Handle, dim);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -100,7 +100,7 @@ namespace TorchSharp
             /// </remarks>
             public Tensor matmul(Tensor target)
             {
-                var res = THSTensor_matmul(handle, target.Handle);
+                var res = THSTensor_matmul(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -115,7 +115,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor mm(Tensor target)
             {
-                var res = THSTensor_mm(handle, target.Handle);
+                var res = THSTensor_mm(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -130,7 +130,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor mv(Tensor target)
             {
-                var res = THSTensor_mv(handle, target.Handle);
+                var res = THSTensor_mv(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -143,7 +143,7 @@ namespace TorchSharp
             /// </summary>
             public Tensor matrix_exp()
             {
-                var res = THSTensor_matrix_exp(handle);
+                var res = THSTensor_matrix_exp(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -159,7 +159,7 @@ namespace TorchSharp
             /// <remarks>Input tensor must be of shape (*, m, m) where * is zero or more batch dimensions.</remarks>
             public Tensor matrix_power(int n)
             {
-                var res = THSLinalg_matrix_power(handle, n);
+                var res = THSLinalg_matrix_power(Handle, n);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -179,7 +179,7 @@ namespace TorchSharp
             public Tensor vdot(Tensor target)
             {
                 if (shape.Length != 1 || target.shape.Length != 1 || shape[0] != target.shape[0]) throw new InvalidOperationException("vdot arguments must have the same shape.");
-                var res = THSTensor_vdot(handle, target.Handle);
+                var res = THSTensor_vdot(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }

--- a/src/TorchSharp/Tensor/Tensor.Math.cs
+++ b/src/TorchSharp/Tensor/Tensor.Math.cs
@@ -31,7 +31,7 @@ namespace TorchSharp
             /// </summary>
             public Tensor abs()
             {
-                var res = THSTensor_abs(handle);
+                var res = THSTensor_abs(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -50,7 +50,7 @@ namespace TorchSharp
             /// </summary>
             public Tensor abs_()
             {
-                var res = THSTensor_abs_(handle);
+                var res = THSTensor_abs_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -82,7 +82,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor add(Tensor target, Scalar alpha)
             {
-                var res = THSTensor_add(handle, target.Handle, alpha.Handle);
+                var res = THSTensor_add(Handle, target.Handle, alpha.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -109,7 +109,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor add(Scalar scalar, Scalar alpha)
             {
-                var res = THSTensor_add_scalar(handle, scalar.Handle, alpha.Handle);
+                var res = THSTensor_add_scalar(Handle, scalar.Handle, alpha.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -136,7 +136,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor add_(Tensor target, Scalar alpha)
             {
-                var res = THSTensor_add_(handle, target.Handle, alpha.Handle);
+                var res = THSTensor_add_(Handle, target.Handle, alpha.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -163,7 +163,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor add_(Scalar scalar, Scalar alpha)
             {
-                var res = THSTensor_add_scalar_(handle, scalar.Handle, alpha.Handle);
+                var res = THSTensor_add_scalar_(Handle, scalar.Handle, alpha.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -184,7 +184,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addbmm(Tensor batch1, Tensor batch2, float beta = 1, float alpha = 1)
             {
-                var res = THSTensor_addbmm(handle, batch1.Handle, batch2.Handle, beta, alpha);
+                var res = THSTensor_addbmm(Handle, batch1.Handle, batch2.Handle, beta, alpha);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -205,7 +205,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addbmm_(Tensor batch1, Tensor batch2, float beta = 1, float alpha = 1)
             {
-                var res = THSTensor_addbmm_(handle, batch1.Handle, batch2.Handle, beta, alpha);
+                var res = THSTensor_addbmm_(Handle, batch1.Handle, batch2.Handle, beta, alpha);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -223,7 +223,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addcdiv(Tensor tensor1, Tensor tensor2, Scalar value)
             {
-                var res = THSTensor_addcdiv(handle, tensor1.Handle, tensor2.Handle, value.Handle);
+                var res = THSTensor_addcdiv(Handle, tensor1.Handle, tensor2.Handle, value.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -241,7 +241,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addcdiv_(Tensor tensor1, Tensor tensor2, Scalar value)
             {
-                var res = THSTensor_addcdiv_(handle, tensor1.Handle, tensor2.Handle, value.Handle);
+                var res = THSTensor_addcdiv_(Handle, tensor1.Handle, tensor2.Handle, value.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -259,7 +259,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addcmul(Tensor tensor1, Tensor tensor2, Scalar value)
             {
-                var res = THSTensor_addcmul(handle, tensor1.Handle, tensor2.Handle, value.Handle);
+                var res = THSTensor_addcmul(Handle, tensor1.Handle, tensor2.Handle, value.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -277,7 +277,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addcmul_(Tensor tensor1, Tensor tensor2, Scalar value)
             {
-                var res = THSTensor_addcmul_(handle, tensor1.Handle, tensor2.Handle, value.Handle);
+                var res = THSTensor_addcmul_(Handle, tensor1.Handle, tensor2.Handle, value.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -297,7 +297,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addmm(Tensor mat1, Tensor mat2, float beta = 1, float alpha = 1)
             {
-                var res = THSTensor_addmm(handle, mat1.Handle, mat2.Handle, beta, alpha);
+                var res = THSTensor_addmm(Handle, mat1.Handle, mat2.Handle, beta, alpha);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -316,7 +316,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addmm_(Tensor mat1, Tensor mat2, float beta = 1, float alpha = 1)
             {
-                var res = THSTensor_addmm_(handle, mat1.Handle, mat2.Handle, beta, alpha);
+                var res = THSTensor_addmm_(Handle, mat1.Handle, mat2.Handle, beta, alpha);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -335,7 +335,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addmv(Tensor mat, Tensor vec, float beta = 1.0f, float alpha = 1.0f)
             {
-                var res = THSTensor_addmv(handle, mat.Handle, vec.Handle, beta, alpha);
+                var res = THSTensor_addmv(Handle, mat.Handle, vec.Handle, beta, alpha);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -354,7 +354,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addmv_(Tensor mat, Tensor vec, float beta = 1.0f, float alpha = 1.0f)
             {
-                var res = THSTensor_addmv_(handle, mat.Handle, vec.Handle, beta, alpha);
+                var res = THSTensor_addmv_(Handle, mat.Handle, vec.Handle, beta, alpha);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -373,7 +373,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addr(Tensor vec1, Tensor vec2, float beta = 1.0f, float alpha = 1.0f)
             {
-                var res = THSTensor_addr(handle, vec1.Handle, vec2.Handle, beta, alpha);
+                var res = THSTensor_addr(Handle, vec1.Handle, vec2.Handle, beta, alpha);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -394,7 +394,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor addr_(Tensor vec1, Tensor vec2, float beta = 1.0f, float alpha = 1.0f)
             {
-                var res = THSTensor_addr_(handle, vec1.Handle, vec2.Handle, beta, alpha);
+                var res = THSTensor_addr_(Handle, vec1.Handle, vec2.Handle, beta, alpha);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -410,7 +410,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor bitwise_and(Tensor other)
             {
-                var res = THSTensor_bitwise_and(handle, other.Handle);
+                var res = THSTensor_bitwise_and(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -425,7 +425,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor bitwise_and_(Tensor other)
             {
-                var res = THSTensor_bitwise_and_(handle, other.Handle);
+                var res = THSTensor_bitwise_and_(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -439,7 +439,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor bitwise_not()
             {
-                var res = THSTensor_bitwise_not(handle);
+                var res = THSTensor_bitwise_not(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -453,7 +453,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor bitwise_not_()
             {
-                var res = THSTensor_bitwise_not_(handle);
+                var res = THSTensor_bitwise_not_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -468,7 +468,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor bitwise_or(Tensor other)
             {
-                var res = THSTensor_bitwise_or(handle, other.Handle);
+                var res = THSTensor_bitwise_or(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -483,7 +483,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor bitwise_or_(Tensor other)
             {
-                var res = THSTensor_bitwise_or_(handle, other.Handle);
+                var res = THSTensor_bitwise_or_(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -498,7 +498,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor bitwise_xor(Tensor other)
             {
-                var res = THSTensor_bitwise_xor(handle, other.Handle);
+                var res = THSTensor_bitwise_xor(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -513,7 +513,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor bitwise_xor_(Tensor other)
             {
-                var res = THSTensor_bitwise_xor_(handle, other.Handle);
+                var res = THSTensor_bitwise_xor_(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -527,7 +527,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor ceil()
             {
-                var res = THSTensor_ceil(handle);
+                var res = THSTensor_ceil(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -542,7 +542,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor ceil_()
             {
-                var res = THSTensor_ceil_(handle);
+                var res = THSTensor_ceil_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -561,7 +561,7 @@ namespace TorchSharp
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_cummax(handle, pa.CreateArray, dimension);
+                    THSTensor_cummax(Handle, pa.CreateArray, dimension);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -582,7 +582,7 @@ namespace TorchSharp
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_cummin(handle, pa.CreateArray, dimension);
+                    THSTensor_cummin(Handle, pa.CreateArray, dimension);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -602,7 +602,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cumsum(long dimension, ScalarType? type = null)
             {
-                var res = THSTensor_cumsum(handle, dimension, type.HasValue, (sbyte)type.GetValueOrDefault());
+                var res = THSTensor_cumsum(Handle, dimension, type.HasValue, (sbyte)type.GetValueOrDefault());
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -619,7 +619,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cumprod(long dimension, ScalarType? type = null)
             {
-                var res = THSTensor_cumprod(handle, dimension, type.HasValue, (sbyte)type.GetValueOrDefault());
+                var res = THSTensor_cumprod(Handle, dimension, type.HasValue, (sbyte)type.GetValueOrDefault());
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -635,7 +635,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor div(Tensor target, RoundingMode rounding_mode = RoundingMode.None)
             {
-                var res = THSTensor_div(handle, target.Handle, rounding_mode == RoundingMode.trunc ? "trunc" : rounding_mode == RoundingMode.floor ? "floor" : null);
+                var res = THSTensor_div(Handle, target.Handle, rounding_mode == RoundingMode.trunc ? "trunc" : rounding_mode == RoundingMode.floor ? "floor" : null);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -659,7 +659,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor div(Scalar target, RoundingMode rounding_mode = RoundingMode.None)
             {
-                var res = THSTensor_div_scalar(handle, target.Handle, rounding_mode == RoundingMode.trunc ? "trunc" : rounding_mode == RoundingMode.floor ? "floor" : null);
+                var res = THSTensor_div_scalar(Handle, target.Handle, rounding_mode == RoundingMode.trunc ? "trunc" : rounding_mode == RoundingMode.floor ? "floor" : null);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -683,7 +683,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor div_(Tensor target, RoundingMode rounding_mode = RoundingMode.None)
             {
-                var res = THSTensor_div_(handle, target.Handle, rounding_mode == RoundingMode.trunc ? "trunc" : rounding_mode == RoundingMode.floor ? "floor" : null);
+                var res = THSTensor_div_(Handle, target.Handle, rounding_mode == RoundingMode.trunc ? "trunc" : rounding_mode == RoundingMode.floor ? "floor" : null);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -707,7 +707,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor div_(Scalar target, RoundingMode rounding_mode = RoundingMode.None)
             {
-                var res = THSTensor_div_scalar_(handle, target.Handle, rounding_mode == RoundingMode.trunc ? "trunc" : rounding_mode == RoundingMode.floor ? "floor" : null);
+                var res = THSTensor_div_scalar_(Handle, target.Handle, rounding_mode == RoundingMode.trunc ? "trunc" : rounding_mode == RoundingMode.floor ? "floor" : null);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -728,7 +728,7 @@ namespace TorchSharp
             /// </summary>
             public Tensor exp()
             {
-                var res = THSTensor_exp(handle);
+                var res = THSTensor_exp(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -741,7 +741,7 @@ namespace TorchSharp
             /// </summary>
             public Tensor exp_()
             {
-                var res = THSTensor_exp_(handle);
+                var res = THSTensor_exp_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -755,7 +755,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor exp2()
             {
-                var res = THSTensor_exp2(handle);
+                var res = THSTensor_exp2(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -769,7 +769,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor expm1()
             {
-                var res = THSTensor_expm1(handle);
+                var res = THSTensor_expm1(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -783,7 +783,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor expm1_()
             {
-                var res = THSTensor_expm1_(handle);
+                var res = THSTensor_expm1_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -799,7 +799,7 @@ namespace TorchSharp
             /// <remarks> If neither input is complex returns a torch.float64 tensor, and if one or more inputs is complex returns a torch.complex128 tensor.</remarks>
             public Tensor float_power(Tensor target)
             {
-                var res = THSTensor_float_power(handle, target.Handle);
+                var res = THSTensor_float_power(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -813,7 +813,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor floor()
             {
-                var res = THSTensor_floor(handle);
+                var res = THSTensor_floor(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -828,7 +828,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor floor_()
             {
-                var res = THSTensor_floor_(handle);
+                var res = THSTensor_floor_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -844,7 +844,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor fmod(Tensor target)
             {
-                var res = THSTensor_fmod(handle, target.Handle);
+                var res = THSTensor_fmod(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -859,7 +859,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor fmod_(Tensor target)
             {
-                var res = THSTensor_fmod_(handle, target.Handle);
+                var res = THSTensor_fmod_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -874,7 +874,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor fmod(Scalar scalar)
             {
-                var res = THSTensor_fmod_scalar(handle, scalar.Handle);
+                var res = THSTensor_fmod_scalar(Handle, scalar.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -889,7 +889,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor fmod_(Scalar scalar)
             {
-                var res = THSTensor_fmod_scalar_(handle, scalar.Handle);
+                var res = THSTensor_fmod_scalar_(Handle, scalar.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -903,7 +903,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor frac()
             {
-                var res = THSTensor_frac(handle);
+                var res = THSTensor_frac(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -917,7 +917,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor frac_()
             {
-                var res = THSTensor_frac_(handle);
+                var res = THSTensor_frac_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -931,7 +931,7 @@ namespace TorchSharp
             /// <returns></returns>
             public (Tensor Mantissa, Tensor Exponent) frexp()
             {
-                var mantissa = THSTensor_frexp(handle, out var exponent);
+                var mantissa = THSTensor_frexp(Handle, out var exponent);
                 if (mantissa == IntPtr.Zero || exponent == IntPtr.Zero)
                     torch.CheckForErrors();
                 return (new Tensor(mantissa), new Tensor(exponent));
@@ -946,7 +946,7 @@ namespace TorchSharp
             /// <param name="other">Right-hand operand.</param>
             public Tensor gcd(Tensor other)
             {
-                var res = THSTensor_gcd(handle, other.Handle);
+                var res = THSTensor_gcd(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -961,7 +961,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor gcd_(Tensor other)
             {
-                var res = THSTensor_gcd_(handle, other.Handle);
+                var res = THSTensor_gcd_(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -980,7 +980,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor histc(long bins = 100, long min = 0, long max = 0)
             {
-                var res = THSTensor_histc(handle, bins, min, max);
+                var res = THSTensor_histc(Handle, bins, min, max);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -996,7 +996,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor hypot(Tensor other)
             {
-                var res = THSTensor_hypot(handle, other.handle);
+                var res = THSTensor_hypot(Handle, other.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1011,7 +1011,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor log()
             {
-                var res = THSTensor_log(handle);
+                var res = THSTensor_log(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1024,7 +1024,7 @@ namespace TorchSharp
             /// </summary>
             public Tensor log_()
             {
-                var res = THSTensor_log_(handle);
+                var res = THSTensor_log_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1039,7 +1039,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logaddexp(Tensor other)
             {
-                var res = THSTensor_logaddexp(handle, other.handle);
+                var res = THSTensor_logaddexp(Handle, other.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1055,7 +1055,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logaddexp2(Tensor other)
             {
-                var res = THSTensor_logaddexp2(handle, other.handle);
+                var res = THSTensor_logaddexp2(Handle, other.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1071,7 +1071,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logcumsumexp(long dim)
             {
-                var res = THSTensor_logcumsumexp(handle, dim);
+                var res = THSTensor_logcumsumexp(Handle, dim);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1089,7 +1089,7 @@ namespace TorchSharp
             /// <remarks>The computation is numerically stabilized.</remarks>
             public Tensor logsumexp(long dim, Boolean keepdim = false)
             {
-                var res = THSTensor_logsumexp(handle, dim, keepdim);
+                var res = THSTensor_logsumexp(Handle, dim, keepdim);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1104,7 +1104,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor log10()
             {
-                var res = THSTensor_log10(handle);
+                var res = THSTensor_log10(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1119,7 +1119,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor log10_()
             {
-                var res = THSTensor_log10_(handle);
+                var res = THSTensor_log10_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1134,7 +1134,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor log1p()
             {
-                var res = THSTensor_log1p(handle);
+                var res = THSTensor_log1p(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1149,7 +1149,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor log1p_()
             {
-                var res = THSTensor_log1p_(handle);
+                var res = THSTensor_log1p_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1163,7 +1163,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor log2()
             {
-                var res = THSTensor_log2(handle);
+                var res = THSTensor_log2(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1178,7 +1178,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor log2_()
             {
-                var res = THSTensor_log2_(handle);
+                var res = THSTensor_log2_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1193,7 +1193,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logical_and(Tensor other)
             {
-                var res = THSTensor_logical_and(handle, other.Handle);
+                var res = THSTensor_logical_and(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1208,7 +1208,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logical_and_(Tensor other)
             {
-                var res = THSTensor_logical_and_(handle, other.Handle);
+                var res = THSTensor_logical_and_(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1222,7 +1222,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logical_not()
             {
-                var res = THSTensor_logical_not(handle);
+                var res = THSTensor_logical_not(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1236,7 +1236,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logical_not_()
             {
-                var res = THSTensor_logical_not_(handle);
+                var res = THSTensor_logical_not_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1251,7 +1251,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logical_or(Tensor other)
             {
-                var res = THSTensor_logical_or(handle, other.Handle);
+                var res = THSTensor_logical_or(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1266,7 +1266,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logical_or_(Tensor other)
             {
-                var res = THSTensor_logical_or_(handle, other.Handle);
+                var res = THSTensor_logical_or_(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1281,7 +1281,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logical_xor(Tensor other)
             {
-                var res = THSTensor_logical_xor(handle, other.Handle);
+                var res = THSTensor_logical_xor(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1296,7 +1296,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor logical_xor_(Tensor other)
             {
-                var res = THSTensor_logical_xor_(handle, other.Handle);
+                var res = THSTensor_logical_xor_(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1316,7 +1316,7 @@ namespace TorchSharp
 
                 unsafe {
                     fixed (double* pEps = epsArr) {
-                        var res = THSTensor_logit(handle, (IntPtr)pEps);
+                        var res = THSTensor_logit(Handle, (IntPtr)pEps);
                         if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                         return new Tensor(res);
                     }
@@ -1333,7 +1333,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor mul(Tensor target)
             {
-                var res = THSTensor_mul(handle, target.Handle);
+                var res = THSTensor_mul(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1355,7 +1355,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor mul(Scalar target)
             {
-                var res = THSTensor_mul_scalar(handle, target.Handle);
+                var res = THSTensor_mul_scalar(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1377,7 +1377,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor mul_(Tensor target)
             {
-                var res = THSTensor_mul_(handle, target.Handle);
+                var res = THSTensor_mul_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1392,7 +1392,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor mul_(Scalar target)
             {
-                var res = THSTensor_mul_scalar_(handle, target.Handle);
+                var res = THSTensor_mul_scalar_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1411,7 +1411,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor neg()
             {
-                var res = THSTensor_neg(handle);
+                var res = THSTensor_neg(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1431,7 +1431,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor neg_()
             {
-                var res = THSTensor_neg_(handle);
+                var res = THSTensor_neg_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1446,7 +1446,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor pow(Tensor exponent)
             {
-                var res = THSTensor_pow(handle, exponent.Handle);
+                var res = THSTensor_pow(Handle, exponent.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1461,7 +1461,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor pow_(Tensor exponent)
             {
-                var res = THSTensor_pow_(handle, exponent.Handle);
+                var res = THSTensor_pow_(Handle, exponent.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1476,7 +1476,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor pow(Scalar exponent)
             {
-                var res = THSTensor_pow_scalar(handle, exponent.Handle);
+                var res = THSTensor_pow_scalar(Handle, exponent.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1491,7 +1491,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor pow_(Scalar exponent)
             {
-                var res = THSTensor_pow_scalar_(handle, exponent.Handle);
+                var res = THSTensor_pow_scalar_(Handle, exponent.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1505,7 +1505,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor reciprocal()
             {
-                var res = THSTensor_reciprocal(handle);
+                var res = THSTensor_reciprocal(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1520,7 +1520,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor reciprocal_()
             {
-                var res = THSTensor_reciprocal_(handle);
+                var res = THSTensor_reciprocal_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1536,7 +1536,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor remainder(Tensor target)
             {
-                var res = THSTensor_remainder(handle, target.Handle);
+                var res = THSTensor_remainder(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1551,7 +1551,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor remainder_(Tensor target)
             {
-                var res = THSTensor_remainder_(handle, target.Handle);
+                var res = THSTensor_remainder_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1566,7 +1566,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor remainder(Scalar scalar)
             {
-                var res = THSTensor_remainder_scalar(handle, scalar.Handle);
+                var res = THSTensor_remainder_scalar(Handle, scalar.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1582,7 +1582,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor remainder_(Scalar scalar)
             {
-                var res = THSTensor_remainder_scalar_(handle, scalar.Handle);
+                var res = THSTensor_remainder_scalar_(Handle, scalar.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1596,7 +1596,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor round()
             {
-                var res = THSTensor_round(handle);
+                var res = THSTensor_round(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1611,7 +1611,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor round_()
             {
-                var res = THSTensor_round_(handle);
+                var res = THSTensor_round_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1626,7 +1626,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor rsqrt()
             {
-                var res = THSTensor_rsqrt(handle);
+                var res = THSTensor_rsqrt(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1640,7 +1640,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor rsqrt_()
             {
-                var res = THSTensor_rsqrt_(handle);
+                var res = THSTensor_rsqrt_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1660,7 +1660,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sqrt()
             {
-                var res = THSTensor_sqrt(handle);
+                var res = THSTensor_sqrt(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1674,7 +1674,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sqrt_()
             {
-                var res = THSTensor_sqrt_(handle);
+                var res = THSTensor_sqrt_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1688,7 +1688,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sign()
             {
-                var res = THSTensor_sign(handle);
+                var res = THSTensor_sign(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1703,7 +1703,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sign_()
             {
-                var res = THSTensor_sign_(handle);
+                var res = THSTensor_sign_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1718,7 +1718,7 @@ namespace TorchSharp
             /// <returns>A boolean tensor of the same shape as the input.</returns>
             public Tensor signbit()
             {
-                var res = THSTensor_signbit(handle);
+                var res = THSTensor_signbit(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1734,7 +1734,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sub(Tensor target)
             {
-                var res = THSTensor_sub(handle, target.Handle);
+                var res = THSTensor_sub(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1749,7 +1749,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sub(Scalar target)
             {
-                var res = THSTensor_sub_scalar(handle, target.Handle);
+                var res = THSTensor_sub_scalar(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1764,7 +1764,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sub_(Tensor target)
             {
-                var res = THSTensor_sub_(handle, target.Handle);
+                var res = THSTensor_sub_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1779,7 +1779,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sub_(Scalar target)
             {
-                var res = THSTensor_sub_scalar_(handle, target.Handle);
+                var res = THSTensor_sub_scalar_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1799,7 +1799,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cumulative_trapezoid(double dx = 1, long dim = -1)
             {
-                IntPtr res = THSTensor_trapezoid_dx(handle, dx, dim);
+                IntPtr res = THSTensor_trapezoid_dx(Handle, dx, dim);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1813,7 +1813,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cumulative_trapezoid(Tensor x, long dim = -1)
             {
-                IntPtr res = THSTensor_trapezoid_x(handle, x.handle, dim);
+                IntPtr res = THSTensor_trapezoid_x(Handle, x.Handle, dim);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1833,7 +1833,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor trapezoid(double dx = 1, long dim = -1)
             {
-                IntPtr res = THSTensor_trapezoid_dx(handle, dx, dim);
+                IntPtr res = THSTensor_trapezoid_dx(Handle, dx, dim);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1847,7 +1847,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor trapezoid(Tensor x, long dim = -1)
             {
-                IntPtr res = THSTensor_trapezoid_x(handle, x.handle, dim);
+                IntPtr res = THSTensor_trapezoid_x(Handle, x.Handle, dim);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1861,7 +1861,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor trunc()
             {
-                var res = THSTensor_trunc(handle);
+                var res = THSTensor_trunc(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1881,7 +1881,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor trunc_()
             {
-                var res = THSTensor_trunc_(handle);
+                var res = THSTensor_trunc_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -1902,7 +1902,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor xlogy(Tensor y)
             {
-                var res = THSTensor_xlogy(handle, y.Handle);
+                var res = THSTensor_xlogy(Handle, y.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1919,7 +1919,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor xlogy_(Tensor y)
             {
-                var res = THSTensor_xlogy_(handle, y.Handle);
+                var res = THSTensor_xlogy_(Handle, y.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1935,7 +1935,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor xlogy(Scalar y)
             {
-                var res = THSTensor_xlogy_scalar(handle, y.Handle);
+                var res = THSTensor_xlogy_scalar(Handle, y.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1952,7 +1952,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor xlogy_(Scalar y)
             {
-                var res = THSTensor_xlogy_scalar_(handle, y.Handle);
+                var res = THSTensor_xlogy_scalar_(Handle, y.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);

--- a/src/TorchSharp/Tensor/Tensor.Trig.cs
+++ b/src/TorchSharp/Tensor/Tensor.Trig.cs
@@ -32,7 +32,7 @@ namespace TorchSharp
             /// </remarks>
             public Tensor angle()
             {
-                var res = THSTensor_angle(handle);
+                var res = THSTensor_angle(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -47,7 +47,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor asin()
             {
-                var res = THSTensor_asin(handle);
+                var res = THSTensor_asin(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -68,7 +68,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor asin_()
             {
-                var res = THSTensor_asin_(handle);
+                var res = THSTensor_asin_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -85,7 +85,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor acos()
             {
-                var res = THSTensor_acos(handle);
+                var res = THSTensor_acos(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -106,7 +106,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor acos_()
             {
-                var res = THSTensor_acos_(handle);
+                var res = THSTensor_acos_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -127,7 +127,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor atan()
             {
-                var res = THSTensor_atan(handle);
+                var res = THSTensor_atan(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -148,7 +148,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor atan_()
             {
-                var res = THSTensor_atan_(handle);
+                var res = THSTensor_atan_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -169,7 +169,7 @@ namespace TorchSharp
             /// <param name="other">The second tensor</param>
             public Tensor atan2(Tensor other)
             {
-                var res = THSTensor_atan2(handle, other.Handle);
+                var res = THSTensor_atan2(Handle, other.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -185,7 +185,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor atan2_(Tensor other)
             {
-                var res = THSTensor_atan2_(handle, other.Handle);
+                var res = THSTensor_atan2_(Handle, other.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -200,7 +200,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cos()
             {
-                var res = THSTensor_cos(handle);
+                var res = THSTensor_cos(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -215,7 +215,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cos_()
             {
-                var res = THSTensor_cos_(handle);
+                var res = THSTensor_cos_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -230,7 +230,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sin()
             {
-                var res = THSTensor_sin(handle);
+                var res = THSTensor_sin(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -245,7 +245,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sin_()
             {
-                var res = THSTensor_sin_(handle);
+                var res = THSTensor_sin_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -260,7 +260,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor tan()
             {
-                var res = THSTensor_tan(handle);
+                var res = THSTensor_tan(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -275,7 +275,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor tan_()
             {
-                var res = THSTensor_tan_(handle);
+                var res = THSTensor_tan_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -290,7 +290,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sinc()
             {
-                var res = THSTensor_sinc(handle);
+                var res = THSTensor_sinc(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -305,7 +305,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sinc_()
             {
-                var res = THSTensor_sinc_(handle);
+                var res = THSTensor_sinc_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -320,7 +320,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sinh()
             {
-                var res = THSTensor_sinh(handle);
+                var res = THSTensor_sinh(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -335,7 +335,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor sinh_()
             {
-                var res = THSTensor_sinh_(handle);
+                var res = THSTensor_sinh_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -350,7 +350,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cosh()
             {
-                var res = THSTensor_cosh(handle);
+                var res = THSTensor_cosh(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -365,7 +365,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor cosh_()
             {
-                var res = THSTensor_cosh_(handle);
+                var res = THSTensor_cosh_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -379,7 +379,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor tanh()
             {
-                var res = THSTensor_tanh(handle);
+                var res = THSTensor_tanh(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -394,7 +394,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor tanh_()
             {
-                var res = THSTensor_tanh_(handle);
+                var res = THSTensor_tanh_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -409,7 +409,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arcsinh()
             {
-                var res = THSTensor_arcsinh(handle);
+                var res = THSTensor_arcsinh(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -430,7 +430,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arcsinh_()
             {
-                var res = THSTensor_arcsinh_(handle);
+                var res = THSTensor_arcsinh_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -451,7 +451,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arccosh()
             {
-                var res = THSTensor_arccosh(handle);
+                var res = THSTensor_arccosh(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -473,7 +473,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arccosh_()
             {
-                var res = THSTensor_arccosh_(handle);
+                var res = THSTensor_arccosh_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -494,7 +494,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arctanh()
             {
-                var res = THSTensor_arctanh(handle);
+                var res = THSTensor_arctanh(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -515,7 +515,7 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arctanh_()
             {
-                var res = THSTensor_arctanh_(handle);
+                var res = THSTensor_arctanh_(Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);

--- a/src/TorchSharp/Tensor/Tensor.torch.cs
+++ b/src/TorchSharp/Tensor/Tensor.torch.cs
@@ -288,7 +288,7 @@ namespace TorchSharp
 
         public static Tensor _standard_gamma(Tensor input, torch.Generator generator = null)
         {
-            var res = THSTensor_standard_gamma_(input.handle, (generator is null) ? IntPtr.Zero : generator.Handle);
+            var res = THSTensor_standard_gamma_(input.Handle, (generator is null) ? IntPtr.Zero : generator.Handle);
             if (res == IntPtr.Zero) { torch.CheckForErrors(); }
             return new Tensor(res);
         }
@@ -297,7 +297,7 @@ namespace TorchSharp
 
         public static Tensor _sample_dirichlet(Tensor input, torch.Generator generator = null)
         {
-            var res = THSTensor_sample_dirichlet_(input.handle, (generator is null) ? IntPtr.Zero : generator.Handle);
+            var res = THSTensor_sample_dirichlet_(input.Handle, (generator is null) ? IntPtr.Zero : generator.Handle);
             if (res == IntPtr.Zero) { torch.CheckForErrors(); }
             return new Tensor(res);
         }

--- a/src/TorchSharp/TorchVision/ResizedCrop.cs
+++ b/src/TorchSharp/TorchVision/ResizedCrop.cs
@@ -17,7 +17,8 @@ namespace TorchSharp.torchvision
 
         public Tensor forward(Tensor input)
         {
-            return resizer.forward(cropper.forward(input));
+            using var cr = cropper.forward(input);
+            return resizer.forward(cr);
         }
 
         private ITransform cropper;

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -244,11 +244,16 @@ namespace TorchSharp
         [Fact]
         public void EvaluateLeakyRelu()
         {
-            var rel = LeakyReLU();
+            var rel = LeakyReLU(0.1);
             var input = torch.randn(new long[] { 64, 8 });
             var output = rel.forward(input);
             var values = output.data<float>().ToArray();
             Assert.Equal(input.shape, output.shape);
+
+            var singleton = torch.tensor(15.0f);
+            Assert.Equal(15.0f, rel.forward(singleton).item<float>());
+            singleton = torch.tensor(-15.0f);
+            Assert.Equal(-1.50f, rel.forward(singleton).item<float>());
         }
 
         [Fact]

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -837,7 +837,7 @@ namespace TorchSharp
 
                 Func<Tensor> closure = () => {
                     using var eval = seq.forward(x);
-                    using var output = loss(eval, y);
+                    var output = loss(eval, y);
 
                     finalLoss = output.ToSingle();
 
@@ -887,7 +887,7 @@ namespace TorchSharp
 
                 Func<Tensor> closure = () => {
                     using var eval = seq.forward(x);
-                    using var output = loss(eval, y);
+                    var output = loss(eval, y);
 
                     finalLoss = output.ToSingle();
 

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -289,8 +289,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -323,9 +323,9 @@ namespace TorchSharp
             float initialLoss = loss(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
-            for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+            for (int i = 0; i < 15; i++) {
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -359,8 +359,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -394,8 +394,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -429,8 +429,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -464,8 +464,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -501,8 +501,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -534,8 +534,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -567,8 +567,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -604,8 +604,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -637,8 +637,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -670,8 +670,8 @@ namespace TorchSharp
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -707,8 +707,8 @@ namespace TorchSharp
             double lastLR = learning_rate;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -750,8 +750,8 @@ namespace TorchSharp
             double lastLR = learning_rate;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -794,8 +794,8 @@ namespace TorchSharp
             double lastLR = learning_rate;
 
             for (int i = 0; i < 10; i++) {
-                var eval = seq.forward(x);
-                var output = loss(eval, y);
+                using var eval = seq.forward(x);
+                using var output = loss(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -836,8 +836,8 @@ namespace TorchSharp
             for (int i = 0; i < 10; i++) {
 
                 Func<Tensor> closure = () => {
-                    var eval = seq.forward(x);
-                    var output = loss(eval, y);
+                    using var eval = seq.forward(x);
+                    using var output = loss(eval, y);
 
                     finalLoss = output.ToSingle();
 
@@ -886,8 +886,8 @@ namespace TorchSharp
             for (int i = 0; i < 10; i++) {
 
                 Func<Tensor> closure = () => {
-                    var eval = seq.forward(x);
-                    var output = loss(eval, y);
+                    using var eval = seq.forward(x);
+                    using var output = loss(eval, y);
 
                     finalLoss = output.ToSingle();
 


### PR DESCRIPTION
I found a whole slew of torchvision functions that did not properly dispose of temporaries. The same problem was found in a number of the optimizers whose step() functions are written in .NET rather than native code.

In the process of fixing that issue, I also moved a number of the algorithms to native code, implementing them in C++ to avoid the interop overhead and the overhead of creating and disposing of short-lived .NET tensor aliases.

Also -- addressed an infinite recursion problem in a couple of the randint() overloads.