### PR TITLE
Fixed issue #496

### DIFF
--- a/src/Native/LibTorchSharp/THSConvolution.cpp
+++ b/src/Native/LibTorchSharp/THSConvolution.cpp
@@ -454,8 +454,8 @@ NNModule THSNN_Conv2d_ctor_1(const int64_t inputChannel, const int64_t outputCha
     NNAnyModule* outAsAnyModule)
 {
     torch::nn::Conv2dOptions::padding_t padd =
-        (paddingX == -1) ? torch::kSame :
-        (paddingX == 0) ? torch::kValid :
+        (paddingX == -1) && (paddingY == 0) ? torch::kSame :
+        (paddingX == 0) && (paddingY == 0) ? torch::kValid :
         (torch::nn::Conv2dOptions::padding_t)torch::ExpandingArray<2>({ paddingX, paddingY });
 
     CATCH_RETURN_NNModule(
@@ -528,8 +528,8 @@ NNModule THSNN_Conv3d_ctor_1(const int64_t inputChannel, const int64_t outputCha
     NNAnyModule* outAsAnyModule)
 {
     torch::nn::Conv3dOptions::padding_t padd =
-        (paddingX == -1) ? torch::kSame :
-        (paddingX == 0) ? torch::kValid :
+        (paddingX == -1) && (paddingY == 0) && (paddingZ == 0) ? torch::kSame :
+        (paddingX == 0) && (paddingY == 0) && (paddingZ == 0) ? torch::kValid :
         (torch::nn::Conv3dOptions::padding_t)torch::ExpandingArray<3>({ paddingX, paddingY, paddingZ });
 
     CATCH_RETURN_NNModule(

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -407,5 +407,14 @@ namespace TorchSharp
             Assert.Throws<ArgumentException>(() => torch.randn(3, 4, dtype: torch.int64));
             Assert.Throws<ArgumentException>(() => torch.randn(3, 4, dtype: torch.@bool));
         }
+
+        [Fact]
+        public void ValidateIssue496()
+        {
+            var c2 = torch.nn.Conv2d(3, 16, kernelSize: (1, 7), stride: (1, 1), padding: (0, 3));
+            var Win = torch.rand(16, 3, 8, 8);
+            var s = c2.forward(Win).shape;
+            Assert.Equal(new long[] {16, 16, 8, 8}, s);
+        }
     }
 }


### PR DESCRIPTION
The C++ code for Conv2d and Conv3d were incorrectly receiving the encoding of padding='same' and padding='valid'