### PR TITLE
Default dtype for torch.randint is int64

### DIFF
--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -662,7 +662,7 @@ namespace TorchSharp
             device = torch.InitializeDevice(device);
             if (!dtype.HasValue) {
                 // Determine the element type dynamically.
-                dtype = get_default_dtype();
+                dtype = ScalarType.Int64;
             }
 
             ValidateIntegerRange(low, dtype.Value, nameof(low));


### PR DESCRIPTION
https://pytorch.org/docs/stable/generated/torch.randint.html#torch.randint

P.S. does not actually seem to be affected by `torch.set_default_tensor_type`, the default returned type is `int64` regardless.