### PR TITLE
Adding support for Tensor.conj() and related functions.

### DIFF
--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -240,7 +240,7 @@ EXPORT_API(Tensor) THSTensor_complex(const Tensor real, const Tensor imag);
 
 EXPORT_API(Tensor) THSTensor_conj(const Tensor tensor);
 
-EXPORT_API(bool)   THSTensor_is_conj(const Tensor tensor);
+EXPORT_API(int64_t)   THSTensor_is_conj(const Tensor tensor);
 
 EXPORT_API(Tensor) THSTensor_conj_physical(const Tensor tensor);
 

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -238,6 +238,17 @@ EXPORT_API(Tensor) THSTensor_clamp_min_(const Tensor input, const Scalar min);
 
 EXPORT_API(Tensor) THSTensor_complex(const Tensor real, const Tensor imag);
 
+EXPORT_API(Tensor) THSTensor_conj(const Tensor tensor);
+
+EXPORT_API(bool)   THSTensor_is_conj(const Tensor tensor);
+
+EXPORT_API(Tensor) THSTensor_conj_physical(const Tensor tensor);
+
+EXPORT_API(Tensor) THSTensor_conj_physical_(const Tensor tensor);
+
+EXPORT_API(Tensor) THSTensor_resolve_conj(const Tensor tensor);
+
+
 EXPORT_API(Tensor) THSTensor_conv1d(const Tensor input, const Tensor weight, const Tensor bias,
     const int64_t* strides, const int strides_length,
     const int64_t* paddings, const int paddings_length,

--- a/src/Native/LibTorchSharp/THSTensorMath.cpp
+++ b/src/Native/LibTorchSharp/THSTensorMath.cpp
@@ -231,6 +231,31 @@ Tensor THSTensor_ceil_(const Tensor tensor)
     CATCH_TENSOR(tensor->ceil_());
 }
 
+Tensor THSTensor_conj(const Tensor tensor)
+{
+    CATCH_TENSOR(tensor->conj());
+}
+
+bool THSTensor_is_conj(const Tensor tensor)
+{
+    CATCH_RETURN_RES(bool, false, res = tensor->is_conj();)
+}
+
+Tensor THSTensor_conj_physical(const Tensor tensor)
+{
+    CATCH_TENSOR(tensor->conj_physical());
+}
+
+Tensor THSTensor_conj_physical_(const Tensor tensor)
+{
+    CATCH_TENSOR(tensor->conj_physical_());
+}
+
+Tensor THSTensor_resolve_conj(const Tensor tensor)
+{
+    CATCH_TENSOR(tensor->resolve_conj());
+}
+
 Tensor THSTensor_cos(const Tensor tensor)
 {
     CATCH_TENSOR(tensor->cos());

--- a/src/Native/LibTorchSharp/THSTensorMath.cpp
+++ b/src/Native/LibTorchSharp/THSTensorMath.cpp
@@ -236,9 +236,9 @@ Tensor THSTensor_conj(const Tensor tensor)
     CATCH_TENSOR(tensor->conj());
 }
 
-bool THSTensor_is_conj(const Tensor tensor)
+int64_t THSTensor_is_conj(const Tensor tensor)
 {
-    CATCH_RETURN_RES(bool, false, res = tensor->is_conj();)
+    CATCH_RETURN_RES(int64_t, 0, res = tensor->is_conj();)
 }
 
 Tensor THSTensor_conj_physical(const Tensor tensor)

--- a/src/TorchSharp/Tensor/Tensor.Math.cs
+++ b/src/TorchSharp/Tensor/Tensor.Math.cs
@@ -549,6 +549,81 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
+            static extern IntPtr THSTensor_conj(IntPtr tensor);
+
+            /// <summary>
+            /// Returns a view of input with a flipped conjugate bit. If input has a non-complex dtype, this function just returns input.
+            /// </summary>
+            /// <returns></returns>
+            public Tensor conj()
+            {
+                var res = THSTensor_conj(Handle);
+                if (res == IntPtr.Zero)
+                    torch.CheckForErrors();
+                return new Tensor(res);
+            }
+
+            [DllImport("LibTorchSharp")]
+            static extern IntPtr THSTensor_conj_physical(IntPtr tensor);
+
+            /// <summary>
+            /// Computes the element-wise conjugate of the given input tensor. If input has a non-complex dtype, this function just returns input.
+            /// </summary>
+            /// <returns></returns>
+            public Tensor conj_physical()
+            {
+                var res = THSTensor_conj_physical(Handle);
+                if (res == IntPtr.Zero)
+                    torch.CheckForErrors();
+                return new Tensor(res);
+            }
+
+            [DllImport("LibTorchSharp")]
+            static extern IntPtr THSTensor_conj_physical_(IntPtr tensor);
+
+            /// <summary>
+            /// In-place version of conj_physical
+            /// </summary>
+            /// <returns></returns>
+            public Tensor conj_physical_()
+            {
+                var res = THSTensor_conj_physical_(Handle);
+                if (res == IntPtr.Zero)
+                    torch.CheckForErrors();
+                return new Tensor(res);
+            }
+
+            [DllImport("LibTorchSharp")]
+            static extern bool THSTensor_is_conj(IntPtr tensor);
+
+            /// <summary>
+            /// Returns true if the input is a conjugated tensor, i.e. its conjugate bit is set to True.
+            /// </summary>
+            /// <returns></returns>
+            public bool is_conj()
+            {
+                var res = THSTensor_is_conj(Handle);
+                torch.CheckForErrors();
+                return res;
+            }
+
+            [DllImport("LibTorchSharp")]
+            static extern IntPtr THSTensor_resolve_conj(IntPtr tensor);
+
+            /// <summary>
+            /// Returns a new tensor with materialized conjugation if input’s conjugate bit is set to True, else returns input.
+            /// The output tensor will always have its conjugate bit set to False.
+            /// </summary>
+            /// <returns></returns>
+            public Tensor resolve_conj()
+            {
+                var res = THSTensor_resolve_conj(Handle);
+                if (res == IntPtr.Zero)
+                    torch.CheckForErrors();
+                return new Tensor(res);
+            }
+
+            [DllImport("LibTorchSharp")]
             static extern void THSTensor_cummax(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
 
             /// <summary>
@@ -2325,6 +2400,37 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The input tensor.</param>
         public static Tensor ceil_(Tensor input) => input.ceil_();
+
+        /// <summary>
+        /// Returns a view of input with a flipped conjugate bit. If input has a non-complex dtype, this function just returns input.
+        /// </summary>
+        /// <param name="input">The input tensor.</param>
+        public static Tensor conj(Tensor input) => input.conj();
+
+        /// <summary>
+        /// Returns true if the input is a conjugated tensor, i.e. its conjugate bit is set to True.
+        /// </summary>
+        /// <param name="input">The input tensor.</param>
+        public static bool is_conj(Tensor input) => input.is_conj();
+
+        /// <summary>
+        /// Computes the element-wise conjugate of the given input tensor. If input has a non-complex dtype, this function just returns input.
+        /// </summary>
+        /// <param name="input">The input tensor.</param>
+        public static Tensor conj_physical(Tensor input) => input.conj_physical();
+
+        /// <summary>
+        /// In-place version of conj_physical
+        /// </summary>
+        /// <param name="input">The input tensor.</param>
+        public static Tensor conj_physical_(Tensor input) => input.conj_physical_();
+
+        /// <summary>
+        /// Returns a new tensor with materialized conjugation if input’s conjugate bit is set to True, else returns input.
+        /// The output tensor will always have its conjugate bit set to False.
+        /// </summary>
+        /// <param name="input">The input tensor.</param>
+        public static Tensor resolve_conj(Tensor input) => input.resolve_conj();
 
         /// <summary>
         /// Returns the cumulative sum of elements of input in the dimension dim.

--- a/src/TorchSharp/Tensor/Tensor.Math.cs
+++ b/src/TorchSharp/Tensor/Tensor.Math.cs
@@ -594,7 +594,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern bool THSTensor_is_conj(IntPtr tensor);
+            static extern long THSTensor_is_conj(IntPtr tensor);
 
             /// <summary>
             /// Returns true if the input is a conjugated tensor, i.e. its conjugate bit is set to True.
@@ -604,7 +604,7 @@ namespace TorchSharp
             {
                 var res = THSTensor_is_conj(Handle);
                 torch.CheckForErrors();
-                return res;
+                return res != 0;
             }
 
             [DllImport("LibTorchSharp")]

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1023,7 +1023,7 @@ namespace TorchSharp
             Assert.Equal(3, gradCounts);
         }
 
-        [Fact(Skip= "Intermittently failing: https://github.com/dotnet/TorchSharp/issues/367")]
+        [Fact]//(Skip= "Intermittently failing: https://github.com/dotnet/TorchSharp/issues/367")]
         public void TestAutoGradMode()
         {
             // TODO: (Skip = "Not working on MacOS (note: may now be working, we need to recheck)")

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -3875,6 +3875,25 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void ConjTest()
+        {
+            var input = torch.randn(10, dtype: complex64);
+            Assert.False(input.is_conj());
+
+            var res = input.conj();
+            Assert.Equal(10, res.shape[0]);
+            Assert.True(torch.is_conj(res));
+
+            var resolved = torch.resolve_conj(res);
+            Assert.Equal(10, res.shape[0]);
+            Assert.False(resolved.is_conj());
+
+            var physical = torch.conj_physical(input);
+            Assert.Equal(10, res.shape[0]);
+            Assert.False(physical.is_conj());
+        }
+
+        [Fact]
         public void RoundTest()
         {
             var data = new float[] { 1.1f, 2.0f, 3.1f };


### PR DESCRIPTION
This is a straight-forward edit: just adding a few Tensor methods related to conjugates.