### PR TITLE
Fixed assigning slice with integer indices

### DIFF
--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -1098,42 +1098,42 @@ Tensor THSTensor_silu_(const Tensor tensor)
     CATCH_TENSOR(torch::silu_(*tensor));
 }
 
-void THSTensor_set1(const Tensor tensor, int64_t index, Scalar value)
+void THSTensor_set1(const Tensor tensor, int64_t index, const Tensor value)
 {
     CATCH(
         (*tensor)[index] = *value;
     )
 }
 
-void THSTensor_set2(const Tensor tensor, int64_t index1, int64_t index2, Scalar value)
+void THSTensor_set2(const Tensor tensor, int64_t index1, int64_t index2, const Tensor value)
 {
     CATCH(
         (*tensor)[index1][index2] = *value;
     )
 }
 
-void THSTensor_set3(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, Scalar value)
+void THSTensor_set3(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, const Tensor value)
 {
     CATCH(
         (*tensor)[index1][index2][index3] = *value;
     )
 }
 
-void THSTensor_set4(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, Scalar value)
+void THSTensor_set4(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, const Tensor value)
 {
     CATCH(
         (*tensor)[index1][index2][index3][index4] = *value;
     )
 }
 
-void THSTensor_set5(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, Scalar value)
+void THSTensor_set5(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, const Tensor value)
 {
     CATCH(
         (*tensor)[index1][index2][index3][index4][index5] = *value;
     )
 }
 
-void THSTensor_set6(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, int64_t index6, Scalar value)
+void THSTensor_set6(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, int64_t index6, const Tensor value)
 {
     CATCH(
         (*tensor)[index1][index2][index3][index4][index5][index6] = *value;

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -1062,17 +1062,17 @@ EXPORT_API(Tensor) THSTensor_set_(Tensor tensor, const Tensor source);
 
 EXPORT_API(Tensor) THSTensor_set_requires_grad(const Tensor tensor, const bool requires_grad);
 
-EXPORT_API(void) THSTensor_set1(const Tensor tensor, int64_t index, Scalar value);
+EXPORT_API(void) THSTensor_set1(const Tensor tensor, int64_t index, const Tensor value);
 
-EXPORT_API(void) THSTensor_set2(const Tensor tensor, int64_t index1, int64_t index2, Scalar value);
+EXPORT_API(void) THSTensor_set2(const Tensor tensor, int64_t index1, int64_t index2, const Tensor value);
 
-EXPORT_API(void) THSTensor_set3(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, Scalar value);
+EXPORT_API(void) THSTensor_set3(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, const Tensor value);
 
-EXPORT_API(void) THSTensor_set4(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, Scalar value);
+EXPORT_API(void) THSTensor_set4(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, const Tensor value);
 
-EXPORT_API(void) THSTensor_set5(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, Scalar value);
+EXPORT_API(void) THSTensor_set5(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, const Tensor value);
 
-EXPORT_API(void) THSTensor_set6(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, int64_t index6, Scalar value);
+EXPORT_API(void) THSTensor_set6(const Tensor tensor, int64_t index1, int64_t index2, int64_t index3, int64_t index4, int64_t index5, int64_t index6, const Tensor value);
 
 EXPORT_API(int64_t) THSTensor_size(const Tensor tensor, const int64_t dim);
 

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -1136,7 +1136,7 @@ namespace TorchSharp
             static extern IntPtr THSTensor_get1(IntPtr handle, long i1);
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_set1(IntPtr handle, long i1, IntPtr value);
+            static extern void THSTensor_set1(IntPtr handle, long i1, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1151,7 +1151,7 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
                 set {
-                    THSTensor_set1(Handle, i1, value.ToScalar().Handle);
+                    THSTensor_set1(Handle, i1, value.Handle);
                     torch.CheckForErrors();
                 }
             }
@@ -1160,7 +1160,7 @@ namespace TorchSharp
             static extern IntPtr THSTensor_get2(IntPtr handle, long i1, long i2);
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_set2(IntPtr handle, long i1, long i2, IntPtr value);
+            static extern void THSTensor_set2(IntPtr handle, long i1, long i2, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1176,7 +1176,7 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
                 set {
-                    THSTensor_set2(Handle, i1, i2, value.ToScalar().Handle);
+                    THSTensor_set2(Handle, i1, i2, value.Handle);
                     torch.CheckForErrors();
                 }
             }
@@ -1185,7 +1185,7 @@ namespace TorchSharp
             static extern IntPtr THSTensor_get3(IntPtr handle, long i1, long i2, long i3);
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_set3(IntPtr handle, long i1, long i2, long i3, IntPtr value);
+            static extern void THSTensor_set3(IntPtr handle, long i1, long i2, long i3, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1203,7 +1203,7 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
                 set {
-                    THSTensor_set3(Handle, i1, i2, i3, value.ToScalar().Handle);
+                    THSTensor_set3(Handle, i1, i2, i3, value.Handle);
                     torch.CheckForErrors();
                 }
             }
@@ -1212,7 +1212,7 @@ namespace TorchSharp
             static extern IntPtr THSTensor_get4(IntPtr handle, long i1, long i2, long i3, long i4);
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_set4(IntPtr handle, long i1, long i2, long i3, long i4, IntPtr value);
+            static extern void THSTensor_set4(IntPtr handle, long i1, long i2, long i3, long i4, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1231,7 +1231,7 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
                 set {
-                    THSTensor_set4(Handle, i1, i2, i3, i4, value.ToScalar().Handle);
+                    THSTensor_set4(Handle, i1, i2, i3, i4, value.Handle);
                     torch.CheckForErrors();
                 }
             }
@@ -1240,7 +1240,7 @@ namespace TorchSharp
             static extern IntPtr THSTensor_get5(IntPtr handle, long i1, long i2, long i3, long i4, long i5);
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_set5(IntPtr handle, long i1, long i2, long i3, long i4, long i5, IntPtr value);
+            static extern void THSTensor_set5(IntPtr handle, long i1, long i2, long i3, long i4, long i5, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1260,7 +1260,7 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
                 set {
-                    THSTensor_set5(Handle, i1, i2, i3, i4, i5, value.ToScalar().Handle);
+                    THSTensor_set5(Handle, i1, i2, i3, i4, i5, value.Handle);
                     torch.CheckForErrors();
                 }
             }
@@ -1270,7 +1270,7 @@ namespace TorchSharp
             static extern IntPtr THSTensor_get6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6);
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_set6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6, IntPtr value);
+            static extern void THSTensor_set6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1291,7 +1291,7 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
                 set {
-                    THSTensor_set6(Handle, i1, i2, i3, i4, i5, i6, value.ToScalar().Handle);
+                    THSTensor_set6(Handle, i1, i2, i3, i4, i5, i6, value.Handle);
                     torch.CheckForErrors();
                 }
             }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -1665,6 +1665,29 @@ namespace TorchSharp
             Assert.Equal(2.0f, t[1, 2, 3, 4, 5, 6].ToSingle());
         }
 
+        // regression for https://github.com/dotnet/TorchSharp/issues/521
+        [Fact]
+        public void SetItemSlice()
+        {
+            var shape = new long[] { 2, 2, 2, 2, 2, 2, 2 };
+
+            using var t = zeros(size: shape);
+            t[1] = 1 * ones(size: new long[] { 2, 2, 2, 2, 2, 2 });
+            t[1, 1] = 2 * ones(size: new long[] { 2, 2, 2, 2, 2 });
+            t[1, 1, 1] = 3 * ones(size: new long[] { 2, 2, 2, 2 });
+            t[1, 1, 1, 1] = 4 * ones(size: new long[] { 2, 2, 2 });
+            t[1, 1, 1, 1, 1] = 5 * ones(size: new long[] { 2, 2 });
+            t[1, 1, 1, 1, 1, 1] = 6 * ones(size: new long[] { 2 });
+
+            Assert.Equal(0, t[0, 0, 0, 0, 0, 0, 0].ToSingle());
+            Assert.Equal(1, t[1, 0, 0, 0, 0, 0, 0].ToSingle());
+            Assert.Equal(2, t[1, 1, 0, 0, 0, 0, 0].ToSingle());
+            Assert.Equal(3, t[1, 1, 1, 0, 0, 0, 0].ToSingle());
+            Assert.Equal(4, t[1, 1, 1, 1, 0, 0, 0].ToSingle());
+            Assert.Equal(5, t[1, 1, 1, 1, 1, 0, 0].ToSingle());
+            Assert.Equal(6, t[1, 1, 1, 1, 1, 1, 0].ToSingle());
+        }
+
         [Fact]
         public void TestScalarToTensor()
         {


### PR DESCRIPTION
`Tensor` `int`-based indexers forced `AsScalar()` call on new values, which prevented assigning tensor slices.

fixes https://github.com/dotnet/TorchSharp/issues/521