### PR TITLE
Fixed yield statement in Data interface of CIFARReader

### DIFF
--- a/src/Examples.Utils/CIFARReader .cs
+++ b/src/Examples.Utils/CIFARReader .cs
@@ -96,7 +96,7 @@ namespace TorchSharp.Examples
         }
 
         public int Size { get {
-                return _size * (_transforms.Count + 1);
+                return _size;
             } }
         private int _size = 0;
 

--- a/src/Examples.Utils/CIFARReader .cs
+++ b/src/Examples.Utils/CIFARReader .cs
@@ -108,11 +108,11 @@ namespace TorchSharp.Examples
         public IEnumerable<(Tensor, Tensor)> Data()
         {
             for (var i = 0; i < data.Count; i++) {
-                yield return (data[i], labels[i]);
-
+                var tfdata = data[i];
                 foreach (var tfrm in _transforms) {
-                    yield return (tfrm.forward(data[i]), labels[i]);
+                    tfdata = tfrm.forward(tfdata);
                 }
+                yield return (tfdata, labels[i]);
             }
         }
 


### PR DESCRIPTION
The example of using CIFARReader does not use any `transforms`, so the returned `IEnumerable<(Tensor, Tensor)>` by `Data()` interface will only return the raw `data` and `labels`. However, with any given transforms, `Data()` could return raw data + each transformed data. Not sure whether I dispose the original data correctly.