### PR TITLE
Started on torchvision.models.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,7 +8,9 @@ __API Changes:__
 
 #587 Added the Storage classes, and Tensor.storage()<br/>
 Added torchvision.models.resnet***() factories<br/>
-Added 'skip' list for loading and saving Module weights.
+Added torchvision.models.alexnet() factory<br/>
+Added torchvision.models.vgg*() factories<br/>
+Added 'skip' list for loading and saving weights.
 
 __Fixed Bugs:__
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,9 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 __API Changes:__
 
-#587 Added the Storage classes, and Tensor.storage()
+#587 Added the Storage classes, and Tensor.storage()<br/>
+Added torchvision.models.resnet***() factories<br/>
+Added 'skip' list for loading and saving Module weights.
 
 __Fixed Bugs:__
 

--- a/src/Examples/CIFAR10.cs
+++ b/src/Examples/CIFAR10.cs
@@ -60,7 +60,7 @@ namespace TorchSharp.Examples
 
             switch (modelName.ToLower()) {
             case "alexnet":
-                model = new AlexNet(modelName, _numClasses, device);
+                model = torchvision.models.alexnet(_numClasses, device:device);  // new AlexNet(modelName, _numClasses, device);
                 break;
             case "mobilenet":
                 model = new MobileNet(modelName, _numClasses, device);
@@ -69,7 +69,8 @@ namespace TorchSharp.Examples
             case "vgg13":
             case "vgg16":
             case "vgg19":
-                model = new VGG(modelName, _numClasses, device);
+                model = torchvision.models.vgg11_bn(1000); //new VGG(modelName, _numClasses, device);
+                model.load(@"c:\Users\niklasg\source\Testing\Python\vgg11_bn.dat");
                 break;
             case "resnet18":
                 model = ResNet.ResNet18(_numClasses, device);
@@ -101,12 +102,13 @@ namespace TorchSharp.Examples
             var gray = torchvision.transforms.Grayscale(3);
             var rotate = torchvision.transforms.Rotate(90);
             var contrast = torchvision.transforms.AdjustContrast(1.25);
+            var resize = torchvision.transforms.Resize(224, 224);
 
             Console.WriteLine($"\tPreparing training and test data...");
             Console.WriteLine();
 
-            using (Dataset train_data = torchvision.datasets.CIFAR100(datasetPath, true, download: true),
-                           test_data = torchvision.datasets.CIFAR100(datasetPath, false, download: true))
+            using (Dataset train_data = torchvision.datasets.CIFAR100(datasetPath, true, download: true, target_transform: resize),
+                           test_data = torchvision.datasets.CIFAR100(datasetPath, false, download: true, target_transform: resize))
             {
                 using var train = new DataLoader(train_data, _trainBatchSize, device: device, shuffle: true);
                 using var test = new DataLoader(test_data, _testBatchSize, device: device, shuffle: false);

--- a/src/Examples/ResNet.cs
+++ b/src/Examples/ResNet.cs
@@ -15,9 +15,6 @@ namespace TorchSharp.Examples
         // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/resnet.py
         // Licence and copypright notice at: https://github.com/kuangliu/pytorch-cifar/blob/master/LICENSE
 
-        private readonly long[] planes = new long[] { 64, 128, 128, 256, 256, 512, 512, 512, 512, 512, 512, 1024, 1024 };
-        private readonly long[] strides = new long[] { 1, 2, 1, 2, 1, 2, 1, 1, 1, 1, 1, 2, 1 };
-
         private readonly Module layers;
         private int in_planes = 64;
 
@@ -64,7 +61,7 @@ namespace TorchSharp.Examples
         public static ResNet ResNet152(int numClasses, Device device = null)
         {
             return new ResNet(
-                "ResNet101",
+                "ResNet152",
                 (name, in_planes, planes, stride) => new Bottleneck(name, in_planes, planes, stride),
                 Bottleneck.expansion, new int[] { 3, 4, 36, 3 },
                 10,
@@ -73,8 +70,6 @@ namespace TorchSharp.Examples
 
         public ResNet(string name, Func<string, int,int,int,Module> block, int expansion, IList<int> num_blocks, int numClasses, Device device = null) : base(name)
         {
-            if (planes.Length != strides.Length) throw new ArgumentException("'planes' and 'strides' must have the same length.");
-
             var modules = new List<(string, Module)>();
 
             modules.Add(($"conv2d-first", Conv2d(3, 64, kernelSize: 3, stride: 1, padding: 1, bias: false)));

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -228,6 +228,11 @@ EXPORT_API(void)     THSNN_LayerNorm_set_weight(const NNModule module, const Ten
 EXPORT_API(NNModule) THSNN_GroupNorm_ctor(const int64_t num_groups, const int64_t num_channels, const double eps, const bool affine, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_GroupNorm_forward(const NNModule module, const Tensor tensor);
 
+EXPORT_API(Tensor)   THSNN_GroupNorm_bias(const NNModule module);
+EXPORT_API(void)     THSNN_GroupNorm_set_bias(const NNModule module, const Tensor bias);
+EXPORT_API(Tensor)   THSNN_GroupNorm_weight(const NNModule module);
+EXPORT_API(void)     THSNN_GroupNorm_set_weight(const NNModule module, const Tensor weight);
+
 EXPORT_API(NNModule) THSNN_LocalResponseNorm_ctor(const int64_t size, const double alpha, const double beta, const double k, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_LocalResponseNorm_forward(const NNModule module, const Tensor tensor);
 

--- a/src/Native/LibTorchSharp/THSNormalization.cpp
+++ b/src/Native/LibTorchSharp/THSNormalization.cpp
@@ -70,6 +70,27 @@ Tensor THSNN_GroupNorm_forward(const NNModule module, const Tensor tensor)
     CATCH_TENSOR((*module)->as<torch::nn::GroupNorm>()->forward(*tensor));
 }
 
+Tensor THSNN_GroupNorm_bias(const NNModule module)
+{
+    return get_bias<torch::nn::GroupNorm>(module);
+}
+
+void THSNN_GroupNorm_set_bias(const NNModule module, const Tensor bias)
+{
+    set_bias<torch::nn::GroupNorm>(module, bias);
+}
+
+Tensor THSNN_GroupNorm_weight(const NNModule module)
+{
+    return get_weight<torch::nn::GroupNorm>(module);
+}
+
+void THSNN_GroupNorm_set_weight(const NNModule module, const Tensor weight)
+{
+    set_weight<torch::nn::GroupNorm>(module, weight);
+}
+
+
 NNModule THSNN_InstanceNorm1d_ctor(const int64_t features, const double eps, const double momentum, const bool affine, const bool track_running_stats, NNAnyModule* outAsAnyModule)
 {
     CATCH_RETURN_NNModule(

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -106,6 +106,11 @@ namespace TorchSharp
                 protected virtual void Dispose(bool disposing)
                 {
                     if (disposing) {
+
+                        foreach (var (_,m) in named_modules()) {
+                            m.Dispose();
+                        }
+
                         handle.Dispose();
                         handle.SetHandleAsInvalid();
                         boxedModule?.Dispose();

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -96,8 +96,8 @@ namespace TorchSharp
                 /// </summary>
                 public void Dispose()
                 {
-                    Dispose(true);
                     GC.SuppressFinalize(this);
+                    Dispose(true);
                 }
 
                 /// <summary>
@@ -105,7 +105,14 @@ namespace TorchSharp
                 /// </summary>
                 protected virtual void Dispose(bool disposing)
                 {
-                    if (disposing) {
+                    if (disposing && !handle.IsInvalid) {
+
+                        foreach (var (_, p) in named_buffers(false)) {
+                            p.Dispose();
+                        }
+                        foreach (var (_, b) in named_parameters(false)) {
+                            b.Dispose();
+                        }
 
                         foreach (var (_,m) in named_modules()) {
                             m.Dispose();
@@ -502,8 +509,8 @@ namespace TorchSharp
                     if (!recurse) yield break;
                     foreach (var (submoduleName, subModule) in _internal_submodules) {
                         foreach (var (parameterName, parameter) in subModule.named_parameters(true)) {
-                            if (seen.Contains(parameter.Handle)) continue;
-                            seen.Add(parameter.Handle);
+                            if (seen.Contains(parameter.handle)) continue;
+                            seen.Add(parameter.handle);
                             yield return ($"{submoduleName}.{parameterName}", parameter);
                         }
                     }

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -418,7 +418,7 @@ namespace TorchSharp
                 {
                     List<string> missing = new List<string>();
                     List<string> unexpected = new List<string>();
-                    skip ??= new List<string>();
+                    skip ??= Array.Empty<string>();
 
                     var destination = state_dict();
 
@@ -823,7 +823,7 @@ namespace TorchSharp
                 /// </remarks>
                 public virtual Module load(System.IO.BinaryReader reader, bool strict = true, IList<string> skip = null)
                 {
-                    skip ??= new List<string>();
+                    skip ??= Array.Empty<string>();
 
                     var sd = state_dict();
 

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -412,25 +412,25 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="source">A dict containing parameters and persistent buffers.</param>
                 /// <param name="strict">Whether to strictly enforce that the keys in state_dict match the keys returned by this module’s state_dict() function.</param>
-                /// <param name="skipped">A list of keys not to consider when loading the dictionary.</param>
+                /// <param name="skip">A list of keys not to consider when loading the dictionary.</param>
                 /// <returns></returns>
-                public virtual (IList<string> missing_keys, IList<string> unexpected_keyes) load_state_dict(Dictionary<string, Tensor> source, bool strict = true, IList<string> skipped = null)
+                public virtual (IList<string> missing_keys, IList<string> unexpected_keyes) load_state_dict(Dictionary<string, Tensor> source, bool strict = true, IList<string> skip = null)
                 {
                     List<string> missing = new List<string>();
                     List<string> unexpected = new List<string>();
-                    if (skipped is null) skipped = new List<string>();
+                    skip ??= new List<string>();
 
                     var destination = state_dict();
 
                     foreach (var key in source.Keys) {
-                        if (skipped.Contains(key)) continue;
+                        if (skip.Contains(key)) continue;
                         if (!destination.ContainsKey(key)) {
                             unexpected.Add(key);
                         }
                     }
 
                     foreach (var key in destination.Keys) {
-                        if (skipped.Contains(key)) continue;
+                        if (skip.Contains(key)) continue;
                         if (!source.ContainsKey(key)) {
                             missing.Add(key);
                         }
@@ -440,7 +440,7 @@ namespace TorchSharp
                         throw new InvalidOperationException("The loaded state_dict is not identical to the target dictionary.");
 
                     foreach (var key in source.Keys) {
-                        if (skipped.Contains(key)) continue;
+                        if (skip.Contains(key)) continue;
                         if (destination.ContainsKey(key)) {
                             destination[key].bytes = source[key].bytes;
                         }
@@ -823,7 +823,7 @@ namespace TorchSharp
                 /// </remarks>
                 public virtual Module load(System.IO.BinaryReader reader, bool strict = true, IList<string> skip = null)
                 {
-                    if (skip == null) skip = new List<string>();
+                    skip ??= new List<string>();
 
                     var sd = state_dict();
 

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -143,14 +143,12 @@ namespace TorchSharp
                             var fieldName = field.Name;
                             var value = field.GetValue(this);
 
-                            switch (value)
-                            {
-                                // This test must come before the Tensor test
-                                case Parameter param when deviceType == param.device_type && deviceIndex == param.device_index:
-                                    continue;
+                            switch (value) {
+                            // This test must come before the Tensor test
+                            case Parameter param when deviceType == param.device_type && deviceIndex == param.device_index:
+                                continue;
 
-                                case Parameter param:
-                                {
+                            case Parameter param: {
                                     var t = param.to(deviceType, deviceIndex);
                                     t.retain_grad();
                                     var p = new Parameter(t, param.requires_grad);
@@ -159,8 +157,7 @@ namespace TorchSharp
                                     break;
                                 }
 
-                                case Tensor tensor when (deviceType != tensor.device_type || deviceIndex != tensor.device_index):
-                                {
+                            case Tensor tensor when (deviceType != tensor.device_type || deviceIndex != tensor.device_index): {
                                     var t = tensor.to(deviceType, deviceIndex);
                                     field.SetValue(this, t);
                                     ConditionallyRegisterBuffer(fieldName, t);
@@ -211,14 +208,12 @@ namespace TorchSharp
                         var fieldName = field.Name;
                         var value = field.GetValue(this);
 
-                        switch (value)
-                        {
-                            // This test must come before the Tensor test
-                            case Parameter param when dtype == param.dtype:
-                                continue;
+                        switch (value) {
+                        // This test must come before the Tensor test
+                        case Parameter param when dtype == param.dtype:
+                            continue;
 
-                            case Parameter param:
-                            {
+                        case Parameter param: {
                                 var t = param.to(dtype);
                                 t.retain_grad();
                                 var p = new Parameter(t, param.requires_grad);
@@ -227,11 +222,10 @@ namespace TorchSharp
                                 break;
                             }
 
-                            case Tensor tensor when dtype == tensor.dtype:
-                                continue;
+                        case Tensor tensor when dtype == tensor.dtype:
+                            continue;
 
-                            case Tensor tensor:
-                            {
+                        case Tensor tensor: {
                                 var t = tensor.to(dtype);
                                 field.SetValue(this, t);
                                 ConditionallyRegisterBuffer(fieldName, t);
@@ -266,7 +260,7 @@ namespace TorchSharp
                 /// <returns></returns>
                 public virtual Module apply(Action<Module> fn)
                 {
-                    foreach (var (_,m) in _internal_submodules) m.apply(fn);
+                    foreach (var (_, m) in _internal_submodules) m.apply(fn);
                     fn(this);
                     return this;
                 }
@@ -403,7 +397,7 @@ namespace TorchSharp
                         destination.TryAdd(key, p.Item2);
                     }
 
-                    foreach (var (n,p) in _internal_submodules) {
+                    foreach (var (n, p) in _internal_submodules) {
                         var key = string.IsNullOrEmpty(prefix) ? $"{n}" : $"{prefix}.{n}";
                         p.state_dict(destination, key);
                     }
@@ -418,30 +412,35 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="source">A dict containing parameters and persistent buffers.</param>
                 /// <param name="strict">Whether to strictly enforce that the keys in state_dict match the keys returned by this module’s state_dict() function.</param>
+                /// <param name="skipped">A list of keys not to consider when loading the dictionary.</param>
                 /// <returns></returns>
-                public virtual (IList<string> missing_keys, IList<string> unexpected_keyes) load_state_dict(Dictionary<string, Tensor> source, bool strict = true)
+                public virtual (IList<string> missing_keys, IList<string> unexpected_keyes) load_state_dict(Dictionary<string, Tensor> source, bool strict = true, IList<string> skipped = null)
                 {
                     List<string> missing = new List<string>();
                     List<string> unexpected = new List<string>();
+                    if (skipped is null) skipped = new List<string>();
 
                     var destination = state_dict();
 
                     foreach (var key in source.Keys) {
+                        if (skipped.Contains(key)) continue;
                         if (!destination.ContainsKey(key)) {
                             unexpected.Add(key);
                         }
                     }
 
                     foreach (var key in destination.Keys) {
+                        if (skipped.Contains(key)) continue;
                         if (!source.ContainsKey(key)) {
                             missing.Add(key);
                         }
                     }
 
                     if (strict && (missing.Count > 0 || unexpected.Count > 0))
-                        throw new InvalidOperationException("The loaded state_dict is not identica to the target dictionary.");
+                        throw new InvalidOperationException("The loaded state_dict is not identical to the target dictionary.");
 
                     foreach (var key in source.Keys) {
+                        if (skipped.Contains(key)) continue;
                         if (destination.ContainsKey(key)) {
                             destination[key].bytes = source[key].bytes;
                         }
@@ -720,30 +719,50 @@ namespace TorchSharp
                 /// Save the parameters and buffers of the module to a disk location.
                 /// </summary>
                 /// <param name="location">The file path.</param>
+                /// <param name="skip">A list of keys not to consider when saving the weights.</param>
                 /// <returns></returns>
-                public Module save(string location)
+                public Module save(string location, IList<string> skip = null)
                 {
                     using var stream = System.IO.File.OpenWrite(location);
                     using var writer = new System.IO.BinaryWriter(stream);
-                    save(writer);
+                    save(writer, skip);
 
                     return this;
                 }
 
-                public Module save(System.IO.BinaryWriter writer)
+                /// <summary>
+                /// Save the parameters and buffers of the module to a disk location.
+                /// </summary>
+                /// <param name="writer">A binary writer instance.</param>
+                /// <param name="skip">A list of keys not to consider when saving the weights.</param>
+                /// <returns></returns>
+                public Module save(System.IO.BinaryWriter writer, IList<string> skip = null)
                 {
                     var sd = state_dict();
 
                     // First, write how many entries.
-                    SaveStateDictionary(writer, sd);
+                    save_state_dict(writer, sd, skip);
 
                     return this;
                 }
 
-                public static void SaveStateDictionary(
-                    System.IO.BinaryWriter writer,
-                    Dictionary<string, Tensor> sd)
+                /// <summary>
+                /// 
+                /// </summary>
+                /// <param name="writer">A binary writer instance.</param>
+                /// <param name="skip">A list of keys not to consider when saving the weights.</param>
+                /// <param name="sd">A dictionary containing all the buffers and parameters of the module.</param>
+                public static void save_state_dict(System.IO.BinaryWriter writer, Dictionary<string, Tensor> sd, IList<string> skip = null)
                 {
+                    if (skip is not null && skip.Count > 0) {
+                        // We need to make a copy, so that the passed-in 'sd' isn't modified.
+                        var tmp = new Dictionary<string, Tensor>();
+                        foreach (var kv in sd.Where(kv => !skip.Contains(kv.Key))) {
+                            tmp.Add(kv.Key, kv.Value);
+                        }
+                        sd = tmp;
+                    }
+
                     writer.Encode(sd.Count); // 4 bytes
 
                     foreach (var kvp in sd) {
@@ -761,8 +780,14 @@ namespace TorchSharp
                 /// If false, will load the parameters and buffers that it finds in the saved file,
                 /// leaving everything else alone.
                 /// </param>
-                /// <returns></returns>
-                public Module load(string location, bool strict = true)
+                /// <param name="skip">A list of keys not to consider when loading the dictionary.</param>              
+                /// <returns>The module, with parameters and buffers loaded.</returns>
+                /// <remarks>
+                /// Using a skip list only prevents tensors in the target module from being modified, it
+                /// does not alter any logic related to checking for matching tensor element types or entries.
+                /// It may be necessary to also pass 'strict=false' to avoid exceptions.
+                /// </remarks>
+                public Module load(string location, bool strict = true, IList<string> skip = null)
                 {
                     var dt = _deviceType;
                     var di = _deviceIndex;
@@ -772,7 +797,7 @@ namespace TorchSharp
                     try {
                         using var stream = System.IO.File.OpenRead(location);
                         using var reader = new System.IO.BinaryReader(stream);
-                        load(reader, strict);
+                        load(reader, strict, skip);
                     } finally {
                         to(dt, di);
                     }
@@ -780,8 +805,26 @@ namespace TorchSharp
                     return this;
                 }
 
-                public virtual Module load(System.IO.BinaryReader reader, bool strict = true)
+                /// <summary>
+                /// Load the parameters and buffers
+                /// </summary>
+                /// <param name="reader">A binary reader instance.</param>
+                /// <param name="strict">
+                /// If true, will only load a module if it exactly corresponds to the current module's state.
+                /// If false, will load the parameters and buffers that it finds in the saved file,
+                /// leaving everything else alone.
+                /// </param>
+                /// <param name="skip">A list of keys not to consider when loading the dictionary.</param>
+                /// <returns>The module, with parameters and buffers loaded.</returns>
+                /// <remarks>
+                /// Using a skip list only prevents tensors in the target module from being modified, it
+                /// does not alter any logic related to checking for matching tensor element types or entries.
+                /// It may be necessary to also pass 'strict=false' to avoid exceptions.
+                /// </remarks>
+                public virtual Module load(System.IO.BinaryReader reader, bool strict = true, IList<string> skip = null)
                 {
+                    if (skip == null) skip = new List<string>();
+
                     var sd = state_dict();
 
                     // First, figure out how many entries.
@@ -797,7 +840,7 @@ namespace TorchSharp
                             throw new ArgumentException($"Mismatched module state names: the target modules does not have a submodule or buffer named '{key}'");
 
                         if (found) {
-                            sd[key].Load(reader);
+                            sd[key].Load(reader, skip: skip.Contains(key));
                         }
                     }
 
@@ -869,17 +912,16 @@ namespace TorchSharp
 
                         var value = field.GetValue(this);
 
-                        switch (value)
-                        {
-                            case Module module:
-                                register_module(fieldName, module);
-                                break;
-                            case Parameter param: // This test must come before the Tensor test
-                                register_parameter(fieldName, param);
-                                break;
-                            case Tensor tensor:
-                                register_buffer(fieldName, tensor);
-                                break;
+                        switch (value) {
+                        case Module module:
+                            register_module(fieldName, module);
+                            break;
+                        case Parameter param: // This test must come before the Tensor test
+                            register_parameter(fieldName, param);
+                            break;
+                        case Tensor tensor:
+                            register_buffer(fieldName, tensor);
+                            break;
                         }
                     }
 

--- a/src/TorchSharp/NN/Normalization/GroupNorm.cs
+++ b/src/TorchSharp/NN/Normalization/GroupNorm.cs
@@ -29,6 +29,42 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
+
+            [DllImport("LibTorchSharp")]
+            private static extern IntPtr THSNN_GroupNorm_bias(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_GroupNorm_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            [DllImport("LibTorchSharp")]
+            private static extern IntPtr THSNN_GroupNorm_weight(torch.nn.Module.HType module);
+            [DllImport("LibTorchSharp")]
+            private static extern void THSNN_GroupNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+            public Parameter bias {
+                get {
+                    var res = THSNN_GroupNorm_bias(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Parameter(res);
+                }
+                set {
+                    THSNN_GroupNorm_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("bias", value);
+                }
+            }
+
+            public Parameter weight {
+                get {
+                    var res = THSNN_GroupNorm_weight(handle);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Parameter(res);
+                }
+                set {
+                    THSNN_GroupNorm_set_weight(handle, value.Handle);
+                    torch.CheckForErrors();
+                    ConditionallyRegisterParameter("weight", value);
+                }
+            }
+
         }
     }
 

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -49,7 +49,7 @@ namespace TorchSharp
                 var seen = new HashSet<IntPtr>();
 
                 for (var i = 0; i < _names.Count; i++) {
-                    foreach (var (n,p) in _modules[i].named_parameters(true)) {
+                    foreach (var (n, p) in _modules[i].named_parameters(true)) {
                         if (seen.Contains(p.Handle)) continue;
                         seen.Add(p.Handle);
                         yield return ($"{_names[i]}.{n}", p);
@@ -112,7 +112,7 @@ namespace TorchSharp
 
                 var t0 = _modules[0].forward(tensor);
 
-                for (var idx = 1; idx < _modules.Count-1; idx++) {
+                for (var idx = 1; idx < _modules.Count - 1; idx++) {
                     var t1 = _modules[idx].forward(t0);
                     t0.Dispose();
                     t0 = t1;
@@ -135,7 +135,9 @@ namespace TorchSharp
 
             protected override void Dispose(bool disposing)
             {
-                foreach (var m in _modules) { m.Dispose(); }
+                if (disposing) {
+                    foreach (var m in _modules) { m.Dispose(); }
+                }
                 base.Dispose(disposing);
             }
 
@@ -186,7 +188,7 @@ namespace TorchSharp
             static public Sequential Sequential()
             {
                 var handle = THSNN_Sequential_ctor();
-                if(handle == IntPtr.Zero) {torch.CheckForErrors();}
+                if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
 
                 return new Sequential(handle);
             }
@@ -221,7 +223,7 @@ namespace TorchSharp
             static public Sequential Sequential(params torch.nn.Module[] modules)
             {
                 var res = Sequential();
-                foreach(var m in modules)
+                foreach (var m in modules)
                     res.Add(m);
                 return res;
             }
@@ -289,7 +291,7 @@ namespace TorchSharp
             static public Sequential Sequential(IEnumerable<torch.nn.Module> modules)
             {
                 var res = Sequential();
-                foreach(var module in modules)
+                foreach (var module in modules)
                     res.Add(module);
                 return res;
             }

--- a/src/TorchSharp/Tensor/Storage.cs
+++ b/src/TorchSharp/Tensor/Storage.cs
@@ -1,3 +1,4 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -179,7 +179,12 @@ namespace TorchSharp
         /// </summary>
         /// <param name="tensor">The tensor into which to load serialized data.</param>
         /// <param name="reader">A BinaryReader instance</param>
-        public static void Load(this Tensor tensor, System.IO.BinaryReader reader)
+        /// <param name="skip">If true, the data will be read from the stream, but not copied to the target tensor.</param>
+        /// <remarks>
+        /// Using a skip list only prevents tensors in the target module from being modified, it
+        /// does not alter the logic related to checking for matching tensor element types.
+        /// </remarks>
+        public static void Load(this Tensor tensor, System.IO.BinaryReader reader, bool skip = false)
         {
             // First, read the type
             var type = (ScalarType)reader.Decode();
@@ -206,7 +211,9 @@ namespace TorchSharp
             if (totalSize > int.MaxValue)
                 throw new NotImplementedException("Loading tensors larger than 2GB");
 
-            tensor.bytes = reader.ReadBytes((int)(totalSize * tensor.ElementSize));
+            var bytes = reader.ReadBytes((int)(totalSize * tensor.ElementSize));
+            if (!skip)
+                tensor.bytes = bytes;
         }
 
         /// <summary>

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -202,7 +202,8 @@ namespace TorchSharp
                 totalSize *= loadedShape[i];
             }
 
-            if (!loadedShape.SequenceEqual(tensor.shape))
+            if (!skip && !loadedShape.SequenceEqual(tensor.shape))
+                // We only care about this if the bytes will be written to the tensor.
                 throw new ArgumentException("Mismatched tensor shape while loading. Make sure that the model you are loading into is exactly the same as the origin.");
 
             //
@@ -211,7 +212,9 @@ namespace TorchSharp
             if (totalSize > int.MaxValue)
                 throw new NotImplementedException("Loading tensors larger than 2GB");
 
+            // This needs to be done even if the tensor is skipped, since we have to advance the input stream.
             var bytes = reader.ReadBytes((int)(totalSize * tensor.ElementSize));
+
             if (!skip)
                 tensor.bytes = bytes;
         }

--- a/src/TorchSharp/TorchSharp.csproj
+++ b/src/TorchSharp/TorchSharp.csproj
@@ -16,7 +16,7 @@
     <None Remove="Tensor\TensorTyped.tt" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" >
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Remove="netstandard.cs" />
   </ItemGroup>
 
@@ -49,18 +49,12 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <!-- Trigger the download+placement of the redist bits and the build of the C++ project -->
-  <Target Name="BuildNativeLibTorch" BeforeTargets="BeforeBuild" >
+  <Target Name="BuildNativeLibTorch" BeforeTargets="BeforeBuild">
     <Message Importance="High" Text="Using VersionSuffix = $(VersionSuffix)" />
     <Message Importance="High" Text="Using Version = $(Version)" />
-    <MSBuild Projects="..\Redist\libtorch-cuda-$(CudaVersionDot)\libtorch-cuda-$(CudaVersionDot).proj"
-            Condition="'$(BuildingInsideVisualStudio)'!='true' AND '$(SkipNative)' != 'true'  AND '$(SkipCuda)' != 'true'"
-            RemoveProperties="TargetFramework"
-            Targets="Build" />
+    <MSBuild Projects="..\Redist\libtorch-cuda-$(CudaVersionDot)\libtorch-cuda-$(CudaVersionDot).proj" Condition="'$(BuildingInsideVisualStudio)'!='true' AND '$(SkipNative)' != 'true'  AND '$(SkipCuda)' != 'true'" RemoveProperties="TargetFramework" Targets="Build" />
 
-    <MSBuild Projects="..\Redist\libtorch-cpu\libtorch-cpu.proj"
-             Condition="'$(BuildingInsideVisualStudio)'!='true' AND '$(SkipNative)' != 'true'"
-             RemoveProperties="TargetFramework"
-             Targets="Build" />
+    <MSBuild Projects="..\Redist\libtorch-cpu\libtorch-cpu.proj" Condition="'$(BuildingInsideVisualStudio)'!='true' AND '$(SkipNative)' != 'true'" RemoveProperties="TargetFramework" Targets="Build" />
 
     <MSBuild Projects="..\Native\build.proj" Condition="'$(SkipNative)' != 'true'" RemoveProperties="TargetFramework" Targets="Build" />
   </Target>

--- a/src/TorchSharp/TorchVision/models/AlexNet.cs
+++ b/src/TorchSharp/TorchVision/models/AlexNet.cs
@@ -1,0 +1,107 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using TorchSharp.torchvision.Modules;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+using static TorchSharp.torch.utils.data;
+
+namespace TorchSharp.torchvision
+{
+    public static partial class models
+    {
+        /// <summary>
+        /// AlexNet
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.alexnet(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.AlexNet alexnet(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.AlexNet(num_classes, dropout, device);
+        }
+    }
+
+    namespace Modules
+    {
+        public class AlexNet : Module
+        {
+            private readonly Module features;
+            private readonly Module avgPool;
+            private readonly Module classifier;
+
+            public AlexNet(int numClasses, float dropout = 0.5f, torch.Device device = null) : base(nameof(AlexNet))
+            {
+                features = Sequential(
+                    Conv2d(3, 64, kernelSize: 11, stride: 4, padding: 2),
+                    ReLU(inPlace: true),
+                    MaxPool2d(kernelSize: 3, stride: 2),
+                    Conv2d(64, 192, kernelSize: 5, padding: 2),
+                    ReLU(inPlace: true),
+                    MaxPool2d(kernelSize: 3, stride:2),
+                    Conv2d(192, 384, kernelSize: 3, padding: 1),
+                    ReLU(inPlace: true),
+                    Conv2d(384, 256, kernelSize: 3, padding: 1),
+                    ReLU(inPlace: true),
+                    Conv2d(256, 256, kernelSize: 3, padding: 1),
+                    ReLU(inPlace: true),
+                    MaxPool2d(kernelSize: 3, stride: 2)
+                );
+
+                avgPool = AdaptiveAvgPool2d(new long[] { 6, 6 });
+
+                classifier = Sequential(
+                    Dropout(probability: dropout),
+                    Linear(256 * 6 * 6, 4096),
+                    ReLU(inPlace: true),
+                    Dropout(probability:dropout),
+                    Linear(4096, 4096),
+                    ReLU(inPlace: true),
+                    Linear(4096, numClasses)
+                );
+
+                RegisterComponents();
+
+                if (device != null && device.type == DeviceType.CUDA)
+                    this.to(device);
+            }
+
+            public override Tensor forward(Tensor input)
+            {
+                using (var _ = NewDisposeScope()) {
+                    var f = features.forward(input);
+                    var avg = avgPool.forward(f);
+                    var x = avg.flatten(1);
+                    return classifier.forward(x).MoveToOuterDisposeScope();
+                }
+            }
+        }
+    }
+}

--- a/src/TorchSharp/TorchVision/models/ResNet.cs
+++ b/src/TorchSharp/TorchVision/models/ResNet.cs
@@ -254,7 +254,7 @@ namespace TorchSharp.torchvision
                 return new ResNet(
                     "ResNet152",
                     (in_planes, planes, stride) => new Bottleneck(in_planes, planes, stride),
-                    Bottleneck.expansion, new int[] { 3, 4, 36, 3 },
+                    Bottleneck.expansion, new int[] { 3, 8, 36, 3 },
                     numClasses,
                     device);
             }
@@ -276,6 +276,19 @@ namespace TorchSharp.torchvision
                 fc = Linear(512 * expansion, numClasses);
 
                 RegisterComponents();
+
+                foreach (var (_, m) in named_modules()) {
+                    switch (m) {
+                    // This test must come before the Tensor test
+                    case TorchSharp.Modules.Conv2d conv:
+                        torch.nn.init.kaiming_normal_(conv.weight, mode: init.FanInOut.FanOut, nonlinearity: init.NonlinearityType.ReLU);
+                        break;
+                    case TorchSharp.Modules.BatchNorm2d bn:
+                        torch.nn.init.constant_(bn.weight, 1);
+                        torch.nn.init.constant_(bn.bias, 0);
+                        break;
+                    }
+                }
 
                 if (device != null && device.type == DeviceType.CUDA)
                     this.to(device);
@@ -328,6 +341,8 @@ namespace TorchSharp.torchvision
                         downsample.Add(BatchNorm2d(expansion * planes));
                     }
 
+                    torch.nn.init.constant_(bn2.weight, 1);
+
                     RegisterComponents();
                 }
 
@@ -346,7 +361,7 @@ namespace TorchSharp.torchvision
                 private readonly Module conv1;
                 private readonly Module bn1;
                 private readonly Module conv2;
-                private readonly Module bn2;
+                private readonly TorchSharp.Modules.BatchNorm2d bn2;
                 private readonly Module relu1;
                 private readonly TorchSharp.Modules.ModuleList downsample = new TorchSharp.Modules.ModuleList();
             }
@@ -371,6 +386,8 @@ namespace TorchSharp.torchvision
                         downsample.Add(BatchNorm2d(expansion * planes));
                     }
 
+                    torch.nn.init.constant_(bn3.weight, 1);
+
                     RegisterComponents();
                 }
 
@@ -393,7 +410,7 @@ namespace TorchSharp.torchvision
                 private readonly Module conv2;
                 private readonly Module bn2;
                 private readonly Module conv3;
-                private readonly Module bn3;
+                private readonly TorchSharp.Modules.BatchNorm2d bn3;
                 private readonly Module relu1;
                 private readonly Module relu2;
 

--- a/src/TorchSharp/TorchVision/models/ResNet.cs
+++ b/src/TorchSharp/TorchVision/models/ResNet.cs
@@ -22,13 +22,24 @@ namespace TorchSharp.torchvision
         /// using the exportsd.py script, then loading into the .NET instance:
         ///
         /// from torchvision import models
+        /// import exportsd
+        /// 
         /// model = models.resnet18(pretrained=True)
-        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
         ///
         /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
         ///
         /// In order for the weights to be loaded, the number of classes has to be the same as
         /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "fc.weight", "fc.bias" as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
         /// </remarks>
         public static Modules.ResNet resnet18(int num_classes = 1000, Device device = null)
         {
@@ -45,13 +56,24 @@ namespace TorchSharp.torchvision
         /// using the exportsd.py script, then loading into the .NET instance:
         ///
         /// from torchvision import models
+        /// import exportsd
+        /// 
         /// model = models.resnet34(pretrained=True)
-        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
         ///
         /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
         ///
         /// In order for the weights to be loaded, the number of classes has to be the same as
         /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "fc.weight", "fc.bias" as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
         /// </remarks>
         public static Modules.ResNet resnet34(int num_classes = 1000, Device device = null)
         {
@@ -68,13 +90,24 @@ namespace TorchSharp.torchvision
         /// using the exportsd.py script, then loading into the .NET instance:
         ///
         /// from torchvision import models
+        /// import exportsd
+        /// 
         /// model = models.resnet50(pretrained=True)
-        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
         ///
         /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
         ///
         /// In order for the weights to be loaded, the number of classes has to be the same as
         /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "fc.weight", "fc.bias" as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
         /// </remarks>
         public static Modules.ResNet resnet50(int num_classes = 1000, Device device = null)
         {
@@ -91,13 +124,24 @@ namespace TorchSharp.torchvision
         /// using the exportsd.py script, then loading into the .NET instance:
         ///
         /// from torchvision import models
+        /// import exportsd
+        /// 
         /// model = models.resnet101(pretrained=True)
-        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
         ///
         /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
         ///
         /// In order for the weights to be loaded, the number of classes has to be the same as
         /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "fc.weight", "fc.bias" as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
         /// </remarks>
         public static Modules.ResNet resnet101(int num_classes = 1000, Device device = null)
         {
@@ -114,14 +158,25 @@ namespace TorchSharp.torchvision
         /// using the exportsd.py script, then loading into the .NET instance:
         ///
         /// from torchvision import models
+        /// import exportsd
+        /// 
         /// model = models.resnet152(pretrained=True)
-        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
         ///
         /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
-        /// </remarks>
         ///
         /// In order for the weights to be loaded, the number of classes has to be the same as
         /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "fc.weight", "fc.bias" as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
         public static Modules.ResNet resnet152(int num_classes = 1000, Device device = null)
         {
             return Modules.ResNet.ResNet152(num_classes, device);

--- a/src/TorchSharp/TorchVision/models/ResNet.cs
+++ b/src/TorchSharp/TorchVision/models/ResNet.cs
@@ -132,11 +132,10 @@ namespace TorchSharp.torchvision
     {
         public class ResNet : Module
         {
-            // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/resnet.py
+            // The code here is is loosely based on
+            // https://github.com/kuangliu/pytorch-cifar/blob/master/models/resnet.py and
+            // https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py
             // Licence and copypright notice at: https://github.com/kuangliu/pytorch-cifar/blob/master/LICENSE
-
-            private readonly long[] planes = new long[] { 64, 128, 128, 256, 256, 512, 512, 512, 512, 512, 512, 1024, 1024 };
-            private readonly long[] strides = new long[] { 1, 2, 1, 2, 1, 2, 1, 1, 1, 1, 1, 2, 1 };
 
             private readonly Module conv1;
             private readonly Module bn1;
@@ -198,7 +197,7 @@ namespace TorchSharp.torchvision
             public static ResNet ResNet152(int numClasses, Device device = null)
             {
                 return new ResNet(
-                    "ResNet101",
+                    "ResNet152",
                     (in_planes, planes, stride) => new Bottleneck(in_planes, planes, stride),
                     Bottleneck.expansion, new int[] { 3, 4, 36, 3 },
                     numClasses,
@@ -207,8 +206,6 @@ namespace TorchSharp.torchvision
 
             public ResNet(string name, Func<int, int, int, Module> block, int expansion, IList<int> num_blocks, int numClasses, Device device = null) : base(name)
             {
-                if (planes.Length != strides.Length) throw new ArgumentException("'planes' and 'strides' must have the same length.");
-
                 var modules = new List<(string, Module)>();
 
                 conv1 = Conv2d(3, 64, kernelSize: 7, stride: 2, padding: 3, bias: false);

--- a/src/TorchSharp/TorchVision/models/ResNet.cs
+++ b/src/TorchSharp/TorchVision/models/ResNet.cs
@@ -1,0 +1,352 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using TorchSharp.torchvision.Modules;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+using static TorchSharp.torch.utils.data;
+
+namespace TorchSharp.torchvision
+{
+    public static partial class models
+    {
+        /// <summary>
+        /// ResNet-18
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// model = models.resnet18(pretrained=True)
+        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        /// </remarks>
+        public static Modules.ResNet resnet18(int num_classes = 1000, Device device = null)
+        {
+            return Modules.ResNet.ResNet18(num_classes, device);
+        }
+
+        /// <summary>
+        /// ResNet-34
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// model = models.resnet34(pretrained=True)
+        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        /// </remarks>
+        public static Modules.ResNet resnet34(int num_classes = 1000, Device device = null)
+        {
+            return Modules.ResNet.ResNet34(num_classes, device);
+        }
+
+        /// <summary>
+        /// ResNet-50
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// model = models.resnet50(pretrained=True)
+        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        /// </remarks>
+        public static Modules.ResNet resnet50(int num_classes = 1000, Device device = null)
+        {
+            return Modules.ResNet.ResNet50(num_classes, device);
+        }
+
+        /// <summary>
+        /// ResNet-101
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// model = models.resnet101(pretrained=True)
+        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        /// </remarks>
+        public static Modules.ResNet resnet101(int num_classes = 1000, Device device = null)
+        {
+            return Modules.ResNet.ResNet101(num_classes, device);
+        }
+
+        /// <summary>
+        /// ResNet-152
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// model = models.resnet152(pretrained=True)
+        /// exportsd.save_state_dict(model.state_dict(), "your file name here")
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        /// </remarks>
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        public static Modules.ResNet resnet152(int num_classes = 1000, Device device = null)
+        {
+            return Modules.ResNet.ResNet152(num_classes, device);
+        }
+    }
+
+    namespace Modules
+    {
+        public class ResNet : Module
+        {
+            // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/resnet.py
+            // Licence and copypright notice at: https://github.com/kuangliu/pytorch-cifar/blob/master/LICENSE
+
+            private readonly long[] planes = new long[] { 64, 128, 128, 256, 256, 512, 512, 512, 512, 512, 512, 1024, 1024 };
+            private readonly long[] strides = new long[] { 1, 2, 1, 2, 1, 2, 1, 1, 1, 1, 1, 2, 1 };
+
+            private readonly Module conv1;
+            private readonly Module bn1;
+            private readonly Module relu1;
+
+            private readonly TorchSharp.Modules.ModuleList layer1 = new TorchSharp.Modules.ModuleList();
+            private readonly TorchSharp.Modules.ModuleList layer2 = new TorchSharp.Modules.ModuleList();
+            private readonly TorchSharp.Modules.ModuleList layer3 = new TorchSharp.Modules.ModuleList();
+            private readonly TorchSharp.Modules.ModuleList layer4 = new TorchSharp.Modules.ModuleList();
+
+            private readonly Module avgpool;
+            private readonly Module maxpool;
+            private readonly Module flatten;
+            private readonly Module fc;
+
+
+            private int in_planes = 64;
+
+            public static ResNet ResNet18(int numClasses, Device device = null)
+            {
+                return new ResNet(
+                    "ResNet18",
+                    (in_planes, planes, stride) => new BasicBlock(in_planes, planes, stride),
+                    BasicBlock.expansion, new int[] { 2, 2, 2, 2 },
+                    numClasses,
+                    device);
+            }
+
+            public static ResNet ResNet34(int numClasses, Device device = null)
+            {
+                return new ResNet(
+                    "ResNet34",
+                    (in_planes, planes, stride) => new BasicBlock(in_planes, planes, stride),
+                    BasicBlock.expansion, new int[] { 3, 4, 6, 3 },
+                    numClasses,
+                    device);
+            }
+
+            public static ResNet ResNet50(int numClasses, Device device = null)
+            {
+                return new ResNet(
+                    "ResNet50",
+                    (in_planes, planes, stride) => new Bottleneck(in_planes, planes, stride),
+                    Bottleneck.expansion, new int[] { 3, 4, 6, 3 },
+                    numClasses,
+                    device);
+            }
+
+            public static ResNet ResNet101(int numClasses, Device device = null)
+            {
+                return new ResNet(
+                    "ResNet101",
+                    (in_planes, planes, stride) => new Bottleneck(in_planes, planes, stride),
+                    Bottleneck.expansion, new int[] { 3, 4, 23, 3 },
+                    numClasses,
+                    device);
+            }
+
+            public static ResNet ResNet152(int numClasses, Device device = null)
+            {
+                return new ResNet(
+                    "ResNet101",
+                    (in_planes, planes, stride) => new Bottleneck(in_planes, planes, stride),
+                    Bottleneck.expansion, new int[] { 3, 4, 36, 3 },
+                    numClasses,
+                    device);
+            }
+
+            public ResNet(string name, Func<int, int, int, Module> block, int expansion, IList<int> num_blocks, int numClasses, Device device = null) : base(name)
+            {
+                if (planes.Length != strides.Length) throw new ArgumentException("'planes' and 'strides' must have the same length.");
+
+                var modules = new List<(string, Module)>();
+
+                conv1 = Conv2d(3, 64, kernelSize: 7, stride: 2, padding: 3, bias: false);
+                bn1 = BatchNorm2d(64);
+                relu1 = ReLU(inPlace: true);
+                maxpool = MaxPool2d(kernelSize: 2, stride: 2, padding: 1);
+                MakeLayer(layer1, block, expansion, 64, num_blocks[0], 1);
+                MakeLayer(layer2, block, expansion, 128, num_blocks[1], 2);
+                MakeLayer(layer3, block, expansion, 256, num_blocks[2], 2);
+                MakeLayer(layer4, block, expansion, 512, num_blocks[3], 2);
+                avgpool = nn.AdaptiveAvgPool2d(new long[] { 1, 1 });
+                flatten = Flatten();
+                fc = Linear(512 * expansion, numClasses);
+
+                RegisterComponents();
+
+                if (device != null && device.type == DeviceType.CUDA)
+                    this.to(device);
+            }
+
+            private void MakeLayer(TorchSharp.Modules.ModuleList modules, Func<int, int, int, Module> block, int expansion, int planes, int num_blocks, int stride)
+            {
+                var strides = new List<int>();
+                strides.Add(stride);
+                for (var i = 0; i < num_blocks - 1; i++) { strides.Add(1); }
+
+                for (var i = 0; i < strides.Count; i++) {
+                    var s = strides[i];
+                    modules.Add(block(in_planes, planes, s));
+                    in_planes = planes * expansion;
+                }
+            }
+
+            public override Tensor forward(Tensor input)
+            {
+                using (var scope = NewDisposeScope()) {
+
+                    var x = maxpool.forward(relu1.forward(bn1.forward(conv1.forward(input))));
+
+                    foreach (var m in layer1) x = m.forward(x);
+                    foreach (var m in layer2) x = m.forward(x);
+                    foreach (var m in layer3) x = m.forward(x);
+                    foreach (var m in layer4) x = m.forward(x);
+
+                    var res = fc.forward(flatten.forward(avgpool.forward(x)));
+                    scope.MoveToOuter(res);
+                    return res;
+                }
+            }
+
+            class BasicBlock : Module
+            {
+                public BasicBlock(int in_planes, int planes, int stride) : base("BasicBlock")
+                {
+                    var modules = new List<(string, Module)>();
+
+                    conv1 = Conv2d(in_planes, planes, kernelSize: 3, stride: stride, padding: 1, bias: false);
+                    bn1 = BatchNorm2d(planes);
+                    relu1 = ReLU(inPlace: true);
+                    conv2 = Conv2d(planes, planes, kernelSize: 3, stride: 1, padding: 1, bias: false);
+                    bn2 = BatchNorm2d(planes);
+
+                    if (stride != 1 || in_planes != expansion * planes) {
+                        downsample.Add(Conv2d(in_planes, expansion * planes, kernelSize: 1, stride: stride, bias: false));
+                        downsample.Add(BatchNorm2d(expansion * planes));
+                    }
+
+                    RegisterComponents();
+                }
+
+                public override Tensor forward(Tensor input)
+                {
+                    var x = relu1.forward(bn1.forward(conv1.forward(input)));
+                    x = bn2.forward(conv2.forward(x));
+
+                    var y = input;
+                    foreach (var m in downsample) y = m.forward(y);
+                    return x.add_(y).relu_();
+                }
+
+                public static int expansion = 1;
+
+                private readonly Module conv1;
+                private readonly Module bn1;
+                private readonly Module conv2;
+                private readonly Module bn2;
+                private readonly Module relu1;
+                private readonly TorchSharp.Modules.ModuleList downsample = new TorchSharp.Modules.ModuleList();
+            }
+
+            class Bottleneck : Module
+            {
+                public Bottleneck(int in_planes, int planes, int stride) : base("Bottleneck")
+                {
+                    var modules = new List<(string, Module)>();
+
+                    conv1 = Conv2d(in_planes, planes, kernelSize: 1, bias: false);
+                    bn1 = BatchNorm2d(planes);
+                    relu1 = ReLU(inPlace: true);
+                    conv2 = Conv2d(planes, planes, kernelSize: 3, stride: stride, padding: 1, bias: false);
+                    bn2 = BatchNorm2d(planes);
+                    relu2 = ReLU(inPlace: true);
+                    conv3 = Conv2d(planes, expansion * planes, kernelSize: 1, bias: false);
+                    bn3 = BatchNorm2d(expansion * planes);
+
+                    if (stride != 1 || in_planes != expansion * planes) {
+                        downsample.Add(Conv2d(in_planes, expansion * planes, kernelSize: 1, stride: stride, bias: false));
+                        downsample.Add(BatchNorm2d(expansion * planes));
+                    }
+
+                    RegisterComponents();
+                }
+
+                public override Tensor forward(Tensor input)
+                {
+                    var x = relu1.forward(bn1.forward(conv1.forward(input)));
+                    x = relu2.forward(bn2.forward(conv2.forward(input)));
+                    x = bn3.forward(conv3.forward(x));
+
+                    var y = input;
+                    foreach (var m in downsample) y = m.forward(y);
+
+                    return x.add_(y).relu_();
+                }
+
+                public static int expansion = 4;
+
+                private readonly Module conv1;
+                private readonly Module bn1;
+                private readonly Module conv2;
+                private readonly Module bn2;
+                private readonly Module conv3;
+                private readonly Module bn3;
+                private readonly Module relu1;
+                private readonly Module relu2;
+
+                private readonly TorchSharp.Modules.ModuleList downsample = new TorchSharp.Modules.ModuleList();
+            }
+        }
+    }
+}

--- a/src/TorchSharp/TorchVision/models/VGG.cs
+++ b/src/TorchSharp/TorchVision/models/VGG.cs
@@ -1,0 +1,381 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using TorchSharp.torchvision.Modules;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+using static TorchSharp.torch.utils.data;
+
+namespace TorchSharp.torchvision
+{
+    public static partial class models
+    {
+        /// <summary>
+        /// VGG-11 without batch-norm layers
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.vgg11(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.VGG vgg11(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.VGG("VGG11", num_classes, false, dropout, device);
+        }
+
+        /// <summary>
+        /// VGG-11 with batch-norm layers
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.vgg11_bn(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.VGG vgg11_bn(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.VGG("VGG11", num_classes, true, dropout, device);
+        }
+
+        /// <summary>
+        /// VGG-13 without batch-norm layers
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.vgg13(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.VGG vgg13(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.VGG("VGG13", num_classes, false, dropout, device);
+        }
+
+        /// <summary>
+        /// VGG-13 with batch-norm layers
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.vgg13_bn(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.VGG vgg13_bn(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.VGG("VGG13", num_classes, true, dropout, device);
+        }
+
+        /// <summary>
+        /// VGG-16 without batch-norm layers
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.vgg16(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.VGG vgg16(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.VGG("VGG16", num_classes, false, dropout, device);
+        }
+
+        /// <summary>
+        /// VGG-16 with batch-norm layers
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.vgg16_bn(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.VGG vgg16_bn(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.VGG("VGG16", num_classes, true, dropout, device);
+        }
+
+        /// <summary>
+        /// VGG-19 without batch-norm layers
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.vgg19(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.VGG vgg19(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.VGG("VGG19", num_classes, false, dropout, device);
+        }
+
+        /// <summary>
+        /// VGG-19 with batch-norm layers
+        /// </summary>
+        /// <param name="num_classes">The number of output classes.</param>
+        /// <param name="dropout">The dropout ratio.</param>
+        /// <param name="device">The device to locate the model on.</param>
+        /// <remarks>
+        /// Pre-trained weights may be retrieved by using Pytorch and saving the model state-dict
+        /// using the exportsd.py script, then loading into the .NET instance:
+        ///
+        /// from torchvision import models
+        /// import exportsd
+        /// 
+        /// model = models.vgg19_bn(pretrained=True)
+        /// f = open("model_weights.dat", "wb")
+        /// exportsd.save_state_dict(model.state_dict(), f)
+        /// f.close()
+        ///
+        /// See also: https://github.com/dotnet/TorchSharp/blob/main/docfx/articles/saveload.md
+        ///
+        /// In order for the weights to be loaded, the number of classes has to be the same as
+        /// in the pre-trained model, which is 1000.
+        ///
+        /// It is also possible to skip loading the last linear layer and use it for transfer-learning
+        /// with a different number of output classes. To do so, pass "classifier.6.weight", "classifier.6.bias"
+        /// as the skip list when loading.
+        ///
+        /// All pre-trained models expect input images normalized in the same way, i.e. mini-batches of 3-channel RGB
+        /// images of shape (3 x H x W), where H and W are expected to be at least 224. The images have to be loaded
+        /// in to a range of [0, 1] and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225].
+        /// </remarks>
+        public static Modules.VGG vgg19_bn(int num_classes = 1000, float dropout = 0.5f, Device device = null)
+        {
+            return new Modules.VGG("VGG19", num_classes, true, dropout, device);
+        }
+    }
+
+    namespace Modules
+    {
+        /// <summary>
+        /// Modified version of VGG to classify CIFAR10 32x32 images.
+        /// </summary>
+        /// <remarks>
+        /// With an unaugmented CIFAR-10 data set, the author of this saw training converge
+        /// at roughly 85% accuracy on the test set, after 50 epochs using VGG-16.
+        /// </remarks>
+        public class VGG : Module
+        {
+            // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/vgg.py
+            // Licence and copypright notice at: https://github.com/kuangliu/pytorch-cifar/blob/master/LICENSE
+
+            private readonly Dictionary<string, long[]> _channels = new Dictionary<string, long[]>() {
+                { "VGG11", new long[] { 64, 0, 128, 0, 256, 256, 0, 512, 512, 0, 512, 512, 0 } },
+                { "VGG13", new long[] { 64, 64, 0, 128, 128, 0, 256, 256, 0, 512, 512, 0, 512, 512, 0 } },
+                { "VGG16", new long[] { 64, 64, 0, 128, 128, 0, 256, 256, 256, 0, 512, 512, 512, 0, 512, 512, 512, 0 } },
+                { "VGG19", new long[] { 64, 64, 0, 128, 128, 0, 256, 256, 256, 256, 0, 512, 512, 512, 512, 0, 512, 512, 512, 512, 0 } }
+            };
+
+            private readonly Module features;
+            private readonly Module classifier;
+            private readonly Module avgpool;         
+
+            public VGG(string name, int numClasses, bool batch_norm, float dropout = 0.5f, Device device = null) : base(name)
+            {
+                var layers = new List<Module>();
+
+                var channels = _channels[name];
+
+                long in_channels = 3;
+
+                for (var i = 0; i < channels.Length; i++) {
+
+                    if (channels[i] == 0) {
+                        layers.Add(MaxPool2d(kernelSize: 2, stride: 2));
+                    } else {
+                        layers.Add(Conv2d(in_channels, channels[i], kernelSize: 3, padding: 1));
+                        if (batch_norm) {
+                            layers.Add(BatchNorm2d(channels[i]));
+                        }
+                        layers.Add(ReLU(inPlace: true));
+                        in_channels = channels[i];
+                    }
+                }
+
+                features = Sequential(layers);
+
+                avgpool = AdaptiveAvgPool2d(new[] { 7L, 7L });
+
+                classifier = Sequential(
+                    Linear(512 * 7 * 7, 4096),
+                    ReLU(true),
+                    Dropout(probability: dropout),
+                    Linear(4096, 4096),
+                    ReLU(true),
+                    Dropout(probability: dropout),
+                    Linear(4096, numClasses)
+                    );
+
+                RegisterComponents();
+
+                if (device != null && device.type == DeviceType.CUDA)
+                    this.to(device);
+            }
+
+            public override Tensor forward(Tensor input)
+            {
+                using (var _ = NewDisposeScope()) {
+                    input = features.forward(input);
+                    input = avgpool.forward(input).flatten(1);
+                    return classifier.forward(input).MoveToOuterDisposeScope();
+                }
+            }
+        }
+    }
+}

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -26,6 +26,7 @@
     <Compile Include="..\TorchSharpTest\TestTorchSharp.cs" Link="TestTorchSharp.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchTensor.cs" Link="TestTorchTensor.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchTensorBugs.cs" Link="TestTorchTensorBugs.cs" />
+    <Compile Include="..\TorchSharpTest\TestTorchVision.cs" Link="TestTorchVision.cs" />
     <Compile Include="..\TorchSharpTest\TestTraining.cs" Link="TestTraining.cs" />
     <Compile Include="..\TorchSharpTest\TestDisposeScopes.cs" Link="TestDisposeScopes.cs" />
   </ItemGroup>

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -57,6 +57,26 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestSaveLoadLinear3()
+        {
+            if (File.Exists(".model.ts")) File.Delete(".model.ts");
+            var linear = Linear(100, 10, true);
+            var params0 = linear.parameters();
+            linear.save(".model.ts");
+
+            var loadedLinear = Linear(10, 10, true);    // Mismatched shape, shouldn't matter when skipped.
+            Assert.Throws<ArgumentException>(() => loadedLinear.load(".model.ts"));
+
+            loadedLinear.load(".model.ts", skip: new[] { "weight" });
+            var params2 = loadedLinear.parameters();
+            File.Delete(".model.ts");
+
+            Assert.NotEqual(params0.First(), params2.First());
+            Assert.Equal(params0.Skip(1).First(), params2.Skip(1).First());
+        }
+
+
+        [Fact]
         public void TestSaveLoadConv2D()
         {
             if (File.Exists(".model.ts")) File.Delete(".model.ts");

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -16,18 +16,44 @@ namespace TorchSharp
     public class TestLoadSave
     {
         [Fact]
-        public void TestSaveLoadLinear()
+        public void TestSaveLoadLinear1()
         {
             if (File.Exists(".model.ts")) File.Delete(".model.ts");
             var linear = Linear(100, 10, true);
             var params0 = linear.parameters();
             linear.save(".model.ts");
+
             var loadedLinear = Linear(100, 10, true);
             loadedLinear.load(".model.ts");
+
             var params1 = loadedLinear.parameters();
+            Assert.Equal(params0, params1);
+
+            loadedLinear = Linear(100, 10, true);
+            loadedLinear.load(".model.ts", skip: new [] { "weight"});
+            var params2 = loadedLinear.parameters();
             File.Delete(".model.ts");
 
-            Assert.Equal(params0, params1);
+            Assert.NotEqual(params0.First(), params2.First());
+            Assert.Equal(params0.Skip(1).First(), params2.Skip(1).First());
+        }
+
+        [Fact]
+        public void TestSaveLoadLinear2()
+        {
+            if (File.Exists(".model.ts")) File.Delete(".model.ts");
+            var linear = Linear(100, 10, true);
+            var params0 = linear.parameters();
+            linear.save(".model.ts", skip: new[] { "weight" });
+
+            var loadedLinear = Linear(100, 10, true);
+            Assert.Throws<ArgumentException>(() => loadedLinear.load(".model.ts", strict: true));
+            loadedLinear.load(".model.ts", strict: false);
+            var params2 = loadedLinear.parameters();
+            File.Delete(".model.ts");
+
+            Assert.NotEqual(params0.First(), params2.First());
+            Assert.Equal(params0.Skip(1).First(), params2.Skip(1).First());
         }
 
         [Fact]

--- a/test/TorchSharpTest/TestTorchVision.cs
+++ b/test/TorchSharpTest/TestTorchVision.cs
@@ -14,7 +14,7 @@ namespace TorchSharp
         [Fact]
         public void TestResNet18()
         {
-            var model = resnet18();
+            using var model = resnet18();
             var sd = model.state_dict();
             Assert.Equal(122, sd.Count);
         }
@@ -22,7 +22,7 @@ namespace TorchSharp
         [Fact]
         public void TestResNet34()
         {
-            var model = resnet34();
+            using var model = resnet34();
             var sd = model.state_dict();
             Assert.Equal(218, sd.Count);
         }
@@ -30,7 +30,7 @@ namespace TorchSharp
         [Fact]
         public void TestResNet50()
         {
-            var model = resnet50();
+            using var model = resnet50();
             var sd = model.state_dict();
             Assert.Equal(320, sd.Count);
         }
@@ -38,7 +38,7 @@ namespace TorchSharp
         [Fact]
         public void TestResNet101()
         {
-            var model = resnet101();
+            using var model = resnet101();
             var sd = model.state_dict();
             Assert.Equal(626, sd.Count);
         }
@@ -46,7 +46,7 @@ namespace TorchSharp
         [Fact]
         public void TestResNet152()
         {
-            var model = resnet152();
+            using var model = resnet152();
             var sd = model.state_dict();
             Assert.Equal(932, sd.Count);
         }
@@ -54,7 +54,7 @@ namespace TorchSharp
         [Fact]
         public void TestAlexNet()
         {
-            var model = alexnet();
+            using var model = alexnet();
             var sd = model.state_dict();
             Assert.Equal(16, sd.Count);
         }
@@ -63,12 +63,12 @@ namespace TorchSharp
         public void TestVGG11()
         {
             {
-                var model = vgg11();
+                using var model = vgg11();
                 var sd = model.state_dict();
                 Assert.Equal(22, sd.Count);
             }
             {
-                var model = vgg11_bn();
+                using var model = vgg11_bn();
                 var sd = model.state_dict();
                 Assert.Equal(62, sd.Count);
             }
@@ -78,12 +78,12 @@ namespace TorchSharp
         public void TestVGG13()
         {
             {
-                var model = vgg13();
+                using var model = vgg13();
                 var sd = model.state_dict();
                 Assert.Equal(26, sd.Count);
             }
             {
-                var model = vgg13_bn();
+                using var model = vgg13_bn();
                 var sd = model.state_dict();
                 Assert.Equal(76, sd.Count);
             }
@@ -93,12 +93,12 @@ namespace TorchSharp
         public void TestVGG16()
         {
             {
-                var model = vgg16();
+                using var model = vgg16();
                 var sd = model.state_dict();
                 Assert.Equal(32, sd.Count);
             }
             {
-                var model = vgg16_bn();
+                using var model = vgg16_bn();
                 var sd = model.state_dict();
                 Assert.Equal(97, sd.Count);
             }
@@ -108,12 +108,12 @@ namespace TorchSharp
         public void TestVGG19()
         {
             {
-                var model = vgg19();
+                using var model = vgg19();
                 var sd = model.state_dict();
                 Assert.Equal(38, sd.Count);
             }
             {
-                var model = vgg19_bn();
+                using var model = vgg19_bn();
                 var sd = model.state_dict();
                 Assert.Equal(118, sd.Count);
             }

--- a/test/TorchSharpTest/TestTorchVision.cs
+++ b/test/TorchSharpTest/TestTorchVision.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using TorchSharp.Modules;
+using static TorchSharp.torchvision.models;
+using Xunit;
+
+
+namespace TorchSharp
+{
+#if NET472_OR_GREATER
+    [Collection("Sequential")]
+#endif // NET472_OR_GREATER
+    public class TestTorchVision
+    { 
+        [Fact]
+        public void TestResNet18()
+        {
+            var model = resnet18();
+            var sd = model.state_dict();
+            Assert.Equal(122, sd.Count);
+        }
+
+        [Fact]
+        public void TestResNet34()
+        {
+            var model = resnet34();
+            var sd = model.state_dict();
+            Assert.Equal(218, sd.Count);
+        }
+
+        [Fact]
+        public void TestResNet50()
+        {
+            var model = resnet50();
+            var sd = model.state_dict();
+            Assert.Equal(320, sd.Count);
+        }
+
+        [Fact]
+        public void TestResNet101()
+        {
+            var model = resnet101();
+            var sd = model.state_dict();
+            Assert.Equal(626, sd.Count);
+        }
+
+        [Fact]
+        public void TestResNet152()
+        {
+            var model = resnet152();
+            var sd = model.state_dict();
+            Assert.Equal(932, sd.Count);
+        }
+
+        [Fact]
+        public void TestAlexNet()
+        {
+            var model = alexnet();
+            var sd = model.state_dict();
+            Assert.Equal(16, sd.Count);
+        }
+
+        [Fact]
+        public void TestVGG11()
+        {
+            {
+                var model = vgg11();
+                var sd = model.state_dict();
+                Assert.Equal(22, sd.Count);
+            }
+            {
+                var model = vgg11_bn();
+                var sd = model.state_dict();
+                Assert.Equal(62, sd.Count);
+            }
+        }
+
+        [Fact]
+        public void TestVGG13()
+        {
+            {
+                var model = vgg13();
+                var sd = model.state_dict();
+                Assert.Equal(26, sd.Count);
+            }
+            {
+                var model = vgg13_bn();
+                var sd = model.state_dict();
+                Assert.Equal(76, sd.Count);
+            }
+        }
+
+        [Fact]
+        public void TestVGG16()
+        {
+            {
+                var model = vgg16();
+                var sd = model.state_dict();
+                Assert.Equal(32, sd.Count);
+            }
+            {
+                var model = vgg16_bn();
+                var sd = model.state_dict();
+                Assert.Equal(97, sd.Count);
+            }
+        }
+
+        [Fact]
+        public void TestVGG19()
+        {
+            {
+                var model = vgg19();
+                var sd = model.state_dict();
+                Assert.Equal(38, sd.Count);
+            }
+            {
+                var model = vgg19_bn();
+                var sd = model.state_dict();
+                Assert.Equal(118, sd.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I added ResNet to torchvision.models. There's no direct support for pretrained weights, we'll need a place to store binary data that isn't in the repo itself, but for now, I'd appreciate comments on the UX.

I also added a 'skip' list to Module.load/save, which could be useful for not loading weights for some modules in a model, for example a last linear layer that will be replaced or has a different shape. 

Primary usage: transfer-learning.

Note that to skip a layer, all the state related to it must be skipped. For example, for a linear layer, both the 'weight' and 'bias,' if present, must be skipped.

With the new API, it should be possible to load a ResNet model that has a different number of classes from the one for which trained weights are available, simply by passing in 'fc.weight' and 'fc.bias' as the skip list when loading.