### PR TITLE
Re-enable Optimization on test runs with NetFX 4.7.2

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -24,8 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletVersion)" />
   </ItemGroup>
 

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -13,9 +13,6 @@
     <UseStyleCopAnalyzer>false</UseStyleCopAnalyzer>
     <VSTestLogger>trx</VSTestLogger>
     <VSTestResultsDirectory>$(OutputPath)</VSTestResultsDirectory>
-    <IsNetFxRelease Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework' And $(Configuration.StartsWith('Release'))">true</IsNetFxRelease>
-    <Optimize Condition="'$(IsNetFxRelease)' == 'true'">false</Optimize>
-    <BuildInParallel Condition="'$(IsNetFxRelease)' == 'true'">false</BuildInParallel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -14,6 +14,9 @@ using static TorchSharp.torch.nn.functional;
 
 namespace TorchSharp
 {
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestNN
     {
         #region "Linear"

--- a/test/TorchSharpTest/TestDataLoader.cs
+++ b/test/TorchSharpTest/TestDataLoader.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace TorchSharp
 {
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestDataLoader
     {
         private class TestDataset : torch.utils.data.Dataset

--- a/test/TorchSharpTest/TestDisposeScopes.cs
+++ b/test/TorchSharpTest/TestDisposeScopes.cs
@@ -9,6 +9,9 @@ using Xunit.Abstractions;
 
 namespace TorchSharp
 {
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestDisposeScopes
     {
         private readonly ITestOutputHelper _testOutputHelper;

--- a/test/TorchSharpTest/TestDistributions.cs
+++ b/test/TorchSharpTest/TestDistributions.cs
@@ -13,6 +13,9 @@ using Xunit;
 
 namespace TorchSharp
 {
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestDistributions
     {
         [Fact]

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -12,6 +12,9 @@ using Xunit;
 
 namespace TorchSharp
 {
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestLoadSave
     {
         [Fact]

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -10,6 +10,9 @@ using static TorchSharp.torch;
 
 namespace TorchSharp
 {
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestTorch
     {
         [Fact]
@@ -98,7 +101,7 @@ namespace TorchSharp
 
                 b = genA.initial_seed();
                 c = genB.initial_seed();
-                d = genC.initial_seed(); 
+                d = genC.initial_seed();
 
                 Assert.Equal(a, b);
                 Assert.Equal(c, d);

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -14,6 +14,9 @@ using Xunit;
 
 namespace TorchSharp
 {
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestTensor
     {
         [Fact]

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -19,6 +19,9 @@ namespace TorchSharp
     // The tests in this file are all derived from reported GitHub Issues, serving
     // as regression tests.
 
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestTorchTensorBugs
     {
 
@@ -481,7 +484,7 @@ namespace TorchSharp
 
             public Module510(int in_channels, int out_channels, int kernel_size=3, int stride = 1, int padding = 0) : base(String.Empty)
             {
-                var temp = BatchNorm1d(out_channels);               
+                var temp = BatchNorm1d(out_channels);
                 this.stack = Sequential(
                     Conv1d(in_channels, out_channels, 3, stride: stride, padding: padding, bias: false),
                     temp,

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -16,6 +16,9 @@ using TorchSharp.Modules;
 
 namespace TorchSharp
 {
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
     public class TestTraining
     {
 

--- a/test/TorchSharpTest/TorchSharpTest.csproj
+++ b/test/TorchSharpTest/TorchSharpTest.csproj
@@ -13,9 +13,6 @@
     <VSTestLogger>trx</VSTestLogger>
     <VSTestResultsDirectory>$(OutputPath)</VSTestResultsDirectory>
     <LangVersion>latest</LangVersion>
-    <IsNetFxRelease Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework' And $(Configuration.StartsWith('Release'))">true</IsNetFxRelease>
-    <Optimize Condition="'$(IsNetFxRelease)' == 'true'">false</Optimize>
-    <BuildInParallel Condition="'$(IsNetFxRelease)' == 'true'">false</BuildInParallel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change is to re-enable the optimization option on the tests when running with NETFX 4.7.2. The change here is to serialize the test execution. This solves the issue of the crashing the test host and avoid the conflict between different tests.

https://github.com/dotnet/TorchSharp/issues/546
https://github.com/dotnet/TorchSharp/pull/543