### PR TITLE
Fixed GRU, LSTM and RNN to honor the device

### DIFF
--- a/src/TorchSharp/NN/Recurrent/GRU.cs
+++ b/src/TorchSharp/NN/Recurrent/GRU.cs
@@ -41,7 +41,7 @@ namespace TorchSharp
                     var N = _batch_first ? input.shape[0] : input.shape[1];
                     var D = _bidirectional ? 2 : 1;
 
-                    h0 = torch.zeros(new long[] { D * _num_layers, N, _hidden_size });
+                    h0 = torch.zeros(new long[] { D * _num_layers, N, _hidden_size }, device:input.device);
                 }
 
                 var res = THSNN_GRU_forward(handle, input.Handle, h0.Handle, out IntPtr hN);

--- a/src/TorchSharp/NN/Recurrent/LSTM.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTM.cs
@@ -42,8 +42,8 @@ namespace TorchSharp
                     var N = _batch_first ? input.shape[0] : input.shape[1];
                     var D = _bidirectional ? 2 : 1;
 
-                    c0 = torch.zeros(new long[] { D * _num_layers, N, _hidden_size });
-                    h0 = torch.zeros(new long[] { D * _num_layers, N, _hidden_size });                   
+                    c0 = torch.zeros(new long[] { D * _num_layers, N, _hidden_size }, device: input.device);
+                    h0 = torch.zeros(new long[] { D * _num_layers, N, _hidden_size }, device: input.device);
                 }
                 else {
                     h0 = h0_c0.Value.Item1;

--- a/src/TorchSharp/NN/Recurrent/RNN.cs
+++ b/src/TorchSharp/NN/Recurrent/RNN.cs
@@ -41,7 +41,7 @@ namespace TorchSharp
                     var N = _batch_first ? input.shape[0] : input.shape[1];
                     var D = _bidirectional ? 2 : 1;
 
-                    h0 = torch.zeros(new long[] { D * _num_layers, N, _hidden_size });
+                    h0 = torch.zeros(new long[] { D * _num_layers, N, _hidden_size }, device: input.device);
                 }
 
                 var res = THSNN_RNN_forward(handle, input.Handle, h0.Handle, out IntPtr hN);

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Globalization;
 using static TorchSharp.Utils.LEB128Codec;
 
 #nullable enable
@@ -41,6 +42,7 @@ namespace TorchSharp
         /// <param name="fltFormat">The format string to use for floating point values.</param>
         /// <param name="width">The width of each line of the output string.</param>
         /// <param name="newLine">The newline string to use, defaults to system default.</param>
+        /// <param name="cultureInfo">The culture info to be used when formatting the numbers.</param>
         /// <returns></returns>
         /// <remarks>
         /// This method does exactly the same as ToString(bool, string, int), but is shorter,
@@ -49,9 +51,9 @@ namespace TorchSharp
         ///
         /// Primarily intended for use in interactive notebooks.
         /// </remarks>
-        public static string str(this Tensor tensor, TensorStringStyle style = TensorStringStyle.Julia, string fltFormat = "g5", int width = 100, string newLine = "\n")
+        public static string str(this Tensor tensor, TensorStringStyle style = TensorStringStyle.Julia, string fltFormat = "g5", int width = 100, string newLine = "\n", CultureInfo? cultureInfo = null)
         {
-            return tensor.ToString(style, fltFormat, width, newLine: newLine);
+            return tensor.ToString(style, fltFormat, width, newLine: newLine, cultureInfo:cultureInfo);
         }
 
         /// <summary>

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -130,7 +130,7 @@ namespace TorchSharp
             }
             {
                 Tensor t = torch.tensor(new float[] { 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f }, 2, 4);
-                var str = t.str();
+                var str = t.str(cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[2x4], type = Float32, device = cpu\n        0   3.141 6.2834 3.1415\n 6.28e-06 -13.142   0.01 4713.1\n", str);
             }
             {
@@ -256,7 +256,7 @@ namespace TorchSharp
             {
                 Tensor t = torch.ones(4, torch.complex64);
                 for (int i = 0; i < t.shape[0]; i++) t[i] = torch.tensor((1.0f * i, 2.43f * i * 2), torch.complex64);
-                var str = t.ToString(TensorStringStyle.Numpy);
+                var str = t.ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[0 1+4.86i 2+9.72i 3+14.58i]", str);
             }
             Assert.Equal("[1 1 1 ... 1 1 1]", torch.ones(100, ScalarType.Int32).ToString(TensorStringStyle.Numpy));
@@ -266,13 +266,13 @@ namespace TorchSharp
         [Fact]
         public void Test2DToNumpyString()
         {
-            Assert.Equal($"[[0 3.141 6.2834 3.1415]{_sep} [6.28e-06 -13.142 0.01 4713.1]]", torch.tensor(new float[] { 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f }, 2, 4).ToString(TensorStringStyle.Numpy));
+            Assert.Equal($"[[0 3.141 6.2834 3.1415]{_sep} [6.28e-06 -13.142 0.01 4713.1]]", torch.tensor(new float[] { 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f }, 2, 4).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
             {
                 Tensor t = torch.zeros(5, 5, torch.complex64);
                 for(int i = 0; i < t.shape[0]; i++)
                     for(int j = 0; j < t.shape[1]; j++)
                         t[i][j] = torch.tensor((1.24f * i, 2.491f * i * 2), torch.complex64);
-                var str = t.ToString(TensorStringStyle.Numpy);
+                var str = t.ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[[0 0 0 0 0]{_sep} [1.24+4.982i 1.24+4.982i 1.24+4.982i 1.24+4.982i 1.24+4.982i]{_sep} [2.48+9.964i 2.48+9.964i 2.48+9.964i 2.48+9.964i 2.48+9.964i]{_sep} [3.72+14.946i 3.72+14.946i 3.72+14.946i 3.72+14.946i 3.72+14.946i]{_sep} [4.96+19.928i 4.96+19.928i 4.96+19.928i 4.96+19.928i 4.96+19.928i]]", str);
             }
             Assert.Equal($"[[0 0 0 0]{_sep} [0 0 0 0]]", torch.zeros(2, 4, torch.complex64).ToString(TensorStringStyle.Numpy));
@@ -293,10 +293,10 @@ namespace TorchSharp
                         new float[] {
                             0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f, 0.01f, 0.0f, 0.0f,
                             0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-                        }, 2, 2, 4).ToString(TensorStringStyle.Numpy));
-                var actual = torch.tensor(Enumerable.Range(1, 250).Select(x => x * 2 + 5).ToList(), new long[] { 5, 5, 10 }, ScalarType.Float32).ToString(TensorStringStyle.Numpy);
+                        }, 2, 2, 4).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
+                var actual = torch.tensor(Enumerable.Range(1, 250).Select(x => x * 2 + 5).ToList(), new long[] { 5, 5, 10 }, ScalarType.Float32).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[[[7 9 11 ... 21 23 25]{_sep}  [27 29 31 ... 41 43 45]{_sep}  [47 49 51 ... 61 63 65]{_sep}  [67 69 71 ... 81 83 85]{_sep}  [87 89 91 ... 101 103 105]]{_sep}{_sep} [[107 109 111 ... 121 123 125]{_sep}  [127 129 131 ... 141 143 145]{_sep}  [147 149 151 ... 161 163 165]{_sep}  [167 169 171 ... 181 183 185]{_sep}  [187 189 191 ... 201 203 205]]{_sep}{_sep} [[207 209 211 ... 221 223 225]{_sep}  [227 229 231 ... 241 243 245]{_sep}  [247 249 251 ... 261 263 265]{_sep}  [267 269 271 ... 281 283 285]{_sep}  [287 289 291 ... 301 303 305]]{_sep}{_sep} [[307 309 311 ... 321 323 325]{_sep}  [327 329 331 ... 341 343 345]{_sep}  [347 349 351 ... 361 363 365]{_sep}  [367 369 371 ... 381 383 385]{_sep}  [387 389 391 ... 401 403 405]]{_sep}{_sep} [[407 409 411 ... 421 423 425]{_sep}  [427 429 431 ... 441 443 445]{_sep}  [447 449 451 ... 461 463 465]{_sep}  [467 469 471 ... 481 483 485]{_sep}  [487 489 491 ... 501 503 505]]]",
-                    torch.tensor(Enumerable.Range(1, 250).Select(x => x * 2 + 5).ToList(), new long[] { 5, 5, 10 }, ScalarType.Float32).ToString(TensorStringStyle.Numpy));
+                    torch.tensor(Enumerable.Range(1, 250).Select(x => x * 2 + 5).ToList(), new long[] { 5, 5, 10 }, ScalarType.Float32).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
             }
         }
 
@@ -308,7 +308,7 @@ namespace TorchSharp
                 0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f,
                 0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-            }, 2, 2, 2, 4).ToString(TensorStringStyle.Numpy));
+            }, 2, 2, 2, 4).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -324,7 +324,7 @@ namespace TorchSharp
                         6.28e-06f, -13.141529f, 0.01f, 4713.14f, 0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                         3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f, 0.01f, 0.0f, 0.0f, 0.0f,
                         0.0f, 0.0f, 0.0f, 0.0f,
-                    }, new long[] {2, 2, 2, 2, 4}).ToString(TensorStringStyle.Numpy));
+                    }, new long[] {2, 2, 2, 2, 4}).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -345,7 +345,7 @@ namespace TorchSharp
                         3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f, 0.01f, 0.0f, 0.0f, 0.0f,
                         0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f,
                         4713.14f, 0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-                    }, new long[] {2, 2, 2, 2, 2, 4}).ToString(TensorStringStyle.Numpy));
+                    }, new long[] {2, 2, 2, 2, 2, 4}).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
         }
 
 

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -637,17 +637,43 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void DemonstrateGruIssu()
+        public void GruModuleWorksWithoutPassingH0()
         {
-            // This test fails if the proposed fix in GRU isn't included - remove
-            // , device:input.device from GRU.forward and this test fails in CUDA. Works in CPU though.
             var device = torch.cuda.is_available() ? torch.CUDA : torch.CPU;
             using (Tensor input = torch.randn(new long[] { 5, 3, 10 }, device:device),
                    h0 = torch.randn(new long[] { 1, 3, 20 }, device:device))
             using (var gru = GRU(10, 20)) {
                 gru.to(device);
-                // Note how h0 isn't passed along here, it's just kept for the assert below.
                 var (output, hN) = gru.forward(input);
+                Assert.Equal(h0.shape, hN.shape);
+                Assert.Equal(new long[] { input.shape[0], input.shape[1], 20 }, output.shape);
+            }
+        }
+
+        [Fact]
+        public void LstmModuleWorksWithoutPassingH0C0()
+        {
+            var device = torch.cuda.is_available() ? torch.CUDA : torch.CPU;
+            using (Tensor input = torch.randn(new long[] { 5, 3, 10 }, device:device),
+                   h0 = torch.randn(new long[] { 1, 3, 20 }, device:device))
+            using (var lstm = LSTM(10, 20)) {
+                lstm.to(device);
+                var (output, hN, hX) = lstm.forward(input);
+                Assert.Equal(h0.shape, hN.shape);
+                Assert.Equal(h0.shape, hX.shape);
+                Assert.Equal(new long[] { input.shape[0], input.shape[1], 20 }, output.shape);
+            }
+        }
+
+        [Fact]
+        public void RnnModuleWorksWithoutPassingH0()
+        {
+            var device = torch.cuda.is_available() ? torch.CUDA : torch.CPU;
+            using (Tensor input = torch.randn(new long[] { 5, 3, 10 }, device:device),
+                   h0 = torch.randn(new long[] { 1, 3, 20 }, device:device))
+            using (var rnn = RNN(10, 20)) {
+                rnn.to(device);
+                var (output, hN) = rnn.forward(input);
                 Assert.Equal(h0.shape, hN.shape);
                 Assert.Equal(new long[] { input.shape[0], input.shape[1], 20 }, output.shape);
             }

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -635,5 +635,22 @@ namespace TorchSharp
                 return this.seq.forward(t);
             }
         }
+
+        [Fact]
+        public void DemonstrateGruIssu()
+        {
+            // This test fails if the proposed fix in GRU isn't included - remove
+            // , device:input.device from GRU.forward and this test fails in CUDA. Works in CPU though.
+            var device = torch.cuda.is_available() ? torch.CUDA : torch.CPU;
+            using (Tensor input = torch.randn(new long[] { 5, 3, 10 }, device:device),
+                   h0 = torch.randn(new long[] { 1, 3, 20 }, device:device))
+            using (var gru = GRU(10, 20)) {
+                gru.to(device);
+                // Note how h0 isn't passed along here, it's just kept for the assert below.
+                var (output, hN) = gru.forward(input);
+                Assert.Equal(h0.shape, hN.shape);
+                Assert.Equal(new long[] { input.shape[0], input.shape[1], 20 }, output.shape);
+            }
+        }
     }
 }


### PR DESCRIPTION
The GRU, LSTM and RNN would create cpu weights if no weights were provided. Now the device of the input is used instead.

Also fixed issues where number formatting was missing - failing tests on machines with different string formatting settings.