### PR TITLE
WIP: Add torchaudio.transforms.Spectrogram and torchaudio.transforms.Inver…

### DIFF
--- a/src/TorchSharp/TorchAudio/Compose.cs
+++ b/src/TorchSharp/TorchAudio/Compose.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+
+using System;
+using static TorchSharp.torch;
+
+namespace TorchSharp
+{
+    public static partial class torchaudio
+    {
+        internal class ComposedTransforms : IDisposable, ITransform
+        {
+            public ComposedTransforms(ITransform[] transforms)
+            {
+                this.transforms = transforms;
+            }
+
+            public void Dispose()
+            {
+                foreach (var t in transforms) {
+                    if (t is IDisposable) {
+                        ((IDisposable)t).Dispose();
+                    }
+                }
+            }
+
+            public Tensor forward(Tensor input)
+            {
+                foreach (var t in transforms) {
+                    input = t.forward(input);
+                }
+                return input;
+            }
+
+            private ITransform[] transforms;
+        }
+
+        public static partial class transforms
+        {
+            /// <summary>
+            /// Composes several transforms together.
+            /// </summary>
+            /// <param name="transforms">A list of transforms to compose serially.</param>
+            /// <returns></returns>
+            static public ITransform Compose(params ITransform[] transforms)
+            {
+                return new ComposedTransforms(transforms);
+            }
+        }
+    }
+}

--- a/src/TorchSharp/TorchAudio/Functional.cs
+++ b/src/TorchSharp/TorchAudio/Functional.cs
@@ -1,0 +1,142 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+using static TorchSharp.torch;
+
+// A number of implementation details in this file have been translated from the Python version or torchvision,
+// largely located in the files found in this folder:
+//
+// https://github.com/pytorch/audio/blob/39c2c0a77e11b82ce152d60df3a92f6854d5f52b/torchaudio/functional/functional.py
+//
+// The origin has the following copyright notice and license:
+//
+// https://github.com/pytorch/audio/blob/main/LICENSE
+//
+
+namespace TorchSharp
+{
+    public static partial class torchaudio
+    {
+        public static partial class functional
+        {
+            /// <summary>
+            /// Compute spectrograms from audio signals.
+            /// </summary>
+            /// <param name="waveform">The audio signal tensor</param>
+            /// <param name="pad">Padding on the sides</param>
+            /// <param name="window">The window function</param>
+            /// <param name="n_fft">The size of Fourier transform</param>
+            /// <param name="hop_length">The hop length</param>
+            /// <param name="win_length">The window length</param>
+            /// <param name="power">Exponent for the magnitude spectrogram</param>
+            /// <param name="normalized">Whether the output is normalized, or not.</param>
+            /// <param name="center">Whether the t-th frame is centered around t * hop_window, or not.</param>
+            /// <param name="pad_mode">The padding mode used when center is true.</param>
+            /// <param name="onesided">Whether the output is onesided or not.</param>
+            /// <param name="return_complex">Deprecated and not used.</param>
+            /// <returns>Spectrograms of audio signals</returns>
+            public static torch.Tensor spectrogram(torch.Tensor waveform, long pad, torch.Tensor window, long n_fft, long hop_length, long win_length, double? power, bool normalized, bool center = true, PaddingModes pad_mode = PaddingModes.Reflect, bool onesided = true, bool? return_complex = null)
+            {
+                if (pad > 0) {
+                    // TODO add "with torch.no_grad():" back when JIT supports it
+                    waveform = torch.nn.functional.pad(waveform, new long[] { pad, pad }, PaddingModes.Constant);
+                }
+
+                // pack batch
+                var shape = waveform.size();
+                waveform = waveform.reshape(-1, shape[shape.Length - 1]);
+
+                // default values are consistent with librosa.core.spectrum._spectrogram
+                var spec_f = torch.stft(
+                    input: waveform,
+                    n_fft: n_fft,
+                    hop_length: hop_length,
+                    win_length: win_length,
+                    window: window,
+                    center: center,
+                    pad_mode: pad_mode,
+                    normalized: false,
+                    onesided: onesided,
+                    return_complex: true);
+
+                // unpack batch
+                var spec_shape = new long[shape.Length + spec_f.dim() - 2];
+                Array.Copy(shape, spec_shape, shape.Length - 1);
+                Array.Copy(spec_f.shape, 1, spec_shape, shape.Length - 1, spec_f.dim() - 1);
+                spec_f = spec_f.reshape(spec_shape);
+
+                if (normalized) {
+                    spec_f /= window.pow(2.0).sum().sqrt();
+                }
+                if (power.HasValue) {
+                    if (power.Value == 1.0) {
+                        return spec_f.abs();
+                    }
+                    return spec_f.abs().pow(power.Value);
+                } else {
+                    return spec_f;
+                }
+            }
+
+            /// <summary>
+            /// Compute inverse of spectrogram.
+            /// </summary>
+            /// <param name="spectrogram">The spectrogram tensor</param>
+            /// <param name="length">The length of the output tensor</param>
+            /// <param name="pad">Padding on the sides</param>
+            /// <param name="window">The window function</param>
+            /// <param name="n_fft">The size of Fourier transform</param>
+            /// <param name="hop_length">The hop length</param>
+            /// <param name="win_length">The window length</param>
+            /// <param name="normalized">Whether the output is normalized, or not.</param>
+            /// <param name="center">Whether the t-th frame is centered around t * hop_window, or not.</param>
+            /// <param name="pad_mode">The padding mode used when center is true.</param>
+            /// <param name="onesided">Whether the output is onesided or not.</param>
+            /// <returns></returns>
+            public static torch.Tensor inverse_spectrogram(torch.Tensor spectrogram, long? length, long pad, torch.Tensor window, long n_fft, long hop_length, long win_length, bool normalized, bool center = true, PaddingModes pad_mode = PaddingModes.Reflect, bool onesided = true)
+            {
+                if (!spectrogram.is_complex()) {
+                    throw new ArgumentException("Expected `spectrogram` to be complex dtype.");
+                }
+
+                if (normalized) {
+                    spectrogram = spectrogram * window.pow(2.0).sum().sqrt();
+                }
+
+                // pack batch
+                var shape = spectrogram.size();
+                spectrogram = spectrogram.reshape(-1, shape[shape.Length - 2], shape[shape.Length - 1]);
+
+                // default values are consistent with librosa.core.spectrum._spectrogram
+                var waveform = torch.istft(
+                    input: spectrogram,
+                    n_fft: n_fft,
+                    hop_length: hop_length,
+                    win_length: win_length,
+                    window: window,
+                    center: center,
+                    normalized: false,
+                    onesided: onesided,
+                    length: length.HasValue ? length.Value + 2 * pad : -1,
+                    return_complex: false
+                );
+
+                if (length.HasValue && pad > 0) {
+                    // remove padding from front and back
+                    waveform = waveform[TensorIndex.Colon, TensorIndex.Slice(pad, -pad)];
+                }
+
+                // unpack batch
+                var waveform_shape = new long[shape.Length - 1];
+                Array.Copy(shape, waveform_shape, shape.Length - 2);
+                waveform_shape[waveform_shape.Length - 1] = waveform.shape[waveform.dim() - 1];
+                waveform = waveform.reshape(waveform_shape);
+
+                return waveform;
+            }
+        }
+    }
+}

--- a/src/TorchSharp/TorchAudio/Transforms.cs
+++ b/src/TorchSharp/TorchAudio/Transforms.cs
@@ -1,0 +1,235 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+using static TorchSharp.torch;
+
+// A number of implementation details in this file have been translated from the Python version or torchvision,
+// largely located in the files found in this folder:
+//
+// https://github.com/pytorch/audio/blob/bb77cbebb620a46fdc0dc7e6dae2253eef3f37e2/torchaudio/transforms/_transforms.py
+//
+// The origin has the following copyright notice and license:
+//
+// https://github.com/pytorch/audio/blob/main/LICENSE
+//
+
+namespace TorchSharp
+{
+    public static partial class torchaudio
+    {
+        public interface ITransform
+        {
+            Tensor forward(Tensor input);
+        }
+
+        public delegate torch.Tensor WindowFunction(long win_length);
+
+        internal class Spectrogram : ITransform
+        {
+            private readonly long n_fft;
+            private readonly long win_length;
+            private readonly long hop_length;
+            private readonly long pad;
+            private readonly Tensor window;
+            private readonly double? power;
+            private readonly bool normalized;
+            private readonly bool center;
+            private readonly PaddingModes pad_mode;
+            private readonly bool onesided;
+
+            public Spectrogram(
+                long n_fft = 400,
+                long? win_length = null,
+                long? hop_length = null,
+                long pad = 0,
+                WindowFunction window_fn = null,
+                Tensor window = null,
+                double? power = 2.0,
+                bool normalized = false,
+                bool center = true,
+                PaddingModes pad_mode = PaddingModes.Reflect,
+                bool onesided = true,
+                bool? return_complex = null)
+            {
+                this.n_fft = n_fft;
+                if (win_length.HasValue) {
+                    this.win_length = win_length.Value;
+                } else {
+                    this.win_length = n_fft;
+                }
+                if (hop_length.HasValue) {
+                    this.hop_length = hop_length.Value;
+                } else {
+                    this.hop_length = this.win_length / 2;
+                }
+                this.pad = pad;
+                if (window is not null) {
+                    this.window = window;
+                } else if (window_fn != null) {
+                    this.window = window_fn(this.win_length);
+                } else {
+                    this.window = torch.hann_window(this.win_length);
+                }
+                this.power = power;
+                this.normalized = normalized;
+                this.center = center;
+                this.pad_mode = pad_mode;
+                this.onesided = onesided;
+                if (return_complex.HasValue) {
+                    Console.WriteLine(
+                        "`return_complex` argument is now deprecated and is not effective." +
+                        "`torchaudio.transforms.Spectrogram(power=null)` always returns a tensor with " +
+                        "complex dtype. Please remove the argument in the function call."
+                    );
+                }
+            }
+
+            public Tensor forward(Tensor input)
+            {
+                return torchaudio.functional.spectrogram(
+                    waveform: input,
+                    pad: pad,
+                    window: window,
+                    n_fft: n_fft,
+                    hop_length: hop_length,
+                    win_length: win_length,
+                    power: power,
+                    normalized: normalized,
+                    center: center,
+                    pad_mode: pad_mode,
+                    onesided: onesided);
+            }
+        }
+
+        internal class InverseSpectrogram : ITransform
+        {
+            private readonly long n_fft;
+            private readonly long win_length;
+            private readonly long hop_length;
+            private readonly long pad;
+            private readonly Tensor window;
+            private readonly bool normalized;
+            private readonly bool center;
+            private readonly PaddingModes pad_mode;
+            private readonly bool onesided;
+
+            public InverseSpectrogram(
+                long n_fft = 400,
+                long? win_length = null,
+                long? hop_length = null,
+                long pad = 0,
+                WindowFunction window_fn = null,
+                Tensor window = null,
+                bool normalized = false,
+                bool center = true,
+                PaddingModes pad_mode = PaddingModes.Reflect,
+                bool onesided = true)
+            {
+                this.n_fft = n_fft;
+                if (win_length.HasValue) {
+                    this.win_length = win_length.Value;
+                } else {
+                    this.win_length = n_fft;
+                }
+                if (hop_length.HasValue) {
+                    this.hop_length = hop_length.Value;
+                } else {
+                    this.hop_length = this.win_length / 2;
+                }
+                this.pad = pad;
+                if (window is not null) {
+                    this.window = window;
+                } else if (window_fn != null) {
+                    this.window = window_fn(this.win_length);
+                } else {
+                    this.window = torch.hann_window(this.win_length);
+                }
+                this.normalized = normalized;
+                this.center = center;
+                this.pad_mode = pad_mode;
+                this.onesided = onesided;
+            }
+
+            public Tensor forward(Tensor input)
+            {
+                return forward(input, null);
+            }
+
+            public Tensor forward(Tensor input, long? length = null)
+            {
+                return torchaudio.functional.inverse_spectrogram(
+                    spectrogram: input,
+                    length: length,
+                    pad: pad,
+                    window: window,
+                    n_fft: n_fft,
+                    hop_length: hop_length,
+                    win_length: win_length,
+                    normalized: normalized,
+                    center: center,
+                    pad_mode: pad_mode,
+                    onesided: onesided);
+            }
+        }
+
+        public static partial class transforms
+        {
+            public static ITransform Spectrogram(
+                long n_fft = 400,
+                long? win_length = null,
+                long? hop_length = null,
+                long pad = 0,
+                WindowFunction window_fn = null,
+                Tensor window = null,
+                double? power = 2.0,
+                bool normalized = false,
+                bool center = true,
+                PaddingModes pad_mode = PaddingModes.Reflect,
+                bool onesided = true,
+                bool? return_complex = null)
+            {
+                return new Spectrogram(
+                    n_fft: n_fft,
+                    hop_length: hop_length,
+                    win_length: win_length,
+                    pad: pad,
+                    window_fn: window_fn,
+                    window: window,
+                    power: power,
+                    normalized: normalized,
+                    center: center,
+                    pad_mode: pad_mode,
+                    onesided: onesided,
+                    return_complex: return_complex);
+            }
+
+            public static ITransform InverseSpectrogram(
+                long n_fft = 400,
+                long? win_length = null,
+                long? hop_length = null,
+                long pad = 0,
+                WindowFunction window_fn = null,
+                Tensor window = null,
+                bool normalized = false,
+                bool center = true,
+                PaddingModes pad_mode = PaddingModes.Reflect,
+                bool onesided = true)
+            {
+                return new InverseSpectrogram(
+                    n_fft: n_fft,
+                    hop_length: hop_length,
+                    win_length: win_length,
+                    pad: pad,
+                    window_fn: window_fn,
+                    window: window,
+                    normalized: normalized,
+                    center: center,
+                    pad_mode: pad_mode,
+                    onesided: onesided);
+            }
+        }
+    }
+}

--- a/test/TorchSharpTest/TestTorchAudio.cs
+++ b/test/TorchSharpTest/TestTorchAudio.cs
@@ -1,0 +1,113 @@
+using System;
+using Xunit;
+
+namespace TorchSharp
+{
+    public class TestTorchAudio
+    {
+        private torch.Tensor make_waveform()
+        {
+            var fc = 220;
+            var fm = 440;
+            var beta = 1;
+            var t = torch.linspace(0, 5, 16000 * 5);
+            var waveform = 1.0 * torch.sin(2 * Math.PI * t * fc + beta * torch.sin(2 * Math.PI * fm * t));
+            return waveform;
+        }
+
+        [Fact]
+        public void FunctionalSpectrogram()
+        {
+            var waveform = make_waveform();
+
+            var spectrogram = torchaudio.functional.spectrogram(
+                waveform: waveform,
+                pad: 3,
+                window: torch.hann_window(400),
+                n_fft: 512,
+                hop_length: 160,
+                win_length: 400,
+                power: 2.0f,
+                normalized: true);
+
+            Assert.Equal(new long[] { 257, 501 }, spectrogram.shape);
+            var mean_square = torch.mean(torch.square(spectrogram)).item<float>();
+            Assert.InRange(mean_square - 50.7892f, -1e-2f, 1e-2f);
+        }
+
+        [Fact]
+        public void FunctionalInverseSpectrogram()
+        {
+            var waveform = make_waveform();
+
+            var spectrogram = torchaudio.functional.spectrogram(
+                waveform: waveform,
+                pad: 3,
+                window: torch.hann_window(400),
+                n_fft: 512,
+                hop_length: 160,
+                win_length: 400,
+                power: null,
+                normalized: false);
+
+            var inversed_waveform = torchaudio.functional.inverse_spectrogram(
+                spectrogram: spectrogram,
+                length: null,
+                pad: 3,
+                window: torch.hann_window(400),
+                n_fft: 512,
+                hop_length: 160,
+                win_length: 400,
+                normalized: false);
+
+            var mse = torch.mean(torch.square(waveform - inversed_waveform)).item<float>();
+            Assert.InRange(mse, 0, 0.1f);
+        }
+
+        [Fact]
+        public void TransformsSpectrogram()
+        {
+            var transform = torchaudio.transforms.Spectrogram();
+            var waveform = make_waveform();
+            var spectrogram = transform.forward(waveform);
+            var expected = torchaudio.functional.spectrogram(
+                waveform: waveform,
+                pad: 0,
+                window: torch.hann_window(400),
+                n_fft: 400,
+                hop_length: 200,
+                win_length: 400,
+                power: 2.0,
+                normalized: false);
+            var mse = torch.mean(torch.square(spectrogram - expected)).item<float>();
+            Assert.InRange(mse, 0f, 1e-10f);
+        }
+
+        [Fact]
+        public void TransformsInverseSpectrogram()
+        {
+            var transform = torchaudio.transforms.InverseSpectrogram();
+            var spectrogram = torchaudio.functional.spectrogram(
+                waveform: make_waveform(),
+                pad: 0,
+                window: torch.hann_window(400),
+                n_fft: 400,
+                hop_length: 200,
+                win_length: 400,
+                power: null,
+                normalized: false);
+            var waveform = transform.forward(spectrogram);
+            var expected = torchaudio.functional.inverse_spectrogram(
+                spectrogram: spectrogram,
+                length: null,
+                pad: 0,
+                window: torch.hann_window(400),
+                n_fft: 400,
+                hop_length: 200,
+                win_length: 400,
+                normalized: false);
+            var mse = torch.mean(torch.square(waveform - expected)).item<float>();
+            Assert.InRange(mse, 0f, 1e-10f);
+        }
+    }
+}


### PR DESCRIPTION
…seSpectrogram

These functions are not very useful without `torchaudio.load()` and datasets.

I may ask this to merge.
Or before merging I can try implement https://github.com/pytorch/audio/blob/main/torchaudio/backend/no_backend.py, https://github.com/pytorch/audio/blob/main/torchaudio/datasets/yesno.py
very simple backend for testing to read WAV files to make this end-to-end.
