### PR TITLE
`torch.hub.download_url_to_file()` fails to download a file > 2GB

### DIFF
--- a/src/TorchSharp/Hub.cs
+++ b/src/TorchSharp/Hub.cs
@@ -43,7 +43,7 @@ namespace TorchSharp
             {
                 try {
                     using (var httpClient = new HttpClient()) {
-                        using (var response = await httpClient.GetAsync(url, cancellationToken)) {
+                        using (var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)) {
                             response.EnsureSuccessStatusCode();
                             using (var writer = File.OpenWrite(dst)) {
                                 await response.Content.CopyToAsync(writer);


### PR DESCRIPTION
Fixes #657 
Similar issue with https://stackoverflow.com/questions/18720435/httpclient-buffer-size-limit-exceeded