### PR TITLE
adding tensor factory for arbitrary arrays

### DIFF
--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -2080,7 +2080,7 @@ namespace TorchSharp
         /// var tensor = torch.tensor_from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
         /// </code>
         /// </example>
-        public static Tensor tensor_from_array(Array rawArray, ScalarType? dtype = null, Device? device = null, bool requiresGrad = false)
+        public static Tensor from_array(Array rawArray, ScalarType? dtype = null, Device? device = null, bool requiresGrad = false)
         {
             // enumerates over all dimensions of the arbitrary array
             // and returns the length of the dimension

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -2045,6 +2045,87 @@ namespace TorchSharp
             return tensor(rawArray, new long[] { dim0, dim1, dim2, dim3 }, dtype, device, requiresGrad);
         }
 
+#nullable enable
+        /// <summary>
+        /// Creates a <see cref="torch.Tensor">torch tensor</see> from an arbitrary <see cref="Array">array</see>.
+        /// </summary>
+        /// <param name="rawArray">The arbitrary array to create the tensor from.</param>
+        /// <param name="dtype">The torch data type.</param>
+        /// <param name="device">The torch device.</param>
+        /// <param name="requiresGrad">Set <value>true</value> if gradients need to be computed for this Tensor; <value>false</value> otherwise.</param>
+        /// <returns>A <see cref="torch.Tensor">torch tensor</see></returns>
+        /// <exception cref="InvalidOperationException">
+        /// When <see cref="Type.GetElementType()">Array.GetType().GetElementType()</see> does not return the .NET element type.
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// When <see cref="Type.GetElementType()">Array.GetType().GetElementType()</see> returns an unsupported .NET element type.
+        /// Supported element types are <see cref="bool" />, <see cref="byte" />, <see cref="sbyte" />, <see cref="short" />,
+        /// <see cref="int" />, <see cref="long" />, <see cref="float" />, <see cref="double" />,
+        /// and <see cref="System.Numerics.Complex" />.
+        /// </exception>
+        /// <example>
+        /// Tensor from array of rank 1
+        /// <code>
+        /// var array = new double[] { { 1, 2, 3, 4, 5, 6, 7, 8 } };
+        /// var tensor = torch.tensor_from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
+        /// </code>
+        /// Tensor from array of rank 2
+        /// <code>
+        /// var array = new double[,] { { 1, 2, 3, 4 }, { 5, 6, 7, 8 } };
+        /// var tensor = torch.tensor_from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
+        /// </code>
+        /// Tensor from array of rank 3
+        /// <code>
+        /// var array = new double[,,] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
+        /// var tensor = torch.tensor_from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
+        /// </code>
+        /// </example>
+        public static Tensor tensor_from_array(Array rawArray, ScalarType? dtype = null, Device? device = null, bool requiresGrad = false)
+        {
+            // enumerates over all dimensions of the arbitrary array
+            // and returns the length of the dimension
+            IEnumerable<long> GetShape(Array arr)
+            {
+                for (var dim = 0; dim < arr.Rank; dim++) {
+                    var dimLength = arr.GetLength(dim);
+                    yield return dimLength;
+                }
+            }
+            var shape = GetShape(rawArray).ToArray();
+
+            var t = rawArray.GetType().GetElementType();
+            if (t is null) throw new InvalidOperationException($"{nameof(rawArray)}.GetType().GetElementType() returned null.");
+
+            IEnumerable<object> GetElements(Array rawArray)
+            {
+                foreach (var element in rawArray) {
+                    yield return element!;
+                }
+            }
+            var elements = GetElements(rawArray);
+
+            // call the existing factory methods to construct the tensor
+            if (t == typeof(bool)) return tensor(elements.Cast<bool>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(byte)) return tensor(elements.Cast<byte>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(sbyte)) return tensor(elements.Cast<sbyte>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(short)) return tensor(elements.Cast<short>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(int)) return tensor(elements.Cast<int>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(long)) return tensor(elements.Cast<long>().ToArray(), shape, dtype, device, requiresGrad);
+#if NET50_OR_GREATER
+            // TODO: implement the required factory method
+            // if (t == typeof(half)) return tensor(elements.Cast<half>().ToArray(), shape, dtype, device, requiresGrad);
+#endif
+            if (t == typeof(float)) return tensor(elements.Cast<float>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(double)) return tensor(elements.Cast<double>().ToArray(), shape, dtype, device, requiresGrad);
+            // TODO: implement the required factory methods
+            // if (t == typeof(Tuple<float, float>)) return tensor(elements.Cast<Tuple<float, float>>().ToArray(), shape, dtype, device, requiresGrad);
+            // if (t == typeof(Tuple<double, double>)) return tensor(elements.Cast<Tuple<double, double>>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(System.Numerics.Complex)) return tensor(elements.Cast<System.Numerics.Complex>().ToArray(), shape, dtype, device, requiresGrad);
+
+            throw new NotSupportedException($"The type {t.FullName} is not supported.");
+        }
+#nullable disable
+
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -2067,24 +2067,26 @@ namespace TorchSharp
         /// Tensor from array of rank 1
         /// <code>
         /// var array = new double[] { { 1, 2, 3, 4, 5, 6, 7, 8 } };
-        /// var tensor = torch.tensor_from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
+        /// var tensor = torch.from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
         /// </code>
         /// Tensor from array of rank 2
         /// <code>
         /// var array = new double[,] { { 1, 2, 3, 4 }, { 5, 6, 7, 8 } };
-        /// var tensor = torch.tensor_from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
+        /// var tensor = torch.from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
         /// </code>
         /// Tensor from array of rank 3
         /// <code>
         /// var array = new double[,,] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
-        /// var tensor = torch.tensor_from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
+        /// var tensor = torch.from_array(rawArray: array, dtype: torch.ScalarType.Float64, device: torch.Device.CPU, requiresGrad: false);
         /// </code>
         /// </example>
+        [System.Diagnostics.Contracts.Pure]
         public static Tensor from_array(Array rawArray, ScalarType? dtype = null, Device? device = null, bool requiresGrad = false)
         {
             // enumerates over all dimensions of the arbitrary array
             // and returns the length of the dimension
-            IEnumerable<long> GetShape(Array arr)
+            [System.Diagnostics.Contracts.Pure]
+            static IEnumerable<long> GetShape(Array arr)
             {
                 for (var dim = 0; dim < arr.Rank; dim++) {
                     var dimLength = arr.GetLength(dim);
@@ -2096,31 +2098,21 @@ namespace TorchSharp
             var t = rawArray.GetType().GetElementType();
             if (t is null) throw new InvalidOperationException($"{nameof(rawArray)}.GetType().GetElementType() returned null.");
 
-            IEnumerable<object> GetElements(Array rawArray)
-            {
-                foreach (var element in rawArray) {
-                    yield return element!;
-                }
-            }
-            var elements = GetElements(rawArray);
-
             // call the existing factory methods to construct the tensor
-            if (t == typeof(bool)) return tensor(elements.Cast<bool>().ToArray(), shape, dtype, device, requiresGrad);
-            if (t == typeof(byte)) return tensor(elements.Cast<byte>().ToArray(), shape, dtype, device, requiresGrad);
-            if (t == typeof(sbyte)) return tensor(elements.Cast<sbyte>().ToArray(), shape, dtype, device, requiresGrad);
-            if (t == typeof(short)) return tensor(elements.Cast<short>().ToArray(), shape, dtype, device, requiresGrad);
-            if (t == typeof(int)) return tensor(elements.Cast<int>().ToArray(), shape, dtype, device, requiresGrad);
-            if (t == typeof(long)) return tensor(elements.Cast<long>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(bool)) return tensor(rawArray.Cast<bool>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(byte)) return tensor(rawArray.Cast<byte>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(sbyte)) return tensor(rawArray.Cast<sbyte>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(short)) return tensor(rawArray.Cast<short>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(int)) return tensor(rawArray.Cast<int>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(long)) return tensor(rawArray.Cast<long>().ToArray(), shape, dtype, device, requiresGrad);
 #if NET50_OR_GREATER
             // TODO: implement the required factory method
-            // if (t == typeof(half)) return tensor(elements.Cast<half>().ToArray(), shape, dtype, device, requiresGrad);
+            // if (t == typeof(half)) return tensor(rawArray.Cast<half>().ToArray(), shape, dtype, device, requiresGrad);
 #endif
-            if (t == typeof(float)) return tensor(elements.Cast<float>().ToArray(), shape, dtype, device, requiresGrad);
-            if (t == typeof(double)) return tensor(elements.Cast<double>().ToArray(), shape, dtype, device, requiresGrad);
-            // TODO: implement the required factory methods
-            // if (t == typeof(Tuple<float, float>)) return tensor(elements.Cast<Tuple<float, float>>().ToArray(), shape, dtype, device, requiresGrad);
-            // if (t == typeof(Tuple<double, double>)) return tensor(elements.Cast<Tuple<double, double>>().ToArray(), shape, dtype, device, requiresGrad);
-            if (t == typeof(System.Numerics.Complex)) return tensor(elements.Cast<System.Numerics.Complex>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(float)) return tensor(rawArray.Cast<float>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(double)) return tensor(rawArray.Cast<double>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof((float, float))) return tensor(rawArray.Cast<(float, float)>().ToArray(), shape, dtype, device, requiresGrad);
+            if (t == typeof(System.Numerics.Complex)) return tensor(rawArray.Cast<System.Numerics.Complex>().ToArray(), shape, dtype, device, requiresGrad);
 
             throw new NotSupportedException($"The type {t.FullName} is not supported.");
         }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -656,6 +656,32 @@ namespace TorchSharp
             x.item<double>();
         }
 
+        [Fact]
+        public void TestFactory()
+        {
+            {
+                var array = new float[8];
+                var t = torch.tensor(array);
+                Assert.Equal(1, t.ndim);
+                Assert.Equal(ScalarType.Float32, t.dtype);
+            }
+
+            {
+                var array = new double[1,2];
+                var t = torch.from_array(array);
+                Assert.Equal(2, t.ndim);
+                Assert.Equal(new long[] { 1, 2 }, t.shape);
+                Assert.Equal(ScalarType.Float64, t.dtype);
+            }
+
+            {
+                var array = new long[1,2,3];
+                var t = torch.from_array(array);
+                Assert.Equal(3, t.ndim);
+                Assert.Equal(new long[] { 1, 2,3 }, t.shape);
+                Assert.Equal(ScalarType.Int64, t.dtype);
+            }
+        }
 
         [Fact]
         public void CreateFloat32TensorZeros()

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -678,8 +678,16 @@ namespace TorchSharp
                 var array = new long[1,2,3];
                 var t = torch.from_array(array);
                 Assert.Equal(3, t.ndim);
-                Assert.Equal(new long[] { 1, 2,3 }, t.shape);
+                Assert.Equal(new long[] { 1, 2, 3 }, t.shape);
                 Assert.Equal(ScalarType.Int64, t.dtype);
+            }
+
+            {
+                var array = new double[,,] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
+                var t = torch.from_array(array);
+                Assert.Equal(3, t.ndim);
+                Assert.Equal(new long[] { 2, 2, 2 }, t.shape);
+                Assert.Equal(ScalarType.Float64, t.dtype);
             }
         }
 


### PR DESCRIPTION
adding a factory method for creating a tensor from an arbitrary array type. 

*Issues*
- some data types are not supported yet, since the appropriate factory methods are missing
- method is not named `tensor`, since the compiler cannot differentiate with the `tensor(IList<> ...)` methods in some cases when given the same name (ie. when the first parameter is of type `List<T>`)
- unit tests are missing, since i was unable to compile the project on my computer (insufficient disk space for the CUDA libs)