### PR TITLE
code cleanup: removing unused namespaces

### DIFF
--- a/src/Examples.Utils/Datasets.cs
+++ b/src/Examples.Utils/Datasets.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Examples.Utils/TorchText.Data.Utils.cs
+++ b/src/Examples.Utils/TorchText.Data.Utils.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace TorchText.Data
 {

--- a/src/Examples/AdversarialExampleGeneration.cs
+++ b/src/Examples/AdversarialExampleGeneration.cs
@@ -1,13 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.IO;
-using System.Collections.Generic;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn.functional;
-using static TorchSharp.TensorExtensionMethods;
-using static TorchSharp.torchvision.datasets;
 using static TorchSharp.torch.utils.data;
-using System.Net;
 
 namespace TorchSharp.Examples
 {

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -1,13 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.IO;
-using System.Linq;
-using System.Collections.Generic;
-using System.Diagnostics;
 
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.nn.functional;
 
 namespace TorchSharp.Examples
 {

--- a/src/Examples/CIFAR10.cs
+++ b/src/Examples/CIFAR10.cs
@@ -1,15 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.IO;
-using System.Linq;
-using System.Collections.Generic;
 using System.Diagnostics;
-
-using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using static TorchSharp.torch.nn.functional;
 using static TorchSharp.torch.utils.data;
-using static TorchSharp.torchvision.datasets;
 
 namespace TorchSharp.Examples
 {

--- a/src/Examples/ImageTransforms.cs
+++ b/src/Examples/ImageTransforms.cs
@@ -3,10 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
-using System.Threading.Tasks;
-
 using SkiaSharp;
-using TorchSharp;
 using static TorchSharp.torch;
 using System.Runtime.InteropServices;
 

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -1,14 +1,11 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.IO;
-using System.Collections.Generic;
 using System.Diagnostics;
 using static TorchSharp.torch;
 
 using static TorchSharp.torch.nn;
 using static TorchSharp.torch.nn.functional;
 using static TorchSharp.torch.utils.data;
-using static TorchSharp.torchvision.datasets;
 
 namespace TorchSharp.Examples
 {

--- a/src/Examples/Program.cs
+++ b/src/Examples/Program.cs
@@ -1,9 +1,4 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TorchSharp.Examples
 {

--- a/src/TorchSharp/Autograd.cs
+++ b/src/TorchSharp/Autograd.cs
@@ -6,8 +6,6 @@ using System.Runtime.InteropServices;
 
 namespace TorchSharp
 {
-    using static torch;
-
     /// <summary>
     /// Helper class, relying on IDisposable to implement block-based scoping of autograd settings.
     /// </summary>

--- a/src/TorchSharp/Device.cs
+++ b/src/TorchSharp/Device.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/Distributions/Bernoulli.cs
+++ b/src/TorchSharp/Distributions/Bernoulli.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Beta.cs
+++ b/src/TorchSharp/Distributions/Beta.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Binomial.cs
+++ b/src/TorchSharp/Distributions/Binomial.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Categorical.cs
+++ b/src/TorchSharp/Distributions/Categorical.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Cauchy.cs
+++ b/src/TorchSharp/Distributions/Cauchy.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Chi2.cs
+++ b/src/TorchSharp/Distributions/Chi2.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Dirichlet.cs
+++ b/src/TorchSharp/Distributions/Dirichlet.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Distribution.cs
+++ b/src/TorchSharp/Distributions/Distribution.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/Distributions/Exponential.cs
+++ b/src/TorchSharp/Distributions/Exponential.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/FisherSnedecor.cs
+++ b/src/TorchSharp/Distributions/FisherSnedecor.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Gamma.cs
+++ b/src/TorchSharp/Distributions/Gamma.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Geometric.cs
+++ b/src/TorchSharp/Distributions/Geometric.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Multinomial.cs
+++ b/src/TorchSharp/Distributions/Multinomial.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Normal.cs
+++ b/src/TorchSharp/Distributions/Normal.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Poisson.cs
+++ b/src/TorchSharp/Distributions/Poisson.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Uniform.cs
+++ b/src/TorchSharp/Distributions/Uniform.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
-
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/FFT.cs
+++ b/src/TorchSharp/FFT.cs
@@ -1,17 +1,10 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Globalization;
-using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 
 namespace TorchSharp
 {
-    using static torch;
-
     // This file contains the mathematical operators on Tensor
 
     public enum FFTNormType

--- a/src/TorchSharp/Generator.cs
+++ b/src/TorchSharp/Generator.cs
@@ -1,13 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Globalization;
-using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
-using TorchSharp;
-using static TorchSharp.torch;
 
 #nullable enable
 

--- a/src/TorchSharp/LinearAlgebra.cs
+++ b/src/TorchSharp/LinearAlgebra.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
-using static TorchSharp.torch;
-
 #nullable enable
 namespace TorchSharp
 {

--- a/src/TorchSharp/NN/Activation/ChannelShuffle.cs
+++ b/src/TorchSharp/NN/Activation/ChannelShuffle.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/NN/Activation/Hardsigmoid.cs
+++ b/src/TorchSharp/NN/Activation/Hardsigmoid.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/NN/Bilinear.cs
+++ b/src/TorchSharp/NN/Bilinear.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;

--- a/src/TorchSharp/NN/Functional.cs
+++ b/src/TorchSharp/NN/Functional.cs
@@ -1,11 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Globalization;
 using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/NN/Identity.cs
+++ b/src/TorchSharp/NN/Identity.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 

--- a/src/TorchSharp/NN/Init.cs
+++ b/src/TorchSharp/NN/Init.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using static TorchSharp.torch;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -1,12 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Dynamic;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
 using System.Runtime.InteropServices;
-using static TorchSharp.torch;
-
 using static TorchSharp.Utils.LEB128Codec;
 using System.Diagnostics;
 

--- a/src/TorchSharp/NN/ModuleDict.cs
+++ b/src/TorchSharp/NN/ModuleDict.cs
@@ -1,12 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Linq;
-using System.Dynamic;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-
-using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
 namespace TorchSharp

--- a/src/TorchSharp/NN/ModuleList.cs
+++ b/src/TorchSharp/NN/ModuleList.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System.Collections;
 using System.Collections.Generic;
-
-using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
 namespace TorchSharp

--- a/src/TorchSharp/NN/MultiheadAttention.cs
+++ b/src/TorchSharp/NN/MultiheadAttention.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
-using static TorchSharp.torch.nn;
+
 #nullable enable
 namespace TorchSharp
 {

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -1,14 +1,11 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
-using System.Collections.Generic;
-
 using static TorchSharp.torch;
 
 #nullable enable
 namespace TorchSharp
 {
-    using System.Collections.Generic;
     using Modules;
 
     namespace Modules

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
-using System.Collections.Generic;
-
 using static TorchSharp.torch;
 
 #nullable enable

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
-using System.Collections.Generic;
-
 using static TorchSharp.torch;
 
 #nullable enable

--- a/src/TorchSharp/NN/OneHot.cs
+++ b/src/TorchSharp/NN/OneHot.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
-using static TorchSharp.torch;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/NN/Parameter.cs
+++ b/src/TorchSharp/NN/Parameter.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using static TorchSharp.torch;
-using static TorchSharp.torch.nn;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/NN/ParameterDict.cs
+++ b/src/TorchSharp/NN/ParameterDict.cs
@@ -1,12 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Linq;
-using System.Dynamic;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-
-using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
 namespace TorchSharp

--- a/src/TorchSharp/NN/ParameterList.cs
+++ b/src/TorchSharp/NN/ParameterList.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System.Collections;
 using System.Collections.Generic;
-using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
 namespace TorchSharp
 {
-    using System.Dynamic;
     using System.Linq;
     using Modules;
 

--- a/src/TorchSharp/NN/Recurrent/GRU.cs
+++ b/src/TorchSharp/NN/Recurrent/GRU.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 

--- a/src/TorchSharp/NN/Recurrent/GRUCell.cs
+++ b/src/TorchSharp/NN/Recurrent/GRUCell.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;

--- a/src/TorchSharp/NN/Recurrent/LSTM.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTM.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
-using static TorchSharp.torch.nn;
 
 #nullable enable
 namespace TorchSharp

--- a/src/TorchSharp/NN/Recurrent/LSTMCell.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTMCell.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;

--- a/src/TorchSharp/NN/Recurrent/RNN.cs
+++ b/src/TorchSharp/NN/Recurrent/RNN.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 

--- a/src/TorchSharp/NN/Recurrent/RNNCell.cs
+++ b/src/TorchSharp/NN/Recurrent/RNNCell.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 using static TorchSharp.torch;

--- a/src/TorchSharp/NN/Vision.cs
+++ b/src/TorchSharp/NN/Vision.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Runtime.InteropServices;
-using static TorchSharp.torch;
 
 #nullable enable
 namespace TorchSharp

--- a/src/TorchSharp/Optimizers/ASGD.cs
+++ b/src/TorchSharp/Optimizers/ASGD.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp
@@ -72,8 +71,6 @@ namespace TorchSharp
 
     namespace Modules
     {
-        using static torch.optim;
-
         public class ASGD : OptimizerHelper
         {
             /// <summary>

--- a/src/TorchSharp/Optimizers/Adadelta.cs
+++ b/src/TorchSharp/Optimizers/Adadelta.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp
@@ -69,8 +68,6 @@ namespace TorchSharp
 
     namespace Modules
     {
-        using static torch.optim;
-
         public class Adadelta : OptimizerHelper
         {
             /// <summary>

--- a/src/TorchSharp/Optimizers/Adagrad.cs
+++ b/src/TorchSharp/Optimizers/Adagrad.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp
@@ -72,8 +71,6 @@ namespace TorchSharp
 
     namespace Modules
     {
-        using static torch.optim;
-
         public class Adagrad : OptimizerHelper
         {
             /// <summary>

--- a/src/TorchSharp/Optimizers/Adam.cs
+++ b/src/TorchSharp/Optimizers/Adam.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Optimizers/AdamW.cs
+++ b/src/TorchSharp/Optimizers/AdamW.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Optimizers/Adamax.cs
+++ b/src/TorchSharp/Optimizers/Adamax.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Optimizers/LRScheduler.cs
+++ b/src/TorchSharp/Optimizers/LRScheduler.cs
@@ -2,9 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Emit;
-using System.Runtime.InteropServices;
-using static TorchSharp.torch;
 
 // All LR schedulers in this file are directly based on the Pytorch implementation at:
 //

--- a/src/TorchSharp/Optimizers/NAdam.cs
+++ b/src/TorchSharp/Optimizers/NAdam.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Optimizers/RAdam.cs
+++ b/src/TorchSharp/Optimizers/RAdam.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Optimizers/RMSprop.cs
+++ b/src/TorchSharp/Optimizers/RMSprop.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Optimizers/Rprop.cs
+++ b/src/TorchSharp/Optimizers/Rprop.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp
@@ -72,8 +71,6 @@ namespace TorchSharp
 
     namespace Modules
     {
-        using static torch.optim;
-
         public class Rprop : OptimizerHelper
         {
             /// <summary>

--- a/src/TorchSharp/Optimizers/SGD.cs
+++ b/src/TorchSharp/Optimizers/SGD.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/Special.cs
+++ b/src/TorchSharp/Special.cs
@@ -1,13 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Globalization;
-using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
-
-using static TorchSharp.torch;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/Tensor/Size.cs
+++ b/src/TorchSharp/Tensor/Size.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
+
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections;

--- a/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
+++ b/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Globalization;
-using System.Linq;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/Tensor/Tensor.Math.cs
+++ b/src/TorchSharp/Tensor/Tensor.Math.cs
@@ -1,11 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Globalization;
 using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/Tensor/Tensor.Trig.cs
+++ b/src/TorchSharp/Tensor/Tensor.Trig.cs
@@ -1,11 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Globalization;
-using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
+
 namespace TorchSharp
 {
     public static partial class torch

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Data.Common;
 
 #nullable enable
 namespace TorchSharp

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -2,10 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 using static TorchSharp.Utils.LEB128Codec;
-using System.Runtime.CompilerServices;
 
 #nullable enable
 namespace TorchSharp

--- a/src/TorchSharp/Tensor/TensorTyped.handwritten.cs
+++ b/src/TorchSharp/Tensor/TensorTyped.handwritten.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Collections.Concurrent;
 
 // The scalar 'from' factories for complex tensors require some hand-written code, cannot be generated.
 

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/src/TorchSharp/TorchVision/AdjustBrightness.cs
+++ b/src/TorchSharp/TorchVision/AdjustBrightness.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
-
-using static TorchSharp.TensorExtensionMethods;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/AdjustContrast.cs
+++ b/src/TorchSharp/TorchVision/AdjustContrast.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
-
-using static TorchSharp.TensorExtensionMethods;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/AdjustGamma.cs
+++ b/src/TorchSharp/TorchVision/AdjustGamma.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
-
-using static TorchSharp.TensorExtensionMethods;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/AdjustHue.cs
+++ b/src/TorchSharp/TorchVision/AdjustHue.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using static TorchSharp.torch;
 
-using static TorchSharp.TensorExtensionMethods;
+using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/AdjustSaturation.cs
+++ b/src/TorchSharp/TorchVision/AdjustSaturation.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
-
-using static TorchSharp.TensorExtensionMethods;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/AdjustSharpness.cs
+++ b/src/TorchSharp/TorchVision/AdjustSharpness.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
-
-using static TorchSharp.TensorExtensionMethods;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/AutoContrast.cs
+++ b/src/TorchSharp/TorchVision/AutoContrast.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using static TorchSharp.torch;
 
-using static TorchSharp.TensorExtensionMethods;
+using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/CenterCrop.cs
+++ b/src/TorchSharp/TorchVision/CenterCrop.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/ColorJitter.cs
+++ b/src/TorchSharp/TorchVision/ColorJitter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Linq;
 using static TorchSharp.torch;
-using static TorchSharp.TensorExtensionMethods;
 
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/Compose.cs
+++ b/src/TorchSharp/TorchVision/Compose.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/ConvertImageDType.cs
+++ b/src/TorchSharp/TorchVision/ConvertImageDType.cs
@@ -1,10 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
-using static TorchSharp.TensorExtensionMethods;
 
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/Crop.cs
+++ b/src/TorchSharp/TorchVision/Crop.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/Equalize.cs
+++ b/src/TorchSharp/TorchVision/Equalize.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using static TorchSharp.torch;
 
-using static TorchSharp.TensorExtensionMethods;
+using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/Erase.cs
+++ b/src/TorchSharp/TorchVision/Erase.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/GaussianBlur.cs
+++ b/src/TorchSharp/TorchVision/GaussianBlur.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/Grayscale.cs
+++ b/src/TorchSharp/TorchVision/Grayscale.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/HorizontalFlip.cs
+++ b/src/TorchSharp/TorchVision/HorizontalFlip.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/ITransform.cs
+++ b/src/TorchSharp/TorchVision/ITransform.cs
@@ -1,9 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/Invert.cs
+++ b/src/TorchSharp/TorchVision/Invert.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/Lambda.cs
+++ b/src/TorchSharp/TorchVision/Lambda.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/Normalize.cs
+++ b/src/TorchSharp/TorchVision/Normalize.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/Pad.cs
+++ b/src/TorchSharp/TorchVision/Pad.cs
@@ -1,10 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
-using static TorchSharp.torch.nn;
 
 namespace TorchSharp.torchvision
 {

--- a/src/TorchSharp/TorchVision/Perspective.cs
+++ b/src/TorchSharp/TorchVision/Perspective.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/Posterize.cs
+++ b/src/TorchSharp/TorchVision/Posterize.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/RandomChoice.cs
+++ b/src/TorchSharp/TorchVision/RandomChoice.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/RandomPerspective.cs
+++ b/src/TorchSharp/TorchVision/RandomPerspective.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/RandomResizedCrop.cs
+++ b/src/TorchSharp/TorchVision/RandomResizedCrop.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/RandomRotation.cs
+++ b/src/TorchSharp/TorchVision/RandomRotation.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/Randomizer.cs
+++ b/src/TorchSharp/TorchVision/Randomizer.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/Resize.cs
+++ b/src/TorchSharp/TorchVision/Resize.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/ResizedCrop.cs
+++ b/src/TorchSharp/TorchVision/ResizedCrop.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/Rotate.cs
+++ b/src/TorchSharp/TorchVision/Rotate.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
+
 using System.Collections.Generic;
-using System.Text;
 using static TorchSharp.torch;
 
 namespace TorchSharp.torchvision

--- a/src/TorchSharp/TorchVision/Solarize.cs
+++ b/src/TorchSharp/TorchVision/Solarize.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/VerticalFlip.cs
+++ b/src/TorchSharp/TorchVision/VerticalFlip.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+
 using static TorchSharp.torch;
 
 

--- a/src/TorchSharp/TorchVision/dsets/CIFAR.cs
+++ b/src/TorchSharp/TorchVision/dsets/CIFAR.cs
@@ -1,13 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
-using TorchSharp.Utils;
 using static TorchSharp.torch;
 using static TorchSharp.torch.utils.data;
 

--- a/src/TorchSharp/TorchVision/dsets/MNIST.cs
+++ b/src/TorchSharp/TorchVision/dsets/MNIST.cs
@@ -1,12 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections;
+
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using TorchSharp.Utils;
 using static TorchSharp.torch;
 using static TorchSharp.torch.utils.data;

--- a/src/TorchSharp/Utils/LEB128Codec.cs
+++ b/src/TorchSharp/Utils/LEB128Codec.cs
@@ -2,7 +2,6 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace TorchSharp.Utils
 {

--- a/src/TorchSharp/netstandard.cs
+++ b/src/TorchSharp/netstandard.cs
@@ -6,7 +6,6 @@
 //
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Dynamic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;

--- a/test/TorchSharpTest/TestDataLoader.cs
+++ b/test/TorchSharpTest/TestDataLoader.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using Xunit;
-using Xunit.Abstractions;
 
 
 namespace TorchSharp

--- a/test/TorchSharpTest/TestDisposeScopes.cs
+++ b/test/TorchSharpTest/TestDisposeScopes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/TorchSharpTest/TestDistributions.cs
+++ b/test/TorchSharpTest/TestDistributions.cs
@@ -1,8 +1,4 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
 
 using static TorchSharp.torch;
 using static TorchSharp.torch.distributions;

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -2,8 +2,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-
 using TorchSharp.Modules;
 using static TorchSharp.torch.nn;
 using Xunit;

--- a/test/TorchSharpTest/TestSaveSD.cs
+++ b/test/TorchSharpTest/TestSaveSD.cs
@@ -1,9 +1,4 @@
-using System;
-using System.IO;
-using System.Linq;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 using TorchSharp.Modules;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Runtime.InteropServices;
-using TorchSharp;
+
 using Xunit;
 
 using static TorchSharp.torch;

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -6,8 +6,6 @@ using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Globalization;
 using static TorchSharp.torch;
-using static TorchSharp.TensorExtensionMethods;
-
 using Xunit;
 
 #nullable enable

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -2,14 +2,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
-
 using static TorchSharp.torch.nn;
 using static TorchSharp.torch.nn.functional;
 using Xunit;
 
 using static TorchSharp.torch;
-using System.Reflection.Metadata.Ecma335;
 using TorchSharp.Modules;
 
 #nullable enable


### PR DESCRIPTION
This diff removes unused namespace imports in order to declutter autocomplete. 