### PR TITLE
Fixed bugs #499 and #500

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,15 +2,16 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
-## NuGet Version 0.95.5
+## NuGet Version 0.96.0
 
 __API Changes:__
 
 'Module.named_parameters()', 'parameters()', 'named_modules()', 'named_children()' all return IEnumerable instances instead of arrays.
-Adding weight and bias properties to the RNN modules. For 
+Adding weight and bias properties to the RNN modules.
 
 __Fixed Bugs:__
 
+#500 BatchNorm1d throws exception during eval with batch size of 1
 #499 Setting Linear.weight is not reflected in 'parameters()'
 #496 Wrong output shape of torch.nn.Conv2d with 2d stride overload
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,10 +6,11 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 __API Changes:__
 
-__NOTE__: This release has breaking changes.
+__NOTE__: This release contains breaking changes.
 
 'Module.named_parameters()', 'parameters()', 'named_modules()', 'named_children()' all return IEnumerable instances instead of arrays.
 Adding weight and bias properties to the RNN modules.
+Lower-cased names: Module.Train --> Module.train and Module.Eval --> Module.eval
 
 __Fixed Bugs:__
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,8 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 __API Changes:__
 
+__NOTE__: This release has breaking changes.
+
 'Module.named_parameters()', 'parameters()', 'named_modules()', 'named_children()' all return IEnumerable instances instead of arrays.
 Adding weight and bias properties to the RNN modules.
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,18 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+## NuGet Version 0.95.5
+
+__API Changes:__
+
+'Module.named_parameters()', 'parameters()', 'named_modules()', 'named_children()' all return IEnumerable instances instead of arrays.
+Adding weight and bias properties to the RNN modules. For 
+
+__Fixed Bugs:__
+
+#499 Setting Linear.weight is not reflected in 'parameters()'
+#496 Wrong output shape of torch.nn.Conv2d with 2d stride overload
+
 ## NuGet Version 0.95.4
 
 __API Changes:__
@@ -151,7 +163,7 @@ __Fixed Bugs:__
 
 __Added Features:__
 
-```
+'''
 torch.nn.MultiHeadAttention
 torch.linalg.cond
 torch.linalg.cholesky_ex
@@ -159,7 +171,7 @@ torch.linalg.inv_ex
 torch.amax/amin
 torch.matrix_exp
 torch.distributions.*   (about half the namespace)
-```
+'''
 
 __API Changes:__
 

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>95</MinorVersion>
-    <PatchVersion>4</PatchVersion>
+    <MinorVersion>96</MinorVersion>
+    <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Examples.Utils/Examples.Utils.csproj
+++ b/src/Examples.Utils/Examples.Utils.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/AdversarialExampleGeneration.cs
+++ b/src/Examples/AdversarialExampleGeneration.cs
@@ -100,7 +100,7 @@ namespace TorchSharp.Examples
                 }
 
                 model.to((Device)device);
-                model.Eval();
+                model.eval();
 
                 var epsilons = new double[] { 0, 0.05, 0.1, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50 };
 

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -50,9 +50,7 @@ namespace TorchSharp.Examples
                 ("l3", Linear(4096, numClasses))
             );
 
-            register_module("features", features);
-            register_module("avg", avgPool);
-            register_module("classify", classifier);
+            RegisterComponents();
 
             if (device != null && device.type == DeviceType.CUDA)
                 this.to(device);

--- a/src/Examples/CIFAR10.cs
+++ b/src/Examples/CIFAR10.cs
@@ -155,7 +155,7 @@ namespace TorchSharp.Examples
             long batchSize,
             long size)
         {
-            model.Train();
+            model.train();
 
             int batchId = 1;
             long total = 0;
@@ -200,7 +200,7 @@ namespace TorchSharp.Examples
             IEnumerable<(Tensor, Tensor)> dataLoader,
             long size)
         {
-            model.Eval();
+            model.eval();
 
             double testLoss = 0;
             long correct = 0;

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -170,7 +170,7 @@ namespace TorchSharp.Examples
             long batchSize,
             long size)
         {
-            model.Train();
+            model.train();
 
             int batchId = 1;
 
@@ -206,7 +206,7 @@ namespace TorchSharp.Examples
             IEnumerable<(Tensor, Tensor)> dataLoader,
             long size)
         {
-            model.Eval();
+            model.eval();
 
             double testLoss = 0;
             int correct = 0;

--- a/src/Examples/Properties/launchSettings.json
+++ b/src/Examples/Properties/launchSettings.json
@@ -2,7 +2,6 @@
   "profiles": {
     "Examples": {
       "commandName": "Project",
-      "commandLineArgs": "VGG11 16 1800",
       "nativeDebugging": true
     }
   }

--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -126,7 +126,7 @@ namespace TorchSharp.Examples
                     using (var output = model.forward(data, src_mask)) {
                         var loss = criterion(output.view(-1, ntokens), targets);
                         loss.backward();
-                        torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5);
+                        torch.nn.utils.clip_grad_norm_(model.parameters().ToArray(), 0.5);
                         optimizer.step();
 
                         total_loss += loss.to(torch.CPU).item<float>();

--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -100,7 +100,7 @@ namespace TorchSharp.Examples
 
         private static void train(int epoch, Tensor train_data, TransformerModel model, Loss criterion, int bptt, int ntokens, torch.optim.Optimizer optimizer)
         {
-            model.Train();
+            model.train();
 
             using (var d = torch.NewDisposeScope()) {
 
@@ -145,7 +145,7 @@ namespace TorchSharp.Examples
 
         private static double evaluate(Tensor eval_data, TransformerModel model, Loss criterion, int bptt, int ntokens, torch.optim.Optimizer optimizer)
         {
-            model.Eval();
+            model.eval();
 
             using (var d = torch.NewDisposeScope()) {
 

--- a/src/Examples/TextClassification.cs
+++ b/src/Examples/TextClassification.cs
@@ -105,7 +105,7 @@ namespace TorchSharp.Examples
 
         static void train(int epoch, IEnumerable<(Tensor, Tensor, Tensor)> train_data, TextClassificationModel model, Loss criterion, torch.optim.Optimizer optimizer)
         {
-            model.Train();
+            model.train();
 
             double total_acc = 0.0;
             long total_count = 0;
@@ -141,7 +141,7 @@ namespace TorchSharp.Examples
 
         static double evaluate(IEnumerable<(Tensor, Tensor, Tensor)> test_data, TextClassificationModel model, Loss criterion)
         {
-            model.Eval();
+            model.eval();
 
             double total_acc = 0.0;
             long total_count = 0;

--- a/src/Examples/TextClassification.cs
+++ b/src/Examples/TextClassification.cs
@@ -123,7 +123,7 @@ namespace TorchSharp.Examples
 
                     var loss = criterion(predicted_labels, labels);
                     loss.backward();
-                    torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5);
+                    torch.nn.utils.clip_grad_norm_(model.parameters().ToArray(), 0.5);
                     optimizer.step();
 
                     total_acc += (predicted_labels.argmax(1) == labels).sum().to(torch.CPU).item<long>();

--- a/src/FSharp.Examples/AdversarialExampleGeneration.fs
+++ b/src/FSharp.Examples/AdversarialExampleGeneration.fs
@@ -121,7 +121,7 @@ let run epochs =
 
     model.``to``(device) |> ignore
 
-    model.Eval()
+    model.eval()
 
     let epsilons = [| 0.0; 0.05; 0.1; 0.15; 0.20; 0.25; 0.30; 0.35; 0.40; 0.45; 0.50|]
 

--- a/src/FSharp.Examples/AlexNet.fs
+++ b/src/FSharp.Examples/AlexNet.fs
@@ -87,7 +87,7 @@ let loss x y = functional.nll_loss().Invoke(x,y)
 
 let train (model:Model) (optimizer:Optimizer) (dataLoader: CIFARReader) epoch =
 
-    model.Train()
+    model.train()
 
     let size = dataLoader.Size
 
@@ -125,7 +125,7 @@ let train (model:Model) (optimizer:Optimizer) (dataLoader: CIFARReader) epoch =
         end
 
 let test (model:Model) (dataLoader:CIFARReader) =
-    model.Eval()
+    model.eval()
 
     let sz = float32 dataLoader.Size
 

--- a/src/FSharp.Examples/FSharp.Examples.fsproj
+++ b/src/FSharp.Examples/FSharp.Examples.fsproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 

--- a/src/FSharp.Examples/MNIST.fs
+++ b/src/FSharp.Examples/MNIST.fs
@@ -87,7 +87,7 @@ type Model(name,device:torch.Device) as this =
 let loss x y = functional.nll_loss(reduction=Reduction.Mean).Invoke(x,y)
 
 let train (model:Model) (optimizer:Optimizer) (dataLoader: MNISTReader) epoch =
-    model.Train()
+    model.train()
 
     let size = dataLoader.Size
     let batchSize = dataLoader.BatchSize
@@ -114,7 +114,7 @@ let train (model:Model) (optimizer:Optimizer) (dataLoader: MNISTReader) epoch =
         batchID <- batchID + 1
 
 let test (model:Model) (dataLoader:MNISTReader) =
-    model.Eval()
+    model.eval()
 
     let sz = float32 dataLoader.Size
 

--- a/src/FSharp.Examples/SequenceToSequence.fs
+++ b/src/FSharp.Examples/SequenceToSequence.fs
@@ -138,7 +138,7 @@ let get_batch (source:torch.Tensor) (index:int64) =
 
 let train epoch (model:TransformerModel) (optimizer:Optimizer) (trainData:torch.Tensor) ntokens =
 
-    model.Train()
+    model.train()
 
     use d = torch.NewDisposeScope()
 
@@ -183,7 +183,7 @@ let train epoch (model:TransformerModel) (optimizer:Optimizer) (trainData:torch.
 
 let evaluate (model:TransformerModel) (evalData:torch.Tensor) ntokens =
 
-    model.Eval()
+    model.eval()
 
     use d = torch.NewDisposeScope()
 

--- a/src/FSharp.Examples/TextClassification.fs
+++ b/src/FSharp.Examples/TextClassification.fs
@@ -71,7 +71,7 @@ type TextClassificationModel(vocabSize, embedDim, nClasses, device:torch.Device)
 
 let train epoch (trainData:IEnumerable<torch.Tensor*torch.Tensor*torch.Tensor>) (model:TextClassificationModel) (optimizer:torch.optim.Optimizer) =
 
-    model.Train()
+    model.train()
 
     let mutable total_acc = 0.0
     let mutable total_count = 0L
@@ -103,7 +103,7 @@ let train epoch (trainData:IEnumerable<torch.Tensor*torch.Tensor*torch.Tensor>) 
 
 let evaluate (testData:IEnumerable<torch.Tensor*torch.Tensor*torch.Tensor>) (model:TextClassificationModel) =
 
-    model.Eval()
+    model.eval()
 
     let mutable total_acc = 0.0
     let mutable total_count = 0L

--- a/src/Native/LibTorchSharp/THSConvolution.cpp
+++ b/src/Native/LibTorchSharp/THSConvolution.cpp
@@ -454,8 +454,8 @@ NNModule THSNN_Conv2d_ctor_1(const int64_t inputChannel, const int64_t outputCha
     NNAnyModule* outAsAnyModule)
 {
     torch::nn::Conv2dOptions::padding_t padd =
-        (paddingX == -1) ? torch::kSame :
-        (paddingX == 0) ? torch::kValid :
+        (paddingX == -1) && (paddingY == 0) ? torch::kSame :
+        (paddingX == 0) && (paddingY == 0) ? torch::kValid :
         (torch::nn::Conv2dOptions::padding_t)torch::ExpandingArray<2>({ paddingX, paddingY });
 
     CATCH_RETURN_NNModule(
@@ -528,8 +528,8 @@ NNModule THSNN_Conv3d_ctor_1(const int64_t inputChannel, const int64_t outputCha
     NNAnyModule* outAsAnyModule)
 {
     torch::nn::Conv3dOptions::padding_t padd =
-        (paddingX == -1) ? torch::kSame :
-        (paddingX == 0) ? torch::kValid :
+        (paddingX == -1) && (paddingY == 0) && (paddingZ == 0) ? torch::kSame :
+        (paddingX == 0) && (paddingY == 0) && (paddingZ == 0) ? torch::kValid :
         (torch::nn::Conv3dOptions::padding_t)torch::ExpandingArray<3>({ paddingX, paddingY, paddingZ });
 
     CATCH_RETURN_NNModule(

--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -756,6 +756,47 @@ Tensor THSNN_RNN_forward(const NNModule module, const Tensor input1, const Tenso
     return output;
 }
 
+Tensor THSNN_RNN_bias_ih(const NNModule module, const int64_t idx)
+{
+    return get_bias_ih<torch::nn::RNN>(module, idx);
+}
+
+void THSNN_RNN_set_bias_ih(const NNModule module, const Tensor bias, const int64_t idx)
+{
+    set_bias_ih<torch::nn::RNN>(module, bias, idx);
+}
+
+Tensor THSNN_RNN_weight_ih(const NNModule module, const int64_t idx)
+{
+    return get_weight_ih<torch::nn::RNN>(module, idx);
+}
+
+void THSNN_RNN_set_weight_ih(const NNModule module, const Tensor weight, const int64_t idx)
+{
+    set_weight_ih<torch::nn::RNN>(module, weight, idx);
+}
+
+Tensor THSNN_RNN_bias_hh(const NNModule module, const int64_t idx)
+{
+    return get_bias_hh<torch::nn::RNN>(module, idx);
+}
+
+void THSNN_RNN_set_bias_hh(const NNModule module, const Tensor bias, const int64_t idx)
+{
+    set_bias_hh<torch::nn::RNN>(module, bias, idx);
+}
+
+Tensor THSNN_RNN_weight_hh(const NNModule module, const int64_t idx)
+{
+    return get_weight_hh<torch::nn::RNN>(module, idx);
+}
+
+void THSNN_RNN_set_weight_hh(const NNModule module, const Tensor weight, const int64_t idx)
+{
+    set_weight_hh<torch::nn::RNN>(module, weight, idx);
+}
+
+
 NNModule THSNN_GRU_ctor(const int64_t input_size, const int64_t hidden_size, const int64_t num_layers, const bool bias, const bool batchFirst, const double dropout, const bool bidirectional, NNAnyModule* outAsAnyModule)
 {
     CATCH_RETURN_NNModule(
@@ -802,9 +843,9 @@ Tensor THSNN_LSTM_forward(const NNModule module, const Tensor input1, const Tens
     Tensor output;
     CATCH(
         auto result = (*module)->as<torch::nn::LSTM>()->forward(*input1, second_arg);
-    output = new torch::Tensor(std::get<0>(result));
-    *h_n = new torch::Tensor(std::get<0>(std::get<1>(result)));
-    *c_n = new torch::Tensor(std::get<1>(std::get<1>(result)));
+        output = new torch::Tensor(std::get<0>(result));
+        *h_n = new torch::Tensor(std::get<0>(std::get<1>(result)));
+        *c_n = new torch::Tensor(std::get<1>(std::get<1>(result)));
     );
     return output;
 }
@@ -826,6 +867,46 @@ Tensor THSNN_RNNCell_forward(const NNModule module, const Tensor input1, const T
     CATCH_TENSOR((*module)->as<torch::nn::RNNCell>()->forward(*input1, (h0 ? *h0 : at::Tensor())));
 }
 
+Tensor THSNN_RNNCell_bias_ih(const NNModule module)
+{
+    return get_bias_ih<torch::nn::RNNCell>(module);
+}
+
+void THSNN_RNNCell_set_bias_ih(const NNModule module, const Tensor bias)
+{
+    set_bias_ih<torch::nn::RNNCell>(module, bias);
+}
+
+Tensor THSNN_RNNCell_weight_ih(const NNModule module)
+{
+    return get_weight_ih<torch::nn::RNNCell>(module);
+}
+
+void THSNN_RNNCell_set_weight_ih(const NNModule module, const Tensor weight)
+{
+    set_weight_ih<torch::nn::RNNCell>(module, weight);
+}
+
+Tensor THSNN_RNNCell_bias_hh(const NNModule module)
+{
+    return get_bias_hh<torch::nn::RNNCell>(module);
+}
+
+void THSNN_RNNCell_set_bias_hh(const NNModule module, const Tensor bias)
+{
+    set_bias_hh<torch::nn::RNNCell>(module, bias);
+}
+
+Tensor THSNN_RNNCell_weight_hh(const NNModule module)
+{
+    return get_weight_hh<torch::nn::RNNCell>(module);
+}
+
+void THSNN_RNNCell_set_weight_hh(const NNModule module, const Tensor weight)
+{
+    set_weight_hh<torch::nn::RNNCell>(module, weight);
+}
+
 NNModule THSNN_GRUCell_ctor(const int64_t input_size, const int64_t hidden_size, const bool bias, NNAnyModule* outAsAnyModule)
 {
     CATCH_RETURN_NNModule(
@@ -839,6 +920,46 @@ NNModule THSNN_GRUCell_ctor(const int64_t input_size, const int64_t hidden_size,
 Tensor  THSNN_GRUCell_forward(const NNModule module, const Tensor input1, const Tensor h0)
 {
     CATCH_TENSOR((*module)->as<torch::nn::GRUCell>()->forward(*input1, (h0 ? *h0 : at::Tensor())));
+}
+
+Tensor THSNN_GRUCell_bias_ih(const NNModule module)
+{
+    return get_bias_ih<torch::nn::GRUCell>(module);
+}
+
+void THSNN_GRUCell_set_bias_ih(const NNModule module, const Tensor bias)
+{
+    set_bias_ih<torch::nn::GRUCell>(module, bias);
+}
+
+Tensor THSNN_GRUCell_weight_ih(const NNModule module)
+{
+    return get_weight_ih<torch::nn::GRUCell>(module);
+}
+
+void THSNN_GRUCell_set_weight_ih(const NNModule module, const Tensor weight)
+{
+    set_weight_ih<torch::nn::GRUCell>(module, weight);
+}
+
+Tensor THSNN_GRUCell_bias_hh(const NNModule module)
+{
+    return get_bias_hh<torch::nn::GRUCell>(module);
+}
+
+void THSNN_GRUCell_set_bias_hh(const NNModule module, const Tensor bias)
+{
+    set_bias_hh<torch::nn::GRUCell>(module, bias);
+}
+
+Tensor THSNN_GRUCell_weight_hh(const NNModule module)
+{
+    return get_weight_hh<torch::nn::GRUCell>(module);
+}
+
+void THSNN_GRUCell_set_weight_hh(const NNModule module, const Tensor weight)
+{
+    set_weight_hh<torch::nn::GRUCell>(module, weight);
 }
 
 NNModule THSNN_LSTMCell_ctor(const int64_t input_size, const int64_t hidden_size, const bool bias, NNAnyModule* outAsAnyModule)
@@ -861,7 +982,48 @@ Tensor THSNN_LSTMCell_forward(const NNModule module, const Tensor input1, const 
         output = new torch::Tensor(std::get<0>(result));
         *c_n = new torch::Tensor(std::get<1>(result));
     );
+
     return output;
+}
+
+Tensor THSNN_LSTMCell_bias_ih(const NNModule module)
+{
+    return get_bias_ih<torch::nn::LSTMCell>(module);
+}
+
+void THSNN_LSTMCell_set_bias_ih(const NNModule module, const Tensor bias)
+{
+    set_bias_ih<torch::nn::LSTMCell>(module, bias);
+}
+
+Tensor THSNN_LSTMCell_weight_ih(const NNModule module)
+{
+    return get_weight_ih<torch::nn::LSTMCell>(module);
+}
+
+void THSNN_LSTMCell_set_weight_ih(const NNModule module, const Tensor weight)
+{
+    set_weight_ih<torch::nn::LSTMCell>(module, weight);
+}
+
+Tensor THSNN_LSTMCell_bias_hh(const NNModule module)
+{
+    return get_bias_hh<torch::nn::LSTMCell>(module);
+}
+
+void THSNN_LSTMCell_set_bias_hh(const NNModule module, const Tensor bias)
+{
+    set_bias_hh<torch::nn::LSTMCell>(module, bias);
+}
+
+Tensor THSNN_LSTMCell_weight_hh(const NNModule module)
+{
+    return get_weight_hh<torch::nn::LSTMCell>(module);
+}
+
+void THSNN_LSTMCell_set_weight_hh(const NNModule module, const Tensor weight)
+{
+    set_weight_hh<torch::nn::LSTMCell>(module, weight);
 }
 
 

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -320,6 +320,41 @@ EXPORT_API(Tensor)   THSNN_GRUCell_forward(const NNModule module, const Tensor i
 EXPORT_API(NNModule) THSNN_LSTMCell_ctor(const int64_t input_size, const int64_t hidden_size, const bool bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_LSTMCell_forward(const NNModule module, const Tensor input1, const Tensor h0, const Tensor c0, Tensor* c_n);
 
+EXPORT_API(Tensor) THSNN_RNN_bias_ih(const NNModule module, const int64_t idx);
+EXPORT_API(void) THSNN_RNN_set_bias_ih(const NNModule module, const Tensor bias, const int64_t idx);
+EXPORT_API(Tensor) THSNN_RNN_weight_ih(const NNModule module, const int64_t idx);
+EXPORT_API(void) THSNN_RNN_set_weight_ih(const NNModule module, const Tensor weight, const int64_t idx);
+EXPORT_API(Tensor) THSNN_RNN_bias_hh(const NNModule module, const int64_t idx);
+EXPORT_API(void) THSNN_RNN_set_bias_hh(const NNModule module, const Tensor bias, const int64_t idx);
+EXPORT_API(Tensor) THSNN_RNN_weight_hh(const NNModule module, const int64_t idx);
+EXPORT_API(void) THSNN_RNN_set_weight_hh(const NNModule module, const Tensor weight, const int64_t idx);
+
+EXPORT_API(Tensor) THSNN_RNNCell_bias_ih(const NNModule module);
+EXPORT_API(void) THSNN_RNNCell_set_bias_ih(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor) THSNN_RNNCell_weight_ih(const NNModule module);
+EXPORT_API(void) THSNN_RNNCell_set_weight_ih(const NNModule module, const Tensor weight);
+EXPORT_API(Tensor) THSNN_RNNCell_bias_hh(const NNModule module);
+EXPORT_API(void) THSNN_RNNCell_set_bias_hh(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor) THSNN_RNNCell_weight_hh(const NNModule module);
+EXPORT_API(void) THSNN_RNNCell_set_weight_hh(const NNModule module, const Tensor weight);
+
+EXPORT_API(Tensor) THSNN_LSTMCell_bias_ih(const NNModule module);
+EXPORT_API(void) THSNN_LSTMCell_set_bias_ih(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor) THSNN_LSTMCell_weight_ih(const NNModule module);
+EXPORT_API(void) THSNN_LSTMCell_set_weight_ih(const NNModule module, const Tensor weight);
+EXPORT_API(Tensor) THSNN_LSTMCell_bias_hh(const NNModule module);
+EXPORT_API(void) THSNN_LSTMCell_set_bias_hh(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor) THSNN_LSTMCell_weight_hh(const NNModule module);
+EXPORT_API(void) THSNN_LSTMCell_set_weight_hh(const NNModule module, const Tensor weight);
+
+EXPORT_API(Tensor) THSNN_GRUCell_bias_ih(const NNModule module);
+EXPORT_API(void) THSNN_GRUCell_set_bias_ih(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor) THSNN_GRUCell_weight_ih(const NNModule module);
+EXPORT_API(void) THSNN_GRUCell_set_weight_ih(const NNModule module, const Tensor weight);
+EXPORT_API(Tensor) THSNN_GRUCell_bias_hh(const NNModule module);
+EXPORT_API(void) THSNN_GRUCell_set_bias_hh(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor) THSNN_GRUCell_weight_hh(const NNModule module);
+EXPORT_API(void) THSNN_GRUCell_set_weight_hh(const NNModule module, const Tensor weight);
 
 // Containers
 

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -170,9 +170,17 @@ EXPORT_API(Tensor)   THSNN_BatchNorm1d_get_mean(const NNModule module);
 EXPORT_API(Tensor)   THSNN_BatchNorm2d_get_mean(const NNModule module);
 EXPORT_API(Tensor)   THSNN_BatchNorm3d_get_mean(const NNModule module);
 
-EXPORT_API(Tensor)     THSNN_BatchNorm1d_get_var(const NNModule module);
-EXPORT_API(Tensor)     THSNN_BatchNorm2d_get_var(const NNModule module);
-EXPORT_API(Tensor)     THSNN_BatchNorm3d_get_var(const NNModule module);
+EXPORT_API(void)     THSNN_BatchNorm1d_set_mean(const NNModule module, const Tensor weight);
+EXPORT_API(void)     THSNN_BatchNorm2d_set_mean(const NNModule module, const Tensor weight);
+EXPORT_API(void)     THSNN_BatchNorm3d_set_mean(const NNModule module, const Tensor weight);
+
+EXPORT_API(Tensor)   THSNN_BatchNorm1d_get_var(const NNModule module);
+EXPORT_API(Tensor)   THSNN_BatchNorm2d_get_var(const NNModule module);
+EXPORT_API(Tensor)   THSNN_BatchNorm3d_get_var(const NNModule module);
+
+EXPORT_API(void)     THSNN_BatchNorm1d_set_var(const NNModule module, const Tensor weight);
+EXPORT_API(void)     THSNN_BatchNorm2d_set_var(const NNModule module, const Tensor weight);
+EXPORT_API(void)     THSNN_BatchNorm3d_set_var(const NNModule module, const Tensor weight);
 
 EXPORT_API(NNModule) THSNN_InstanceNorm1d_ctor(const int64_t features, const double eps, const double momentum, const bool affine, const bool track_running_stats, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_InstanceNorm1d_forward(const NNModule module, const Tensor tensor);
@@ -183,6 +191,11 @@ EXPORT_API(Tensor)   THSNN_InstanceNorm3d_forward(const NNModule module, const T
 
 EXPORT_API(NNModule) THSNN_LayerNorm_ctor(const int64_t* norm_shape, const int64_t norm_shape_len, const double eps, const bool elementwise_affine, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_LayerNorm_forward(const NNModule module, const Tensor tensor);
+
+EXPORT_API(Tensor)   THSNN_LayerNorm_bias(const NNModule module);
+EXPORT_API(void)     THSNN_LayerNorm_set_bias(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor)   THSNN_LayerNorm_weight(const NNModule module);
+EXPORT_API(void)     THSNN_LayerNorm_set_weight(const NNModule module, const Tensor weight);
 
 EXPORT_API(NNModule) THSNN_GroupNorm_ctor(const int64_t num_groups, const int64_t num_channels, const double eps, const bool affine, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_GroupNorm_forward(const NNModule module, const Tensor tensor);

--- a/src/Native/LibTorchSharp/THSNormalization.cpp
+++ b/src/Native/LibTorchSharp/THSNormalization.cpp
@@ -128,12 +128,12 @@ NNModule THSNN_LayerNorm_ctor(const int64_t* norm_shape, const int64_t norm_shap
 {
     CATCH_RETURN_NNModule(
         std::vector<int64_t> normalized_shape;
-    for (int64_t i = 0; i < norm_shape_len; ++i)
-    {
-        normalized_shape.push_back(norm_shape[i]);
-    }
-    auto opts = torch::nn::LayerNormOptions(normalized_shape).eps(eps).elementwise_affine(elementwise_affine);
-    res = create_module<torch::nn::LayerNormImpl>(opts, outAsAnyModule);
+        for (int64_t i = 0; i < norm_shape_len; ++i)
+        {
+            normalized_shape.push_back(norm_shape[i]);
+        }
+        auto opts = torch::nn::LayerNormOptions(normalized_shape).eps(eps).elementwise_affine(elementwise_affine);
+        res = create_module<torch::nn::LayerNormImpl>(opts, outAsAnyModule);
     );
 }
 
@@ -141,6 +141,27 @@ Tensor THSNN_LayerNorm_forward(const NNModule module, const Tensor tensor)
 {
     CATCH_TENSOR((*module)->as<torch::nn::LayerNorm>()->forward(*tensor));
 }
+
+Tensor THSNN_LayerNorm_bias(const NNModule module)
+{
+    return get_bias<torch::nn::LayerNorm>(module);
+}
+
+void THSNN_LayerNorm_set_bias(const NNModule module, const Tensor bias)
+{
+    set_bias<torch::nn::LayerNorm>(module, bias);
+}
+
+Tensor THSNN_LayerNorm_weight(const NNModule module)
+{
+    return get_weight<torch::nn::LayerNorm>(module);
+}
+
+void THSNN_LayerNorm_set_weight(const NNModule module, const Tensor weight)
+{
+    set_weight<torch::nn::LayerNorm>(module, weight);
+}
+
 
 NNModule THSNN_LocalResponseNorm_ctor(const int64_t size, const double alpha, const double beta, const double k, NNAnyModule* outAsAnyModule)
 {
@@ -179,6 +200,20 @@ Tensor THSNN_BatchNorm1d_get_var(const NNModule module)
         return v.defined() ? ResultTensor(v) : nullptr;
     );
     return nullptr;
+}
+
+void THSNN_BatchNorm1d_set_mean(const NNModule module, const Tensor bias)
+{
+    CATCH(
+        (*module)->as<torch::nn::BatchNorm1d>()->running_mean = *bias;
+    );
+}
+
+void THSNN_BatchNorm1d_set_var(const NNModule module, const Tensor bias)
+{
+    CATCH(
+        (*module)->as<torch::nn::BatchNorm1d>()->running_var = *bias;
+    );
 }
 
 Tensor THSNN_BatchNorm1d_bias(const NNModule module)
@@ -224,6 +259,20 @@ Tensor THSNN_BatchNorm2d_get_var(const NNModule module)
     return nullptr;
 }
 
+void THSNN_BatchNorm2d_set_mean(const NNModule module, const Tensor bias)
+{
+    CATCH(
+        (*module)->as<torch::nn::BatchNorm2d>()->running_mean = *bias;
+    );
+}
+
+void THSNN_BatchNorm2d_set_var(const NNModule module, const Tensor bias)
+{
+    CATCH(
+        (*module)->as<torch::nn::BatchNorm2d>()->running_var = *bias;
+    );
+}
+
 Tensor THSNN_BatchNorm2d_bias(const NNModule module)
 {
     return get_bias<torch::nn::BatchNorm2d>(module);
@@ -265,6 +314,20 @@ Tensor THSNN_BatchNorm3d_get_var(const NNModule module)
     return v.defined() ? ResultTensor(v) : nullptr;
     );
     return nullptr;
+}
+
+void THSNN_BatchNorm3d_set_mean(const NNModule module, const Tensor bias)
+{
+    CATCH(
+        (*module)->as<torch::nn::BatchNorm3d>()->running_mean = *bias;
+    );
+}
+
+void THSNN_BatchNorm3d_set_var(const NNModule module, const Tensor bias)
+{
+    CATCH(
+        (*module)->as<torch::nn::BatchNorm3d>()->running_var = *bias;
+    );
 }
 
 Tensor THSNN_BatchNorm3d_bias(const NNModule module)

--- a/src/Native/LibTorchSharp/Utils.h
+++ b/src/Native/LibTorchSharp/Utils.h
@@ -125,6 +125,123 @@ void set_bias(const NNModule module, const Tensor bias)
     );
 }
 
+template <typename T>
+Tensor get_weight_ih(const NNModule module)
+{
+    CATCH_TENSOR((*module)->as<T>()->weight_ih);
+}
+
+template <typename T>
+Tensor get_weight_hh(const NNModule module)
+{
+    CATCH_TENSOR((*module)->as<T>()->weight_hh);
+}
+
+template <typename T>
+void set_weight_ih(const NNModule module, const Tensor weights)
+{
+    CATCH(
+        (*module)->as<T>()->weight_ih = *weights;
+    );
+}
+
+template <typename T>
+void set_weight_hh(const NNModule module, const Tensor weights)
+{
+    CATCH(
+        (*module)->as<T>()->weight_hh = *weights;
+    );
+}
+
+template <typename T>
+Tensor get_bias_ih(const NNModule module)
+{
+    CATCH_TENSOR((*module)->as<T>()->bias_ih);
+}
+
+template <typename T>
+Tensor get_bias_hh(const NNModule module)
+{
+    CATCH_TENSOR((*module)->as<T>()->bias_hh);
+}
+
+template <typename T>
+void set_bias_ih(const NNModule module, const Tensor bias)
+{
+    CATCH(
+        (*module)->as<T>()->bias_ih = *bias;
+    );
+}
+
+template <typename T>
+void set_bias_hh(const NNModule module, const Tensor bias)
+{
+    CATCH(
+        (*module)->as<T>()->bias_hh = *bias;
+    );
+}
+
+#define WIH_BASE 0
+#define WHH_BASE 1
+#define BIH_BASE 2
+#define BHH_BASE 3
+
+template <typename T>
+Tensor get_weight_ih(const NNModule module, const int64_t idx)
+{
+    CATCH_TENSOR((*module)->as<T>()->all_weights()[WIH_BASE + idx * 4]);
+}
+
+template <typename T>
+Tensor get_weight_hh(const NNModule module, const int64_t idx)
+{
+    CATCH_TENSOR((*module)->as<T>()->all_weights()[WHH_BASE + idx * 4]);
+}
+
+template <typename T>
+void set_weight_ih(const NNModule module, const Tensor weights, const int64_t idx)
+{
+    CATCH(
+        (*module)->as<T>()->all_weights()[WIH_BASE + idx * 4] = *weights;
+    );
+}
+
+template <typename T>
+void set_weight_hh(const NNModule module, const Tensor weights, const int64_t idx)
+{
+    CATCH(
+        (*module)->as<T>()->all_weights()[WHH_BASE + idx * 4] = *weights;
+    );
+}
+
+template <typename T>
+Tensor get_bias_ih(const NNModule module, const int64_t idx)
+{
+    CATCH_TENSOR((*module)->as<T>()->all_weights()[BIH_BASE + idx * 4]);
+}
+
+template <typename T>
+Tensor get_bias_hh(const NNModule module, const int64_t idx)
+{
+    CATCH_TENSOR((*module)->as<T>()->all_weights()[BHH_BASE + idx * 4]);
+}
+
+template <typename T>
+void set_bias_ih(const NNModule module, const Tensor bias, const int64_t idx)
+{
+    CATCH(
+        (*module)->as<T>()->all_weights()[BIH_BASE + idx * 4] = *bias;
+    );
+}
+
+template <typename T>
+void set_bias_hh(const NNModule module, const Tensor bias, const int64_t idx)
+{
+    CATCH(
+        (*module)->as<T>()->all_weights()[BHH_BASE + idx * 4] = *bias;
+    );
+}
+
 template<typename TImpl>
 NNModule create_module(NNAnyModule* outAsAnyModule)
 {

--- a/src/TorchSharp/NN/Bilinear.cs
+++ b/src/TorchSharp/NN/Bilinear.cs
@@ -37,11 +37,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Bilinear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias {
+            public Parameter? bias {
                 get {
                     var res = THSNN_Bilinear_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_Bilinear_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -54,11 +54,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Bilinear_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_Bilinear_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_Bilinear_set_weight(handle, value.Handle);
@@ -97,7 +97,7 @@ namespace TorchSharp
                 /// Applies a bilinear transformation to the incoming data
                 /// </summary>
                 /// <returns></returns>
-                static public Tensor bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias = null)
+                static public Tensor bilinear(Tensor input1, Tensor input2, Modules.Parameter weight, Modules.Parameter? bias = null)
                 {
                     var in1Features = input1.shape[^1];
                     var in2Features = input2.shape[^1];

--- a/src/TorchSharp/NN/Bilinear.cs
+++ b/src/TorchSharp/NN/Bilinear.cs
@@ -46,6 +46,7 @@ namespace TorchSharp
                 set {
                     THSNN_Bilinear_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
             [DllImport("LibTorchSharp")]
@@ -62,6 +63,7 @@ namespace TorchSharp
                 set {
                     THSNN_Bilinear_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Convolution/Conv1D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv1D.cs
@@ -53,6 +53,7 @@ namespace TorchSharp
                 set {
                     THSNN_Conv1d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
             [DllImport("LibTorchSharp")]
@@ -69,6 +70,7 @@ namespace TorchSharp
                 set {
                     THSNN_Conv1d_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Convolution/Conv1D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv1D.cs
@@ -44,11 +44,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Conv1d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias {
+            public Parameter? bias {
                 get {
                     var res = THSNN_Conv1d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_Conv1d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -61,11 +61,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Conv1d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_Conv1d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_Conv1d_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/Convolution/Conv2D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv2D.cs
@@ -29,11 +29,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Conv2d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias {
+            public Parameter? bias {
                 get {
                     var res = THSNN_Conv2d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_Conv2d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -46,11 +46,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Conv2d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_Conv2d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_Conv2d_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/Convolution/Conv2D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv2D.cs
@@ -38,6 +38,7 @@ namespace TorchSharp
                 set {
                     THSNN_Conv2d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
             [DllImport("LibTorchSharp")]
@@ -54,6 +55,7 @@ namespace TorchSharp
                 set {
                     THSNN_Conv2d_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Convolution/Conv3D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv3D.cs
@@ -29,11 +29,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Conv3d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias {
+            public Parameter? bias {
                 get {
                     var res = THSNN_Conv3d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_Conv3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -46,11 +46,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Conv3d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_Conv3d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_Conv3d_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/Convolution/Conv3D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv3D.cs
@@ -38,6 +38,7 @@ namespace TorchSharp
                 set {
                     THSNN_Conv3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
             [DllImport("LibTorchSharp")]
@@ -54,6 +55,7 @@ namespace TorchSharp
                 set {
                     THSNN_Conv3d_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
@@ -38,6 +38,7 @@ namespace TorchSharp
                 set {
                     THSNN_ConvTranspose1d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
             [DllImport("LibTorchSharp")]
@@ -54,6 +55,7 @@ namespace TorchSharp
                 set {
                     THSNN_ConvTranspose1d_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
@@ -29,11 +29,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_ConvTranspose1d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias {
+            public Parameter? bias {
                 get {
                     var res = THSNN_ConvTranspose1d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_ConvTranspose1d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -46,11 +46,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_ConvTranspose1d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_ConvTranspose1d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_ConvTranspose1d_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
@@ -29,11 +29,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_ConvTranspose2d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias {
+            public Parameter? bias {
                 get {
                     var res = THSNN_ConvTranspose2d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_ConvTranspose2d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -46,12 +46,12 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_ConvTranspose2d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight
+            public Parameter weight
                 {
                 get {
                     var res = THSNN_ConvTranspose2d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_ConvTranspose2d_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
@@ -38,6 +38,7 @@ namespace TorchSharp
                 set {
                     THSNN_ConvTranspose2d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
             [DllImport("LibTorchSharp")]
@@ -55,6 +56,7 @@ namespace TorchSharp
                 set {
                     THSNN_ConvTranspose2d_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
@@ -29,11 +29,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_ConvTranspose3d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias {
+            public Parameter? bias {
                 get {
                     var res = THSNN_ConvTranspose3d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_ConvTranspose3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -46,11 +46,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_ConvTranspose3d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_ConvTranspose3d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_ConvTranspose3d_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
@@ -38,6 +38,7 @@ namespace TorchSharp
                 set {
                     THSNN_ConvTranspose3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
             [DllImport("LibTorchSharp")]
@@ -54,6 +55,7 @@ namespace TorchSharp
                 set {
                     THSNN_ConvTranspose3d_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Embedding.cs
+++ b/src/TorchSharp/NN/Embedding.cs
@@ -38,6 +38,7 @@ namespace TorchSharp
                 set {
                     THSNN_Embedding_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Embedding.cs
+++ b/src/TorchSharp/NN/Embedding.cs
@@ -29,11 +29,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Embedding_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_Embedding_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_Embedding_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -89,11 +89,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_EmbeddingBag_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_EmbeddingBag_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_EmbeddingBag_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -98,6 +98,7 @@ namespace TorchSharp
                 set {
                     THSNN_EmbeddingBag_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -16,7 +16,9 @@ namespace TorchSharp
     {
         public class Linear : torch.nn.Module
         {
-            internal Linear(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+            internal Linear(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
+            {
+            }
 
             public new static Linear Load(String modelPath)
             {
@@ -33,11 +35,11 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
+
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_Linear_bias(torch.nn.Module.HType module);
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Linear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
-
             public Tensor? bias {
                 get {
                     var res = THSNN_Linear_bias(handle);
@@ -47,8 +49,10 @@ namespace TorchSharp
                 set {
                     THSNN_Linear_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
+
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_Linear_weight(torch.nn.Module.HType module);
             [DllImport("LibTorchSharp")]
@@ -63,6 +67,7 @@ namespace TorchSharp
                 set {
                     THSNN_Linear_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
         }

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -40,11 +40,11 @@ namespace TorchSharp
             extern static IntPtr THSNN_Linear_bias(torch.nn.Module.HType module);
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Linear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
-            public Tensor? bias {
+            public Parameter? bias {
                 get {
                     var res = THSNN_Linear_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_Linear_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -58,11 +58,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_Linear_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_Linear_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_Linear_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -260,7 +260,7 @@ namespace TorchSharp
                 /// <returns></returns>
                 public virtual Module apply(Action<Module> fn)
                 {
-                    foreach (var m in GetModulesInternal()) m.apply(fn);
+                    foreach (var (_,m) in _internal_submodules) m.apply(fn);
                     fn(this);
                     return this;
                 }
@@ -632,29 +632,6 @@ namespace TorchSharp
                             _internal_buffers.Add(name, value);
                         }
                     }
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern long THSNN_Module_children_size(HType module);
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_Module_child(HType module, int index);
-
-                /// Get the sub-modules of this module. The Module objects won't have the correct .NET types
-                /// so this is not made public.
-                internal virtual Module[] GetModulesInternal()
-                {
-                    var numModules = THSNN_Module_children_size(handle);
-                    torch.CheckForErrors();
-                    Module[] result = new Module[numModules];
-
-                    for (int i = 0; i < numModules; i++) {
-                        var childHandle = THSNN_Module_child(handle, i);
-                        torch.CheckForErrors();
-                        result[i] = new Module(childHandle, null, ownsHandle: false);
-                    }
-
-                    return result;
                 }
 
                 [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -370,20 +370,20 @@ namespace TorchSharp
                 public Dictionary<string, Tensor> state_dict()
                 {
                     var res = new Dictionary<string, Tensor>();
-                    state_dict(res);
+                    state_dict("", res);
                     return res;
                 }
 
-                protected virtual void state_dict(Dictionary<string, Tensor> res)
+                protected virtual void state_dict(string prefix, Dictionary<string, Tensor> res)
                 {
                     foreach (var p in named_parameters()) {
-                        res.Add(p.Item1, p.Item2);
+                        res.TryAdd(p.Item1, p.Item2);
                     }
                     foreach (var p in named_buffers()) {
-                        res.Add(p.Item1, p.Item2);
+                        res.TryAdd(p.Item1, p.Item2);
                     }
-                    foreach (var p in _internal_submodules.Values) {
-                        p.state_dict(res);
+                    foreach (var (n,p) in _internal_submodules) {
+                        p.state_dict(String.IsNullOrEmpty(prefix) ? $"{n}" : $"{prefix}.{n}", res);
                     }
                 }
 

--- a/src/TorchSharp/NN/ModuleDict.cs
+++ b/src/TorchSharp/NN/ModuleDict.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Linq;
+using System.Dynamic;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -94,6 +95,26 @@ namespace TorchSharp
                 }
             }
 
+            public override bool TryGetMember(GetMemberBinder binder, out object result)
+            {
+                var ok = _dict.TryGetValue(binder.Name, out var res);
+                result = ok ? res : null;
+                return ok;
+            }
+
+            public override bool TrySetMember(SetMemberBinder binder, object value)
+            {
+                var name = binder.Name;
+                var submodule = value as Module;
+                if (submodule is not null) {
+                    this[name] = submodule;
+                } else if (_dict.ContainsKey(name)) {
+                    Remove(name);
+                }
+
+                return false;
+            }
+
             public void Add((string, Module) item)
             {
                 _dict.Add(item.Item1, item.Item2);
@@ -129,17 +150,22 @@ namespace TorchSharp
 
             public void Insert(int index, (string, Module) item)
             {
+                _dict.Add(item.Item1, item.Item2);
                 _list.Insert(index, item);
             }
 
             public bool Remove((string, Module) item)
             {
+                _dict.Remove(item.Item1);
                 return _list.Remove(item);
             }
 
             public void RemoveAt(int index)
             {
+                if (index >= _list.Count) throw new IndexOutOfRangeException();
+                var (n, p) = _list[index];
                 _list.RemoveAt(index);
+                _dict.Remove(n);
             }
 
             public bool ContainsKey(string key)

--- a/src/TorchSharp/NN/ModuleDict.cs
+++ b/src/TorchSharp/NN/ModuleDict.cs
@@ -70,7 +70,11 @@ namespace TorchSharp
 
             public (string, Module) this[int index] {
                 get => _list[index];
-                set => _list[index] = value;
+                set {
+                    var name = value.Item1;
+                    _list[index] = value;
+                    _dict[name] = value.Item2;
+                }
             }
 
             public bool IsReadOnly => false;
@@ -81,7 +85,14 @@ namespace TorchSharp
 
             public int Count => _dict.Count;
 
-            public Module this[string key] { get => _dict[key]; set => _dict[key] = value; }
+            public Module this[string key] {
+                get => _dict[key];
+                set {
+                    _dict[key] = value;
+                    var idx = _list.FindIndex(kv => kv.Item1.Equals(key));
+                    _list[idx] = (key, value);
+                }
+            }
 
             public void Add((string, Module) item)
             {

--- a/src/TorchSharp/NN/ModuleDict.cs
+++ b/src/TorchSharp/NN/ModuleDict.cs
@@ -95,26 +95,6 @@ namespace TorchSharp
                 }
             }
 
-            public override bool TryGetMember(GetMemberBinder binder, out object result)
-            {
-                var ok = _dict.TryGetValue(binder.Name, out var res);
-                result = ok ? res : null;
-                return ok;
-            }
-
-            public override bool TrySetMember(SetMemberBinder binder, object value)
-            {
-                var name = binder.Name;
-                var submodule = value as Module;
-                if (submodule is not null) {
-                    this[name] = submodule;
-                } else if (_dict.ContainsKey(name)) {
-                    Remove(name);
-                }
-
-                return false;
-            }
-
             public void Add((string, Module) item)
             {
                 _dict.Add(item.Item1, item.Item2);

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -52,11 +52,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern void THSNN_BatchNorm1d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
-            public Tensor bias {
+            public Parameter bias {
                 get {
                     var res = THSNN_BatchNorm1d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm1d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -65,11 +65,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_BatchNorm1d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm1d_set_weight(handle, value.Handle);
@@ -78,11 +78,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? running_mean {
+            public Parameter? running_mean {
                 get {
                     var res = THSNN_BatchNorm1d_get_mean(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm1d_set_mean(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -91,11 +91,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? running_var {
+            public Parameter? running_var {
                 get {
                     var res = THSNN_BatchNorm1d_get_var(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm1d_set_var(handle, (value is null ? IntPtr.Zero : value.Handle));

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -104,12 +104,15 @@ namespace TorchSharp
                 }
             }
 
-            protected override void state_dict(string prefix, Dictionary<string, Tensor> res)
+            protected override Dictionary<string, Tensor> state_dict(Dictionary<string, Tensor>? destination = null, string? prefix = null)
             {
+                if (destination == null)
+                    destination = new Dictionary<string, Tensor>();
                 var v = running_var;
                 var m = running_mean;
-                if (v is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
-                if (m is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
+                if (v is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
+                if (m is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
+                return destination;
             }
 
             public void reset_running_stats()

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -47,6 +47,10 @@ namespace TorchSharp
             private static extern IntPtr THSNN_BatchNorm1d_get_mean(torch.nn.Module.HType module);
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_BatchNorm1d_get_var(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_BatchNorm1d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_BatchNorm1d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Tensor bias {
                 get {
@@ -80,6 +84,11 @@ namespace TorchSharp
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
                     return new Tensor(res);
                 }
+                set {
+                    THSNN_BatchNorm1d_set_mean(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
+                }
             }
 
             public Tensor? running_var {
@@ -87,6 +96,11 @@ namespace TorchSharp
                     var res = THSNN_BatchNorm1d_get_var(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
                     return new Tensor(res);
+                }
+                set {
+                    THSNN_BatchNorm1d_set_var(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
 

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -104,17 +104,6 @@ namespace TorchSharp
                 }
             }
 
-            protected override Dictionary<string, Tensor> state_dict(Dictionary<string, Tensor>? destination = null, string? prefix = null)
-            {
-                if (destination == null)
-                    destination = new Dictionary<string, Tensor>();
-                var v = running_var;
-                var m = running_mean;
-                if (v is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
-                if (m is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
-                return destination;
-            }
-
             public void reset_running_stats()
             {
                 THSNN_BatchNorm1d_reset_stats(handle);

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -104,12 +104,12 @@ namespace TorchSharp
                 }
             }
 
-            protected override void state_dict(Dictionary<string, Tensor> res)
+            protected override void state_dict(string prefix, Dictionary<string, Tensor> res)
             {
                 var v = running_var;
                 var m = running_mean;
-                if (v is not null) res.Add("running_var", v);
-                if (m is not null) res.Add("running_mean", m);
+                if (v is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
+                if (m is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
             }
 
             public void reset_running_stats()

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
+using System.Collections.Generic;
+
 using static TorchSharp.torch;
 
 #nullable enable
@@ -54,6 +56,7 @@ namespace TorchSharp
                 set {
                     THSNN_BatchNorm2d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
 
@@ -66,6 +69,7 @@ namespace TorchSharp
                 set {
                     THSNN_BatchNorm2d_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
 
@@ -89,6 +93,14 @@ namespace TorchSharp
             {
                 THSNN_BatchNorm2d_reset_stats(handle);
                 torch.CheckForErrors();
+            }
+
+            protected override void state_dict(Dictionary<string, Tensor> res)
+            {
+                var v = running_var;
+                var m = running_mean;
+                if (v is not null) res.Add("running_var", v);
+                if (m is not null) res.Add("running_mean", m);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -46,6 +46,10 @@ namespace TorchSharp
             private static extern IntPtr THSNN_BatchNorm2d_get_mean(torch.nn.Module.HType module);
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_BatchNorm2d_get_var(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_BatchNorm2d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_BatchNorm2d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Tensor bias {
                 get {
@@ -79,6 +83,11 @@ namespace TorchSharp
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
                     return new Tensor(res);
                 }
+                set {
+                    THSNN_BatchNorm2d_set_mean(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
+                }
             }
 
             public Tensor? running_var {
@@ -86,6 +95,11 @@ namespace TorchSharp
                     var res = THSNN_BatchNorm2d_get_var(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
                     return new Tensor(res);
+                }
+                set {
+                    THSNN_BatchNorm2d_set_var(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
 

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -50,11 +50,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern void THSNN_BatchNorm2d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
-            public Tensor bias {
+            public Parameter bias {
                 get {
                     var res = THSNN_BatchNorm2d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm2d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -63,11 +63,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_BatchNorm2d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm2d_set_weight(handle, value.Handle);
@@ -76,11 +76,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor running_mean {
+            public Parameter running_mean {
                 get {
                     var res = THSNN_BatchNorm2d_get_mean(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm2d_set_mean(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -89,11 +89,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor running_var {
+            public Parameter running_var {
                 get {
                     var res = THSNN_BatchNorm2d_get_var(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm2d_set_var(handle, (value is null ? IntPtr.Zero : value.Handle));

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 
 using static TorchSharp.torch;
 
-#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -77,7 +76,7 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? running_mean {
+            public Tensor running_mean {
                 get {
                     var res = THSNN_BatchNorm2d_get_mean(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
@@ -90,7 +89,7 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? running_var {
+            public Tensor running_var {
                 get {
                     var res = THSNN_BatchNorm2d_get_var(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
@@ -109,12 +108,15 @@ namespace TorchSharp
                 torch.CheckForErrors();
             }
 
-            protected override void state_dict(string prefix, Dictionary<string, Tensor> res)
+            protected override Dictionary<string, Tensor> state_dict(Dictionary<string, Tensor> destination = null, string prefix = null)
             {
+                if (destination == null)
+                    destination = new Dictionary<string, Tensor>();
                 var v = running_var;
                 var m = running_mean;
-                if (v is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
-                if (m is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
+                if (v is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
+                if (m is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
+                return destination;
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -107,17 +107,6 @@ namespace TorchSharp
                 THSNN_BatchNorm2d_reset_stats(handle);
                 torch.CheckForErrors();
             }
-
-            protected override Dictionary<string, Tensor> state_dict(Dictionary<string, Tensor> destination = null, string prefix = null)
-            {
-                if (destination == null)
-                    destination = new Dictionary<string, Tensor>();
-                var v = running_var;
-                var m = running_mean;
-                if (v is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
-                if (m is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
-                return destination;
-            }
         }
     }
 

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -109,12 +109,12 @@ namespace TorchSharp
                 torch.CheckForErrors();
             }
 
-            protected override void state_dict(Dictionary<string, Tensor> res)
+            protected override void state_dict(string prefix, Dictionary<string, Tensor> res)
             {
                 var v = running_var;
                 var m = running_mean;
-                if (v is not null) res.Add("running_var", v);
-                if (m is not null) res.Add("running_mean", m);
+                if (v is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
+                if (m is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -51,11 +51,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern void THSNN_BatchNorm3d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
-            public Tensor bias {
+            public Parameter bias {
                 get {
                     var res = THSNN_BatchNorm3d_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -64,11 +64,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_BatchNorm3d_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm3d_set_weight(handle, value.Handle);
@@ -77,11 +77,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? running_mean {
+            public Parameter? running_mean {
                 get {
                     var res = THSNN_BatchNorm3d_get_mean(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm3d_set_mean(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -90,11 +90,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? running_var {
+            public Parameter? running_var {
                 get {
                     var res = THSNN_BatchNorm3d_get_var(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_BatchNorm3d_set_var(handle, (value is null ? IntPtr.Zero : value.Handle));

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
+using System.Collections.Generic;
+
 using static TorchSharp.torch;
 
 #nullable enable
@@ -54,6 +56,7 @@ namespace TorchSharp
                 set {
                     THSNN_BatchNorm3d_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
 
@@ -66,6 +69,7 @@ namespace TorchSharp
                 set {
                     THSNN_BatchNorm3d_set_weight(handle, value.Handle);
                     torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
                 }
             }
 
@@ -89,6 +93,14 @@ namespace TorchSharp
             {
                 THSNN_BatchNorm3d_reset_stats(handle);
                 torch.CheckForErrors();
+            }
+
+            protected override void state_dict(Dictionary<string, Tensor> res)
+            {
+                var v = running_var;
+                var m = running_mean;
+                if (v is not null) res.Add("running_var", v);
+                if (m is not null) res.Add("running_mean", m);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -109,12 +109,15 @@ namespace TorchSharp
                 torch.CheckForErrors();
             }
 
-            protected override void state_dict(string prefix, Dictionary<string, Tensor> res)
+            protected override Dictionary<string, Tensor> state_dict(Dictionary<string, Tensor>? destination = null, string? prefix = null)
             {
+                if (destination == null)
+                    destination = new Dictionary<string, Tensor>();
                 var v = running_var;
                 var m = running_mean;
-                if (v is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
-                if (m is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
+                if (v is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
+                if (m is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
+                return destination;
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -46,6 +46,10 @@ namespace TorchSharp
             private static extern IntPtr THSNN_BatchNorm3d_get_mean(torch.nn.Module.HType module);
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_BatchNorm3d_get_var(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_BatchNorm3d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_BatchNorm3d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Tensor bias {
                 get {
@@ -79,6 +83,11 @@ namespace TorchSharp
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
                     return new Tensor(res);
                 }
+                set {
+                    THSNN_BatchNorm3d_set_mean(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
+                }
             }
 
             public Tensor? running_var {
@@ -86,6 +95,11 @@ namespace TorchSharp
                     var res = THSNN_BatchNorm3d_get_var(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); return null; }
                     return new Tensor(res);
+                }
+                set {
+                    THSNN_BatchNorm3d_set_var(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
                 }
             }
 

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -108,17 +108,6 @@ namespace TorchSharp
                 THSNN_BatchNorm3d_reset_stats(handle);
                 torch.CheckForErrors();
             }
-
-            protected override Dictionary<string, Tensor> state_dict(Dictionary<string, Tensor>? destination = null, string? prefix = null)
-            {
-                if (destination == null)
-                    destination = new Dictionary<string, Tensor>();
-                var v = running_var;
-                var m = running_mean;
-                if (v is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
-                if (m is not null) destination.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
-                return destination;
-            }
         }
     }
 

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -109,12 +109,12 @@ namespace TorchSharp
                 torch.CheckForErrors();
             }
 
-            protected override void state_dict(Dictionary<string, Tensor> res)
+            protected override void state_dict(string prefix, Dictionary<string, Tensor> res)
             {
                 var v = running_var;
                 var m = running_mean;
-                if (v is not null) res.Add("running_var", v);
-                if (m is not null) res.Add("running_mean", m);
+                if (v is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_var" : $"{prefix}.running_var", v);
+                if (m is not null) res.Add(String.IsNullOrEmpty(prefix) ? "running_mean" : $"{prefix}.running_mean", m);
             }
         }
     }

--- a/src/TorchSharp/NN/Normalization/LayerNorm.cs
+++ b/src/TorchSharp/NN/Normalization/LayerNorm.cs
@@ -38,11 +38,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern void THSNN_LayerNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
 
-            public Tensor bias {
+            public Parameter bias {
                 get {
                     var res = THSNN_LayerNorm_bias(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_LayerNorm_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -51,11 +51,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor weight {
+            public Parameter weight {
                 get {
                     var res = THSNN_LayerNorm_weight(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_LayerNorm_set_weight(handle, value.Handle);

--- a/src/TorchSharp/NN/Normalization/LayerNorm.cs
+++ b/src/TorchSharp/NN/Normalization/LayerNorm.cs
@@ -28,6 +28,41 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
+
+            [DllImport("LibTorchSharp")]
+            private static extern IntPtr THSNN_LayerNorm_bias(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_LayerNorm_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            [DllImport("LibTorchSharp")]
+            private static extern IntPtr THSNN_LayerNorm_weight(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_LayerNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+            public Tensor bias {
+                get {
+                    var res = THSNN_LayerNorm_bias(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+                set {
+                    THSNN_LayerNorm_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
+                }
+            }
+
+            public Tensor weight {
+                get {
+                    var res = THSNN_LayerNorm_weight(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+                set {
+                    THSNN_LayerNorm_set_weight(handle, value.Handle);
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
+                }
+            }
         }
     }
 

--- a/src/TorchSharp/NN/Optimizer.cs
+++ b/src/TorchSharp/NN/Optimizer.cs
@@ -149,7 +149,7 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             private static extern IntPtr THSNN_LBFGS_ctor(IntPtr parameters, int len, double learningRate, long max_iter, long max_eval, double tolerange_grad, double tolerance_change, long history_size);
 
-            public static LBFGSOptimizer LBFGS(IEnumerable<Tensor> parameters, double learningRate = 0.01, long max_iter = 20, long? max_eval = null, double tolerange_grad = 1e-5, double tolerance_change = 1e-9, long history_size = 100)
+            public static LBFGSOptimizer LBFGS(IEnumerable<Parameter> parameters, double learningRate = 0.01, long max_iter = 20, long? max_eval = null, double tolerange_grad = 1e-5, double tolerance_change = 1e-9, long history_size = 100)
             {
                 if (!max_eval.HasValue) max_eval = 5 * max_iter / 4;
 
@@ -177,7 +177,7 @@ namespace TorchSharp
             /// <param name="momentum">Momentum factor (default: 0)</param>
             /// <param name="centered">if true, compute the centered RMSProp, the gradient is normalized by an estimation of its variance</param>
             /// <returns></returns>
-            public static RMSPropOptimizer RMSProp(IEnumerable<Tensor> parameters, double learningRate = 0.01, double alpha = 0.99, double eps = 1e-8, double weight_decay = 0, double momentum = 0, bool centered = false)
+            public static RMSPropOptimizer RMSProp(IEnumerable<Parameter> parameters, double learningRate = 0.01, double alpha = 0.99, double eps = 1e-8, double weight_decay = 0, double momentum = 0, bool centered = false)
             {
                 var parray = new PinnedArray<IntPtr>();
                 IntPtr paramsRef = parray.CreateArray(parameters.Select(p => p.Handle).ToArray());
@@ -203,7 +203,7 @@ namespace TorchSharp
             /// <param name="weight_decay">Weight decay (L2 penalty) (default: 0)</param>
             /// <param name="amsgrad">Whether to use the AMSGrad variant of this algorithm. (default: False)</param>
             /// <returns></returns>
-            public static AdamOptimizer Adam(IEnumerable<Tensor> parameters, double learningRate = 1e-3, double beta1 = 0.9, double beta2 = 0.99, double eps = 1e-8, double weight_decay = 0, bool amsgrad = false)
+            public static AdamOptimizer Adam(IEnumerable<Parameter> parameters, double learningRate = 1e-3, double beta1 = 0.9, double beta2 = 0.99, double eps = 1e-8, double weight_decay = 0, bool amsgrad = false)
             {
                 var parray = new PinnedArray<IntPtr>();
                 IntPtr paramsRef = parray.CreateArray(parameters.Select(p => p.Handle).ToArray());
@@ -229,7 +229,7 @@ namespace TorchSharp
             /// <param name="weight_decay">Weight decay (L2 penalty) (default: 0)</param>
             /// <param name="amsgrad">Whether to use the AMSGrad variant of this algorithm. (default: False)</param>
             /// <returns></returns>
-            public static AdamWOptimizer AdamW(IEnumerable<Tensor> parameters, double learningRate = 1e-3, double beta1 = 0.9, double beta2 = 0.99, double eps = 1e-8, double weight_decay = 0, bool amsgrad = false)
+            public static AdamWOptimizer AdamW(IEnumerable<Parameter> parameters, double learningRate = 1e-3, double beta1 = 0.9, double beta2 = 0.99, double eps = 1e-8, double weight_decay = 0, bool amsgrad = false)
             {
                 var parray = new PinnedArray<IntPtr>();
                 IntPtr paramsRef = parray.CreateArray(parameters.Select(p => p.Handle).ToArray());
@@ -254,7 +254,7 @@ namespace TorchSharp
             /// <param name="initial_accumulator_value"></param>
             /// <param name="eps">Term added to the denominator to improve numerical stability (default: 1e-10)</param>
             /// <returns></returns>
-            public static AdagradOptimizer Adagrad(IEnumerable<Tensor> parameters, double learningRate = 1e-2, double lr_decay = 0, double weight_decay = 0, double initial_accumulator_value = 0, double eps = 1e-10)
+            public static AdagradOptimizer Adagrad(IEnumerable<Parameter> parameters, double learningRate = 1e-2, double lr_decay = 0, double weight_decay = 0, double initial_accumulator_value = 0, double eps = 1e-10)
             {
                 var parray = new PinnedArray<IntPtr>();
                 IntPtr paramsRef = parray.CreateArray(parameters.Select(p => p.Handle).ToArray());
@@ -377,7 +377,7 @@ namespace TorchSharp
             /// <param name="weight_decay">Weight decay (L2 penalty) (default: 0)</param>
             /// <param name="nesterov">Enables Nesterov momentum (default: False)</param>
             /// <returns></returns>
-            public static SGDOptimizer SGD(IEnumerable<Tensor> parameters, double learningRate, double momentum = 0, double dampening = 0, double weight_decay = 0, bool nesterov = false)
+            public static SGDOptimizer SGD(IEnumerable<Parameter> parameters, double learningRate, double momentum = 0, double dampening = 0, double weight_decay = 0, bool nesterov = false)
             {
                 var parray = new PinnedArray<IntPtr>();
                 IntPtr paramsRef = parray.CreateArray(parameters.Select(p => p.Handle).ToArray());

--- a/src/TorchSharp/NN/ParameterDict.cs
+++ b/src/TorchSharp/NN/ParameterDict.cs
@@ -70,7 +70,11 @@ namespace TorchSharp
 
             public (string, Parameter) this[int index] {
                 get => _list[index];
-                set => _list[index] = value;
+                set {
+                    var name = value.Item1;
+                    _list[index] = value;
+                    _dict[name] = value.Item2;
+                }
             }
 
             public bool IsReadOnly => false;
@@ -81,7 +85,14 @@ namespace TorchSharp
 
             public int Count => _dict.Count;
 
-            public Parameter this[string key] { get => _dict[key]; set => _dict[key] = value; }
+            public Parameter this[string key] {
+                get => _dict[key];
+                set {
+                    _dict[key] = value;
+                    var idx = _list.FindIndex(kv => kv.Item1.Equals(key));
+                    _list[idx] = (key, value);
+                }
+            }
 
             public void Add((string, Parameter) item)
             {

--- a/src/TorchSharp/NN/ParameterDict.cs
+++ b/src/TorchSharp/NN/ParameterDict.cs
@@ -108,27 +108,6 @@ namespace TorchSharp
                 return null;
             }
 
-            public override bool TryGetMember(GetMemberBinder binder, out object result)
-            {
-                var ok = _dict.TryGetValue(binder.Name, out var res);
-                result = ok ? res : null;
-                return ok;
-            }
-
-            public override bool TrySetMember(SetMemberBinder binder, object value)
-            {
-                var name = binder.Name;
-                var parameter = value as Parameter;
-                if (parameter is not null) {
-                    this[name] = parameter;
-                }
-                else if (_dict.ContainsKey(name)) {
-                    Remove(name);
-                }
-
-                return false;
-            }
-
             public void Add((string, Parameter) item)
             {
                 _dict.Add(item.Item1, item.Item2);

--- a/src/TorchSharp/NN/ParameterDict.cs
+++ b/src/TorchSharp/NN/ParameterDict.cs
@@ -95,6 +95,19 @@ namespace TorchSharp
                 }
             }
 
+            public override bool has_parameter(string target)
+            {
+                return _dict.ContainsKey(target);
+            }
+
+            public override Parameter get_parameter(string target)
+            {
+                if (_dict.TryGetValue(target, out var result)) {
+                    return result;
+                }
+                return null;
+            }
+
             public override bool TryGetMember(GetMemberBinder binder, out object result)
             {
                 var ok = _dict.TryGetValue(binder.Name, out var res);
@@ -151,6 +164,7 @@ namespace TorchSharp
 
             public void Insert(int index, (string, Parameter) item)
             {
+                _dict.Add(item.Item1, item.Item2);
                 _list.Insert(index, item);
             }
 
@@ -176,7 +190,9 @@ namespace TorchSharp
             public bool Remove(string key)
             {
                 var value = _dict[key];
-                return _dict.Remove(key) && _list.Remove((key, value));
+                var idx = _list.FindIndex(kv => kv.Item1.Equals(key));
+                _list.RemoveAt(idx);
+                return _dict.Remove(key);
             }
 
             public bool TryGetValue(string key, [MaybeNullWhen(false)] out Parameter value)

--- a/src/TorchSharp/NN/ParameterList.cs
+++ b/src/TorchSharp/NN/ParameterList.cs
@@ -6,6 +6,7 @@ using static TorchSharp.torch.nn;
 
 namespace TorchSharp
 {
+    using System.Dynamic;
     using System.Linq;
     using Modules;
 
@@ -37,6 +38,19 @@ namespace TorchSharp
             public override IEnumerable<(string name, Parameter parameter)> named_parameters(bool recurse = true)
             {
                 return Enumerable.Range(0, _list.Count).Select(i => ($"{i}", _list[i]));
+            }
+
+            public override bool has_parameter(string target)
+            {
+                return int.TryParse(target, out int idx) && idx > -1 && idx < _list.Count && _list[idx] is not null;
+            }
+
+            public override Parameter get_parameter(string target)
+            {
+                if (int.TryParse(target, out int idx) && idx > -1 && idx < _list.Count) {
+                    return _list[idx];
+                }
+                return null;
             }
 
             private bool _registered = false;

--- a/src/TorchSharp/NN/ParameterList.cs
+++ b/src/TorchSharp/NN/ParameterList.cs
@@ -6,6 +6,7 @@ using static TorchSharp.torch.nn;
 
 namespace TorchSharp
 {
+    using System.Linq;
     using Modules;
 
     namespace Modules
@@ -31,6 +32,11 @@ namespace TorchSharp
                     register_parameter($"{i}", _list[i]);
                 }
                 _registered = true;
+            }
+
+            public override IEnumerable<(string name, Parameter parameter)> named_parameters(bool recurse = true)
+            {
+                return Enumerable.Range(0, _list.Count).Select(i => ($"{i}", _list[i]));
             }
 
             private bool _registered = false;

--- a/src/TorchSharp/NN/Recurrent/GRUCell.cs
+++ b/src/TorchSharp/NN/Recurrent/GRUCell.cs
@@ -48,11 +48,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_GRUCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias_ih {
+            public Parameter? bias_ih {
                 get {
                     var res = THSNN_GRUCell_bias_ih(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_GRUCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -61,11 +61,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? bias_hh {
+            public Parameter? bias_hh {
                 get {
                     var res = THSNN_GRUCell_bias_hh(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_GRUCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -83,11 +83,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_GRUCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight_ih {
+            public Parameter weight_ih {
                 get {
                     var res = THSNN_GRUCell_weight_ih(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_GRUCell_set_weight_ih(handle, value.Handle);
@@ -96,11 +96,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor weight_hh {
+            public Parameter weight_hh {
                 get {
                     var res = THSNN_GRUCell_weight_hh(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_GRUCell_set_weight_hh(handle, value.Handle);

--- a/src/TorchSharp/NN/Recurrent/GRUCell.cs
+++ b/src/TorchSharp/NN/Recurrent/GRUCell.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
-
+#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -32,11 +32,81 @@ namespace TorchSharp
             /// <param name="input">Tensor of shape (batch, input_size) containing the features of the input sequence.</param>
             /// <param name="h0">Tensor of shape (batch, hidden_size) containing the initial hidden state for each element in the batch.</param>
             /// <returns></returns>
-            public override Tensor forward(Tensor input, Tensor h0 = null)
+            public override Tensor forward(Tensor input, Tensor? h0 = null)
             {
                 var hN = THSNN_GRUCell_forward(handle, input.Handle, h0?.Handle ?? IntPtr.Zero);
                 if (hN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(hN);
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_GRUCell_bias_ih(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_GRUCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_GRUCell_bias_hh(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_GRUCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+            public Tensor? bias_ih {
+                get {
+                    var res = THSNN_GRUCell_bias_ih(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                }
+                set {
+                    THSNN_GRUCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias_ih", value);
+                }
+            }
+
+            public Tensor? bias_hh {
+                get {
+                    var res = THSNN_GRUCell_bias_hh(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                }
+                set {
+                    THSNN_GRUCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias_hh", value);
+                }
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_GRUCell_weight_ih(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_GRUCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_GRUCell_weight_hh(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_GRUCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+            public Tensor weight_ih {
+                get {
+                    var res = THSNN_GRUCell_weight_ih(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+                set {
+                    THSNN_GRUCell_set_weight_ih(handle, value.Handle);
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight_ih", value);
+                }
+            }
+
+            public Tensor weight_hh {
+                get {
+                    var res = THSNN_GRUCell_weight_hh(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+                set {
+                    THSNN_GRUCell_set_weight_hh(handle, value.Handle);
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight_hh", value);
+                }
             }
         }
     }

--- a/src/TorchSharp/NN/Recurrent/LSTMCell.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTMCell.cs
@@ -39,6 +39,76 @@ namespace TorchSharp
                 if (hN == IntPtr.Zero || cN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return (new Tensor(hN), new Tensor(cN));
             }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_LSTMCell_bias_ih(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_LSTMCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_LSTMCell_bias_hh(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_LSTMCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+            public Tensor? bias_ih {
+                get {
+                    var res = THSNN_LSTMCell_bias_ih(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                }
+                set {
+                    THSNN_LSTMCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias_ih", value);
+                }
+            }
+
+            public Tensor? bias_hh {
+                get {
+                    var res = THSNN_LSTMCell_bias_hh(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                }
+                set {
+                    THSNN_LSTMCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias_hh", value);
+                }
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_LSTMCell_weight_ih(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_LSTMCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_LSTMCell_weight_hh(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_LSTMCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+            public Tensor weight_ih {
+                get {
+                    var res = THSNN_LSTMCell_weight_ih(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+                set {
+                    THSNN_LSTMCell_set_weight_ih(handle, value.Handle);
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight_ih", value);
+                }
+            }
+
+            public Tensor weight_hh {
+                get {
+                    var res = THSNN_LSTMCell_weight_hh(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+                set {
+                    THSNN_LSTMCell_set_weight_hh(handle, value.Handle);
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight_hh", value);
+                }
+            }
         }
     }
 

--- a/src/TorchSharp/NN/Recurrent/LSTMCell.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTMCell.cs
@@ -49,11 +49,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_LSTMCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias_ih {
+            public Parameter? bias_ih {
                 get {
                     var res = THSNN_LSTMCell_bias_ih(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_LSTMCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -62,11 +62,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? bias_hh {
+            public Parameter? bias_hh {
                 get {
                     var res = THSNN_LSTMCell_bias_hh(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_LSTMCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -84,11 +84,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_LSTMCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight_ih {
+            public Parameter weight_ih {
                 get {
                     var res = THSNN_LSTMCell_weight_ih(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_LSTMCell_set_weight_ih(handle, value.Handle);
@@ -97,11 +97,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor weight_hh {
+            public Parameter weight_hh {
                 get {
                     var res = THSNN_LSTMCell_weight_hh(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_LSTMCell_set_weight_hh(handle, value.Handle);

--- a/src/TorchSharp/NN/Recurrent/RNN.cs
+++ b/src/TorchSharp/NN/Recurrent/RNN.cs
@@ -40,18 +40,18 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_RNN_bias_hh(torch.nn.Module.HType module, long idx);
 
-            public Tensor? get_bias_ih(long idx)
+            public Parameter? get_bias_ih(long idx)
             {
                 var res = THSNN_RNN_bias_ih(handle, idx);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                return ((res == IntPtr.Zero) ? null : new Parameter(res));
             }
 
-            public Tensor? get_bias_hh(long idx)
+            public Parameter? get_bias_hh(long idx)
             {
                 var res = THSNN_RNN_bias_hh(handle, idx);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                return ((res == IntPtr.Zero) ? null : new Parameter(res));
             }
 
 #if false   // Disabled until we can figure out how to set the native code parameters.
@@ -81,18 +81,18 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_RNN_weight_hh(torch.nn.Module.HType module, long idx);
 
-            public Tensor get_weight_ih(long idx)
+            public Parameter get_weight_ih(long idx)
             {
                 var res = THSNN_RNN_weight_ih(handle, idx);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                return new Tensor(res);
+                return new Parameter(res);
             }
 
-            public Tensor get_weight_hh(long idx)
+            public Parameter get_weight_hh(long idx)
             {
                 var res = THSNN_RNN_weight_hh(handle, idx);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                return new Tensor(res);
+                return new Parameter(res);
             }
 
 #if false   // Disabled until we can figure out how to set the native code parameters.

--- a/src/TorchSharp/NN/Recurrent/RNN.cs
+++ b/src/TorchSharp/NN/Recurrent/RNN.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
-
+#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -14,7 +14,9 @@ namespace TorchSharp
     {
         public class RNN : torch.nn.Module
         {
-            internal RNN(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+            internal RNN(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
+            {
+            }
 
             [DllImport("LibTorchSharp")]
             extern static IntPtr THSNN_RNN_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
@@ -26,12 +28,92 @@ namespace TorchSharp
             /// <param name="h0">Tensor of shape (num_layers * num_directions, batch, hidden_size)containing the initial hidden state for each element in the batch.
             /// Defaults to 0 if not provided. If the RNN is bidirectional, num_directions should be 2, else it should be 1.</param>
             /// <returns></returns>
-            public new (Tensor, Tensor) forward(Tensor input, Tensor h0 = null)
+            public new (Tensor, Tensor) forward(Tensor input, Tensor? h0 = null)
             {
                 var res = THSNN_RNN_forward(handle, input.Handle, h0?.Handle ?? IntPtr.Zero, out IntPtr hN);
                 if (res == IntPtr.Zero || hN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return (new Tensor(res), new Tensor(hN));
             }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_RNN_bias_ih(torch.nn.Module.HType module, long idx);
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_RNN_bias_hh(torch.nn.Module.HType module, long idx);
+
+            public Tensor? get_bias_ih(long idx)
+            {
+                var res = THSNN_RNN_bias_ih(handle, idx);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return ((res == IntPtr.Zero) ? null : new Tensor(res));
+            }
+
+            public Tensor? get_bias_hh(long idx)
+            {
+                var res = THSNN_RNN_bias_hh(handle, idx);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return ((res == IntPtr.Zero) ? null : new Tensor(res));
+            }
+
+#if false   // Disabled until we can figure out how to set the native code parameters.
+
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_RNN_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor, long idx);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_RNN_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor, long idx);
+
+            public void set_bias_ih(Tensor? value, long idx)
+            {
+                THSNN_RNN_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle), idx);
+                torch.CheckForErrors();
+                ConditionallyRegisterParameter($"bias_ih_l{idx}", value);
+            }
+
+            public void set_bias_hh(Tensor? value, long idx)
+            {
+                THSNN_RNN_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle), idx);
+                torch.CheckForErrors();
+                ConditionallyRegisterParameter($"bias_hh_l{idx}", value);
+            }
+#endif
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_RNN_weight_ih(torch.nn.Module.HType module, long idx);
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_RNN_weight_hh(torch.nn.Module.HType module, long idx);
+
+            public Tensor get_weight_ih(long idx)
+            {
+                var res = THSNN_RNN_weight_ih(handle, idx);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public Tensor get_weight_hh(long idx)
+            {
+                var res = THSNN_RNN_weight_hh(handle, idx);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+#if false   // Disabled until we can figure out how to set the native code parameters.
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_RNN_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor, long idx);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_RNN_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor, long idx);
+            public void set_weight_ih(Tensor? value, long idx)
+            {
+                THSNN_RNN_set_weight_ih(handle, (value is null ? IntPtr.Zero : value.Handle), idx);
+                torch.CheckForErrors();
+                ConditionallyRegisterParameter($"weight_ih_l{idx}", value);
+            }
+
+            public void set_weight_hh(Tensor? value, long idx)
+            {
+                THSNN_RNN_set_weight_hh(handle, (value is null ? IntPtr.Zero : value.Handle), idx);
+                torch.CheckForErrors();
+                ConditionallyRegisterParameter($"weight_hh_l{idx}", value);
+            }
+#endif
         }
     }
 

--- a/src/TorchSharp/NN/Recurrent/RNNCell.cs
+++ b/src/TorchSharp/NN/Recurrent/RNNCell.cs
@@ -51,11 +51,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_RNNCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor? bias_ih {
+            public Parameter? bias_ih {
                 get {
                     var res = THSNN_RNNCell_bias_ih(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_RNNCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -65,11 +65,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor? bias_hh {
+            public Parameter? bias_hh {
                 get {
                     var res = THSNN_RNNCell_bias_hh(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                    return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
                     THSNN_RNNCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
@@ -88,11 +88,11 @@ namespace TorchSharp
             [DllImport("LibTorchSharp")]
             extern static void THSNN_RNNCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
 
-            public Tensor weight_ih {
+            public Parameter weight_ih {
                 get {
                     var res = THSNN_RNNCell_weight_ih(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_RNNCell_set_weight_ih(handle, value.Handle);
@@ -101,11 +101,11 @@ namespace TorchSharp
                 }
             }
 
-            public Tensor weight_hh {
+            public Parameter weight_hh {
                 get {
                     var res = THSNN_RNNCell_weight_hh(handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
+                    return new Parameter(res);
                 }
                 set {
                     THSNN_RNNCell_set_weight_hh(handle, value.Handle);

--- a/src/TorchSharp/NN/Recurrent/RNNCell.cs
+++ b/src/TorchSharp/NN/Recurrent/RNNCell.cs
@@ -7,6 +7,7 @@ using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
 
+#nullable enable
 namespace TorchSharp
 {
     using Modules;
@@ -15,7 +16,9 @@ namespace TorchSharp
     {
         public class RNNCell : torch.nn.Module
         {
-            internal RNNCell(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+            internal RNNCell(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
+            {
+            }
 
             public new static RNNCell Load(String modelPath)
             {
@@ -32,11 +35,83 @@ namespace TorchSharp
             /// <param name="input">Tensor of shape (batch, input_size) containing the features of the input sequence.</param>
             /// <param name="h0">Tensor of shape (batch, hidden_size) containing the initial hidden state for each element in the batch.</param>
             /// <returns></returns>
-            public override Tensor forward(Tensor input, Tensor h0 = null)
+            public override Tensor forward(Tensor input, Tensor? h0 = null)
             {
                 var hN = THSNN_RNNCell_forward(handle, input.Handle, h0?.Handle ?? IntPtr.Zero);
                 if (hN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(hN);
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_RNNCell_bias_ih(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_RNNCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_RNNCell_bias_hh(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_RNNCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+            public Tensor? bias_ih {
+                get {
+                    var res = THSNN_RNNCell_bias_ih(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                }
+                set {
+                    THSNN_RNNCell_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias_ih", value);
+
+                }
+            }
+
+            public Tensor? bias_hh {
+                get {
+                    var res = THSNN_RNNCell_bias_hh(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return ((res == IntPtr.Zero) ? null : new Tensor(res));
+                }
+                set {
+                    THSNN_RNNCell_set_bias_hh(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias_hh", value);
+
+                }
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_RNNCell_weight_ih(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_RNNCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSNN_RNNCell_weight_hh(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            extern static void THSNN_RNNCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+            public Tensor weight_ih {
+                get {
+                    var res = THSNN_RNNCell_weight_ih(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+                set {
+                    THSNN_RNNCell_set_weight_ih(handle, value.Handle);
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight_ih", value);
+                }
+            }
+
+            public Tensor weight_hh {
+                get {
+                    var res = THSNN_RNNCell_weight_hh(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+                set {
+                    THSNN_RNNCell_set_weight_hh(handle, value.Handle);
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight_hh", value);
+                }
             }
         }
     }

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -135,6 +135,18 @@ namespace TorchSharp
                 foreach (var m in _modules) { m.Eval(); }
             }
 
+            public override nn.Module to(ScalarType dtype)
+            {
+                foreach (var m in _modules) { m.to(dtype); }
+                return this;
+            }
+
+            public override nn.Module to(DeviceType deviceType, int deviceIndex = -1)
+            {
+                foreach (var m in _modules) { m.to(deviceType, deviceIndex); }
+                return this;
+            }
+
             // Currently, Sequential is implemented entirely in managed code, but if we go back to
             // using the native forward() implementation, this collection is still necessary.
             // The module handles are held in the native runtime, which calls back into managed code,

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -125,14 +125,14 @@ namespace TorchSharp
                 base.Dispose(disposing);
             }
 
-            public override void Train()
+            public override void train()
             {
-                foreach (var m in _modules) { m.Train(); }
+                foreach (var m in _modules) { m.train(); }
             }
 
-            public override void Eval()
+            public override void eval()
             {
-                foreach (var m in _modules) { m.Eval(); }
+                foreach (var m in _modules) { m.eval(); }
             }
 
             public override nn.Module to(ScalarType dtype)

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -24,7 +24,7 @@ namespace TorchSharp
                 [MarshalAs(UnmanagedType.LPStr)] string name,
                 torch.nn.BoxedModule.HType boxedSubModule);
 
-            public void Add(string name, torch.nn.Module submodule)
+            internal void Add(string name, torch.nn.Module submodule)
             {
                 Debug.Assert(!handle.IsInvalid);
                 if (submodule.BoxedModule == null)
@@ -37,11 +37,45 @@ namespace TorchSharp
                 _names.Add(name);
             }
 
-            public void Add(torch.nn.Module module)
+            internal void Add(torch.nn.Module module)
             {
-                Add(_modules.Count.ToString(), module);
+                var name = _modules.Count.ToString();
+                Add(name, module);
             }
 
+            public override IEnumerable<(string name, Parameter parameter)> named_parameters(bool recurse = true)
+            {
+                if (!recurse) yield break;
+
+                for (var i = 0; i < _names.Count; i++) {
+                    foreach (var (n,p) in _modules[i].named_parameters(true)) {
+                        yield return ($"{_names[i]}.{n}", p);
+                    }
+                }
+            }
+
+            public override IEnumerable<(string name, torch.nn.Module module)> named_children()
+            {
+                for (var i = 0; i < _names.Count; i++) {
+                    yield return ($"{_names[i]}", _modules[i]);
+                }
+            }
+
+            public override IEnumerable<(string name, torch.nn.Module module)> named_modules()
+            {
+                for (var i = 0; i < _names.Count; i++) {
+                    yield return ($"{_names[i]}", _modules[i]);
+                }
+
+                for (var i = 0; i < _names.Count; i++) {
+                    var sm = _modules[i];
+                    var name = _names[i];
+                    foreach (var (n, p) in sm.named_modules()) {
+                        yield return ($"{name}.{n}", p);
+                    }
+                }
+
+            }
             internal Sequential(IntPtr handle) : base(handle, IntPtr.Zero)
             {
             }

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 using static TorchSharp.Utils.LEB128Codec;
+using System.Runtime.CompilerServices;
 
 #nullable enable
 namespace TorchSharp
@@ -16,6 +17,16 @@ namespace TorchSharp
     /// </summary>
     public static class TensorExtensionMethods
     {
+        /// <summary>
+        /// Convert to a parameter.
+        /// </summary>
+        /// <param name="tensor">A tensor.</param>
+        /// <returns></returns>
+        public static Modules.Parameter AsParameter(this Tensor tensor)
+        {
+            return new Modules.Parameter(tensor);
+        }
+
         /// <summary>
         /// Get a string representation of the tensor.
         /// </summary>

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -316,7 +316,7 @@ namespace TorchSharp
                 /// <param name="max_norm"></param>
                 /// <param name="norm_type"></param>
                 /// <returns></returns>
-                public static double clip_grad_norm_(IList<Tensor> tensors, double max_norm, double norm_type = 2.0)
+                public static double clip_grad_norm_(IEnumerable<Modules.Parameter> tensors, double max_norm, double norm_type = 2.0)
                 {
                     using (var parray = new PinnedArray<IntPtr>()) {
                         IntPtr tensorsRef = parray.CreateArray(tensors.Select(p => p.Handle).ToArray());

--- a/src/TorchSharp/Utils/OrderedDict.cs
+++ b/src/TorchSharp/Utils/OrderedDict.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace TorchSharp.Utils
+{
+    public class OrderedDict<TKey, TValue> : IDictionary<TKey, TValue>, IList<(TKey, TValue)>
+    {
+        /// <summary>
+        /// Remove all items from the ParameterDict.
+        /// </summary>
+        public void clear()
+        {
+            _list.Clear();
+            _dict.Clear();
+        }
+
+        /// <summary>
+        /// Return an enumeration of the ParameterDict key/value pairs.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerator<(TKey, TValue)> items() => _list.GetEnumerator();
+
+        /// <summary>
+        /// Return the ParameterDict keys.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<TKey> keys() => _dict.Keys;
+
+        /// <summary>
+        /// Return the ParameterDict values.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<TValue> values() => _dict.Values;
+
+        public (TKey, TValue) this[int index] {
+            get => _list[index];
+            set {
+                var name = value.Item1;
+                _list[index] = value;
+                _dict[name] = value.Item2;
+            }
+        }
+
+        public bool IsReadOnly => false;
+
+        public ICollection<TKey> Keys => _list.Select(kv => kv.Item1).ToList();
+
+        public ICollection<TValue> Values => _list.Select(kv => kv.Item2).ToList();
+
+        public int Count => _dict.Count;
+
+        public TValue this[TKey key] {
+            get => _dict[key];
+            set {
+                _dict[key] = value;
+                var idx = _list.FindIndex(kv => kv.Item1.Equals(key));
+                _list[idx] = (key,value);
+            }
+        }
+
+        public void Add((TKey, TValue) item)
+        {
+            _dict.Add(item.Item1, item.Item2);
+            _list.Add(item);
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            _dict.Add(key, value);
+            _list.Add((key, value));
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            _dict.Add(item.Key, item.Value);
+            _list.Add((item.Key, item.Value));
+        }
+
+        public bool Contains((TKey, TValue) item)
+        {
+            return _list.Contains(item);
+        }
+
+        public void CopyTo((TKey, TValue)[] array, int arrayIndex)
+        {
+            _list.CopyTo(array, arrayIndex);
+        }
+
+        public int IndexOf((TKey, TValue) item)
+        {
+            return _list.IndexOf(item);
+        }
+
+        public void Insert(int index, (TKey, TValue) item)
+        {
+            _list.Insert(index, item);
+        }
+
+        public bool Remove((TKey, TValue) item)
+        {
+            return _list.Remove(item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _list.RemoveAt(index);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return _dict.ContainsKey(key);
+        }
+
+        public bool Remove(TKey key)
+        {
+            var value = _dict[key];
+            return _dict.Remove(key) && _list.Remove((key, value));
+        }
+
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+        {
+            return _dict.TryGetValue(key, out value);
+        }
+
+        public void Clear()
+        {
+            _dict.Clear();
+            _list.Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return _dict.ContainsKey(item.Key);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return _dict.Remove(item.Key);
+        }
+
+        public IEnumerator<(TKey, TValue)> GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable<KeyValuePair<TKey, TValue>>)this).GetEnumerator();
+        }
+
+        private List<(TKey, TValue)> _list = new List<(TKey, TValue)>();
+        private Dictionary<TKey, TValue> _dict = new Dictionary<TKey, TValue>();
+    }
+
+}

--- a/src/TorchSharp/Utils/OrderedDict.cs
+++ b/src/TorchSharp/Utils/OrderedDict.cs
@@ -96,17 +96,22 @@ namespace TorchSharp.Utils
 
         public void Insert(int index, (TKey, TValue) item)
         {
+            _dict.Add(item.Item1, item.Item2);
             _list.Insert(index, item);
         }
 
         public bool Remove((TKey, TValue) item)
         {
+            _dict.Remove(item.Item1);
             return _list.Remove(item);
         }
 
         public void RemoveAt(int index)
         {
+            if (index >= _list.Count) throw new IndexOutOfRangeException();
+            var (n, p) = _list[index];
             _list.RemoveAt(index);
+            _dict.Remove(n);
         }
 
         public bool ContainsKey(TKey key)
@@ -117,7 +122,9 @@ namespace TorchSharp.Utils
         public bool Remove(TKey key)
         {
             var value = _dict[key];
-            return _dict.Remove(key) && _list.Remove((key, value));
+            var idx = _list.FindIndex(kv => kv.Item1.Equals(key));
+            _list.RemoveAt(idx);
+            return _dict.Remove(key);
         }
 
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -2133,6 +2133,14 @@ namespace TorchSharp
             {
                 var ones = torch.ones(new long[] { 16, 3, 28 });
                 using (var pool = BatchNorm1d(3)) {
+
+                    var sd = pool.state_dict();
+                    Assert.Equal(5, sd.Count);
+                    var np = pool.named_parameters();
+                    Assert.Equal(2, np.Count());
+                    var nb = pool.named_buffers();
+                    Assert.Equal(3, nb.Count());
+
                     var pooled = pool.forward(ones);
                     Assert.Equal(ones.shape, pooled.shape);
                     Assert.Throws<ArgumentException>(() => pool.forward(torch.ones(new long[] { 16 })));

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1527,7 +1527,7 @@ namespace TorchSharp
                 throw new NotImplementedException();
             }
 
-            private Parameter test { get; set; }
+            private Parameter test;
             private ParameterList list = new ParameterList();
             private ParameterDict dict = new ParameterDict();
         }
@@ -1551,7 +1551,7 @@ namespace TorchSharp
                 throw new NotImplementedException();
             }
 
-            public Module submodule { get; set; }
+            public Module submodule;
             private ModuleList list = new ModuleList();
             private ModuleDict dict = new ModuleDict();
         }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1429,6 +1429,24 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestCustomModuleDynamic1()
+        {
+            dynamic module = new TestModule1(torch.randn(new long[] { 2, 2 }), true);
+            int x = module.list.Count;
+            Assert.Equal(1, x);
+            Assert.IsType<ParameterList>(module.list);
+        }
+
+        [Fact]
+        public void TestCustomModuleDynamic2()
+        {
+            dynamic module = new TestModule2(torch.randn(new long[] { 2, 2 }), true);
+            var x = module.dict.first;
+            Assert.NotNull(x);
+            Assert.IsType<TestModule1>(x);
+        }
+
+        [Fact]
         public void TestCustomModuleWithInPlaceModification()
         {
             var param = torch.randn(new long[] { 1000, 100 });

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -174,7 +174,7 @@ namespace TorchSharp
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/TorchSharp/issues/499")]
         public void TestLinearEditWeightsAndBias()
         {
             var lin = Linear(1000, 1000, true);
@@ -184,12 +184,26 @@ namespace TorchSharp
             lin.bias = bias;
             lin.weight = weights;
 
-            Assert.Equal(lin.weight.shape.Length, weights.shape.Length);
-            Assert.Equal(lin.weight.shape[0], weights.shape[0]);
-            Assert.Equal(lin.weight.shape[1], weights.shape[1]);
+            var w1 = lin.weight;
+            var b1 = lin.bias;
+
+            Assert.Equal(w1.shape.Length, weights.shape.Length);
+            Assert.Equal(w1.shape[0], weights.shape[0]);
+            Assert.Equal(w1.shape[1], weights.shape[1]);
 
             for (int i = 0; i < 100; i++) {
-                Assert.Equal(lin.bias.data<float>()[i], bias.data<float>()[i]);
+                Assert.Equal(b1.data<float>()[i], bias.data<float>()[i]);
+            }
+
+            var w2 = lin.parameters()[0];
+            var b2 = lin.parameters()[1];
+
+            Assert.Equal(weights.shape.Length, w2.shape.Length);
+            Assert.Equal(weights.shape[0], w2.shape[0]);
+            Assert.Equal(weights.shape[1], w2.shape[1]);
+
+            for (int i = 0; i < 100; i++) {
+                Assert.Equal(b2.data<float>()[i], bias.data<float>()[i]);
             }
         }
 

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.IO;
+using System.Dynamic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -957,10 +957,7 @@ namespace TorchSharp
             public CondModel(string name, bool isTrue) : base(name)
             {
                 _isTrue = isTrue;
-                register_module("fb", fb);
-                register_module("fbT1", fbT1);
-                register_module("fbF1", fbF1);
-                register_module("fbF2", fbF2);
+                RegisterComponents();
             }
 
             public override Tensor forward(Tensor input)
@@ -989,7 +986,7 @@ namespace TorchSharp
             var x = torch.randn(new long[] { 64, 1000 }, requiresGrad: true);
             var y = torch.randn(new long[] { 64, 10 }, requiresGrad: true);
 
-            modT.Train();
+            modT.train();
 
             var eval = modT.forward(x);
             var loss = mse_loss(Reduction.Sum);
@@ -1008,7 +1005,7 @@ namespace TorchSharp
             Assert.Equal(2, gradCounts);
 
             //{ "grad can be implicitly created only for scalar outputs (_make_grads at ..\\..\\torch\\csrc\\autograd\\autograd.cpp:47)\n(no backtrace available)"}
-            modF.Train();
+            modF.train();
 
             eval = modF.forward(x);
             output = loss(eval, y);
@@ -2662,7 +2659,7 @@ namespace TorchSharp
             using (var K = torch.tensor(k_data, src_seq_len, batch_size, kembed_dim))
             using (var V = torch.tensor(v_data, src_seq_len, batch_size, vembed_dim))
             using (var Attn = torch.tensor(attn_data, batch_size, src_seq_len, src_seq_len)) {
-                mha.Eval();
+                mha.eval();
                 var (att_out, att_wts) = mha.forward(Q, K, V);
                 var t = att_wts.allclose(Attn, rtol: 0.5, atol: 0.5);
                 Assert.True(t);

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -68,19 +68,19 @@ namespace TorchSharp
             Assert.True(original.has_parameter("test"));
 
             var params0 = original.parameters();
-            Assert.True(params0[0].requires_grad);
+            Assert.True(params0.ToArray().ToArray()[0].requires_grad);
             original.save(".model.ts");
 
             var loaded = new TestModule1();
             Assert.True(loaded.has_parameter("test"));
 
             var params1 = loaded.parameters();
-            Assert.True(params1[0].requires_grad);
-            Assert.NotEqual(params0, params1);
+            Assert.True(params1.ToArray()[0].requires_grad);
+            Assert.NotEqual(params0.ToArray(), params1);
 
             loaded.load(".model.ts");
             var params2 = loaded.parameters();
-            Assert.True(params2[0].requires_grad);
+            Assert.True(params2.ToArray()[0].requires_grad);
 
             File.Delete(".model.ts");
 
@@ -252,20 +252,20 @@ namespace TorchSharp
                 if (File.Exists(".model.ts")) File.Delete(".model.ts");
                 var gru = GRU(2, 2, 2);
                 gru.to(DeviceType.CUDA);
-                var params0 = gru.parameters();
+                var params0 = gru.parameters().ToArray();
                 Assert.Equal(DeviceType.CUDA, params0[0].device_type);
 
                 gru.save(".model.ts");
 
                 // Make sure the model is still on the GPU when we come back.
 
-                params0 = gru.parameters();
+                params0 = gru.parameters().ToArray();
                 Assert.Equal(DeviceType.CUDA, params0[0].device_type);
 
                 var loadedGru = GRU(2, 2, 2);
                 loadedGru.to(DeviceType.CUDA);
                 loadedGru.load(".model.ts");
-                var params1 = loadedGru.parameters();
+                var params1 = loadedGru.parameters().ToArray();
 
                 Assert.Equal(DeviceType.CUDA, params1[0].device_type);
 

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -407,5 +407,14 @@ namespace TorchSharp
             Assert.Throws<ArgumentException>(() => torch.randn(3, 4, dtype: torch.int64));
             Assert.Throws<ArgumentException>(() => torch.randn(3, 4, dtype: torch.@bool));
         }
+
+        [Fact]
+        public void ValidateIssue496()
+        {
+            var c2 = torch.nn.Conv2d(3, 16, kernelSize: (1, 7), stride: (1, 1), padding: (0, 3));
+            var Win = torch.rand(16, 3, 8, 8);
+            var s = c2.forward(Win).shape;
+            Assert.Equal(new long[] {16, 16, 8, 8}, s);
+        }
     }
 }

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -421,16 +421,16 @@ namespace TorchSharp
         public void ValidateIssue500()
         {
             using (var pool = BatchNorm1d(28)) {
-                pool.Eval();
+                pool.eval();
                 pool.forward(torch.ones(1, 28));
             }
             using (var pool = BatchNorm1d(28))
             using (var seq = Sequential(pool)) {
-                seq.Eval();
+                seq.eval();
                 seq.forward(torch.ones(1, 28));
             }
             using (var seq = new Module500()) {
-                seq.Eval();
+                seq.eval();
                 seq.forward(torch.ones(1, 28));
             }
         }


### PR DESCRIPTION
This extensive change to the code addresses a couple of bugs. #499 was the bigger one, requiring the code to move maintenance of module parameters, buffers, and submodules into managed code.

Basically, when setting a parameter property such as Linear.weight, the named_parameters collection was not updated. This meant that an optimizer would not pick up the new tensor, leading to errors.

A breaking change in this PR is that named_parameters() and parameters() both return IEnumerable instances instead of arrays. This is more flexible, and also more in line with what PyTorch does.

Further, BatchNorm{123]d did not include running_mean or running_var in the state_dict() results, nor did it allow those buffers to be accessed or set.

For #500, the problem was that eval() and train() were not properly propagated to all submodules. This manifested itself as a bug to BatchNorm1d, which does not allow batch_size=1 during training, but does during evaluation. Here, too, the solution was to do the propagation in managed code rather than in the underlying native code.

** DO NOT MERGE: once the PR is accepted, I will bump the version number.