### PR TITLE
fix package loading of TorchSharp-cpu from F#/.NET Interactive

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,8 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 __Fixed Bugs:__
 
+Using libtorch CPU packages from F# Interactive required explicit native loads
+
 #510 Module.Load throws Mismatched state_dict sizes exception on BatchNorm1d<br/>
 
 ## NuGet Version 0.96.0

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>96</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -124,7 +124,7 @@ namespace TorchSharp
                     trace.AppendLine($"Step 3 - Alternative load from consolidated directory of native binaries from nuget packages");
                     trace.AppendLine($"");
 
-                    var cpuRootPackage = "libtorch-cpu";
+                    var cpuRootPackage = "libtorch-cpu-{nativeRid}";
                     var cudaRootPackage = $"libtorch-cuda-{cudaVersion}-{nativeRid}";
                     var target =
                         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "LibTorchSharp.dll" :

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -124,7 +124,7 @@ namespace TorchSharp
                     trace.AppendLine($"Step 3 - Alternative load from consolidated directory of native binaries from nuget packages");
                     trace.AppendLine($"");
 
-                    var cpuRootPackage = "libtorch-cpu-{nativeRid}";
+                    var cpuRootPackage = $"libtorch-cpu-{nativeRid}";
                     var cudaRootPackage = $"libtorch-cuda-{cudaVersion}-{nativeRid}";
                     var target =
                         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "LibTorchSharp.dll" :
@@ -196,7 +196,7 @@ namespace TorchSharp
                         trace.AppendLine("    Giving up, TorchSharp.dll does not appear to have been loaded from package directories");
                     }
                     if (!ok) {
-                        var message = $"This application uses TorchSharp but doesn't contain reference to either {cudaRootPackage} or {cpuRootPackage}, {libtorchPackageVersion}. Consider either referencing one of these packages or call System.Runtime.InteropServices.NativeLibrary.Load(path-to-{target}) explicitly for a Python install or a download of libtorch.so/torch.dll. See https://github.com/dotnet/TorchSharp/issues/169.\". Trace from LoadNativeBackend:\n{trace}";
+                        var message = $"This application or script uses TorchSharp but doesn't contain a reference to {(useCudaBackend ? cudaRootPackage : cpuRootPackage)}, Version={libtorchPackageVersion}.\n\nConsider referencing one of the combination packages TorchSharp-cpu, TorchSharp-cuda-linux, TorchSharp-cuda-windows or call System.Runtime.InteropServices.NativeLibrary.Load(path-to-{target}) explicitly for a Python install of pytorch. See https://github.com/dotnet/TorchSharp/issues/169.\".\n\nFor CUDA, you may need to call 'TorchSharp.torch.InitializeDeviceType(TorchSharp.DeviceType.CUDA)' before any use of TorchSharp CUDA packages from scripts or notebooks.\n\nTrace from LoadNativeBackend:\n{trace}";
                         Console.WriteLine(message);
                         throw new NotSupportedException(message);
                     }


### PR DESCRIPTION
This should fix https://github.com/DiffSharp/DiffSharp/issues/387

