### PR TITLE
RNN, LSTM, GRU support `PackedSequence`

### DIFF
--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -747,10 +747,23 @@ NNModule THSNN_RNN_ctor(const int64_t input_size, const int64_t hidden_size, con
 
 Tensor THSNN_RNN_forward(const NNModule module, const Tensor input1, const Tensor input2, Tensor* h_n)
 {
-    Tensor output;
+    Tensor output = nullptr;
+    *h_n = nullptr;
     CATCH(
         auto result = (*module)->as<torch::nn::RNN>()->forward(*input1, (input2 ? *input2 : at::Tensor()));
         output = new torch::Tensor(std::get<0>(result));
+        *h_n = new torch::Tensor(std::get<1>(result));
+    );
+    return output;
+}
+
+PackedSequence THSNN_RNN_forward_with_packed_input(const NNModule module, const PackedSequence input1, const Tensor input2, Tensor* h_n)
+{
+    PackedSequence output = nullptr;
+    *h_n = nullptr;
+    CATCH(
+        auto result = (*module)->as<torch::nn::RNN>()->forward_with_packed_input(*input1, (input2 ? *input2 : at::Tensor()));
+        output = new torch::nn::utils::rnn::PackedSequence(std::get<0>(result));
         *h_n = new torch::Tensor(std::get<1>(result));
     );
     return output;
@@ -820,10 +833,23 @@ NNModule THSNN_GRU_ctor(const int64_t input_size, const int64_t hidden_size, con
 
 Tensor THSNN_GRU_forward(const NNModule module, const Tensor input1, const Tensor input2, Tensor* h_n)
 {
-    Tensor output;
+    Tensor output = nullptr;
+    *h_n = nullptr;
     CATCH(
         auto result = (*module)->as<torch::nn::GRU>()->forward(*input1, (input2 ? *input2 : at::Tensor()));
         output = new torch::Tensor(std::get<0>(result));
+        *h_n = new torch::Tensor(std::get<1>(result));
+    );
+    return output;
+}
+
+PackedSequence THSNN_GRU_forward_with_packed_input(const NNModule module, const PackedSequence input1, const Tensor input2, Tensor* h_n)
+{
+    PackedSequence output = nullptr;
+    *h_n = nullptr;
+    CATCH(
+        auto result = (*module)->as<torch::nn::GRU>()->forward_with_packed_input(*input1, (input2 ? *input2 : at::Tensor()));
+        output = new torch::nn::utils::rnn::PackedSequence(std::get<0>(result));
         *h_n = new torch::Tensor(std::get<1>(result));
     );
     return output;
@@ -854,10 +880,28 @@ Tensor THSNN_LSTM_forward(const NNModule module, const Tensor input1, const Tens
 {
     const std::tuple<at::Tensor, at::Tensor>& second_arg = (h0 == nullptr || c0 == nullptr) ? std::make_tuple(at::Tensor(), at::Tensor()) : std::make_tuple(*h0, *c0);
 
-    Tensor output;
+    Tensor output = nullptr;
+    *h_n = nullptr;
+    *c_n = nullptr;
     CATCH(
         auto result = (*module)->as<torch::nn::LSTM>()->forward(*input1, second_arg);
         output = new torch::Tensor(std::get<0>(result));
+        *h_n = new torch::Tensor(std::get<0>(std::get<1>(result)));
+        *c_n = new torch::Tensor(std::get<1>(std::get<1>(result)));
+    );
+    return output;
+}
+
+PackedSequence THSNN_LSTM_forward_with_packed_input(const NNModule module, const PackedSequence input1, const Tensor h0, const Tensor c0, Tensor* h_n, Tensor* c_n)
+{
+    const std::tuple<at::Tensor, at::Tensor>& second_arg = (h0 == nullptr || c0 == nullptr) ? std::make_tuple(at::Tensor(), at::Tensor()) : std::make_tuple(*h0, *c0);
+
+    PackedSequence output = nullptr;
+    *h_n = nullptr;
+    *c_n = nullptr;
+    CATCH(
+        auto result = (*module)->as<torch::nn::LSTM>()->forward_with_packed_input(*input1, second_arg);
+        output = new torch::nn::utils::rnn::PackedSequence(std::get<0>(result));
         *h_n = new torch::Tensor(std::get<0>(std::get<1>(result)));
         *c_n = new torch::Tensor(std::get<1>(std::get<1>(result)));
     );
@@ -1077,6 +1121,26 @@ Tensor THSNN_one_hot(const Tensor self, const int64_t num_classes)
     CATCH_RETURN_Tensor(
         res = ResultTensor(torch::nn::functional::one_hot(*self, num_classes));
     )
+}
+
+Tensor THSNN_PackedSequence_data(PackedSequence sequence)
+{
+    CATCH_TENSOR(sequence->data());
+}
+
+Tensor THSNN_PackedSequence_batch_sizes(PackedSequence sequence)
+{
+    CATCH_TENSOR(sequence->batch_sizes());
+}
+
+Tensor THSNN_PackedSequence_sorted_indices(PackedSequence sequence)
+{
+    CATCH_TENSOR(sequence->sorted_indices());
+}
+
+Tensor THSNN_PackedSequence_unsorted_indices(PackedSequence sequence)
+{
+    CATCH_TENSOR(sequence->unsorted_indices());
 }
 
 void THSNN_PackedSequence_dispose(PackedSequence sequence)

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -369,10 +369,13 @@ EXPORT_API(void)     THSNN_MultiheadAttention_forward(const NNModule module, con
 
 EXPORT_API(NNModule) THSNN_RNN_ctor(const int64_t input_size, const int64_t hidden_size, const int64_t num_layers, const int64_t nonlinearity, const bool bias, const bool batchFirst, const double dropout, const bool bidirectional, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_RNN_forward(const NNModule module, const Tensor input1, const Tensor input2, Tensor* h_n);
+EXPORT_API(PackedSequence) THSNN_RNN_forward_with_packed_input(const NNModule module, const PackedSequence input1, const Tensor input2, Tensor* h_n);
 EXPORT_API(NNModule) THSNN_GRU_ctor(const int64_t input_size, const int64_t hidden_size, const int64_t num_layers, const bool bias, const bool batchFirst, const double dropout, const bool bidirectional, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_GRU_forward(const NNModule module, const Tensor input1, const Tensor input2, Tensor* h_n);
+EXPORT_API(PackedSequence) THSNN_GRU_forward_with_packed_input(const NNModule module, const PackedSequence input1, const Tensor input2, Tensor* h_n);
 EXPORT_API(NNModule) THSNN_LSTM_ctor(const int64_t input_size, const int64_t hidden_size, const int64_t num_layers, const bool bias, const bool batchFirst, const double dropout, const bool bidirectional, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_LSTM_forward(const NNModule module, const Tensor input1, const Tensor h0, const Tensor c0, Tensor* h_n, Tensor* c_n);
+EXPORT_API(PackedSequence) THSNN_LSTM_forward_with_packed_input(const NNModule module, const PackedSequence input1, const Tensor h0, const Tensor c0, Tensor* h_n, Tensor* c_n);
 
 EXPORT_API(NNModule) THSNN_RNNCell_ctor(const int64_t input_size, const int64_t hidden_size, const int64_t nonlinearity, const bool bias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor)   THSNN_RNNCell_forward(const NNModule module, const Tensor input1, const Tensor h0);
@@ -500,6 +503,10 @@ EXPORT_API(void) THSNN_initKaimingUniform(Tensor tensor, double a);
 
 // Utils RNN
 
+EXPORT_API(Tensor) THSNN_PackedSequence_data(PackedSequence sequence);
+EXPORT_API(Tensor) THSNN_PackedSequence_batch_sizes(PackedSequence sequence);
+EXPORT_API(Tensor) THSNN_PackedSequence_sorted_indices(PackedSequence sequence);
+EXPORT_API(Tensor) THSNN_PackedSequence_unsorted_indices(PackedSequence sequence);
 EXPORT_API(void) THSNN_PackedSequence_dispose(PackedSequence sequence);
 EXPORT_API(PackedSequence) THSNN_pack_padded_sequence(Tensor input, Tensor lengths, bool batch_first, bool enforce_sorted);
 EXPORT_API(void) THSNN_pad_packed_sequence(PackedSequence sequence, bool batch_first, double padding_value, int64_t total_length, Tensor* res1, Tensor* res2);

--- a/src/TorchSharp/NN/Recurrent/GRU.cs
+++ b/src/TorchSharp/NN/Recurrent/GRU.cs
@@ -41,12 +41,39 @@ namespace TorchSharp
                     var N = _batch_first ? input.shape[0] : input.shape[1];
                     var D = _bidirectional ? 2 : 1;
 
-                    h0 = torch.zeros(D * _num_layers, N, _hidden_size, device:input.device);
+                    h0 = torch.zeros(D * _num_layers, N, _hidden_size, dtype: input.dtype, device: input.device);
                 }
 
                 var res = THSNN_GRU_forward(handle, input.Handle, h0.Handle, out IntPtr hN);
                 if (res == IntPtr.Zero || hN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return (new Tensor(res), new Tensor(hN));
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_GRU_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
+
+            /// <summary>
+            /// Applies a multi-layer gated recurrent unit (GRU) RNN to an input sequence.
+            /// </summary>
+            /// <param name="input">PackedSequence containing the features of the input sequence.</param>
+            /// <param name="h0">Tensor of shape (num_layers * num_directions, batch, hidden_size)containing the initial hidden state for each element in the batch.
+            /// Defaults to 0 if not provided. If the GRU is bidirectional, num_directions should be 2, else it should be 1.</param>
+            /// <returns></returns>
+            /// <returns></returns>
+            public (torch.nn.utils.rnn.PackedSequence, Tensor) forward(torch.nn.utils.rnn.PackedSequence input, Tensor h0 = null)
+            {
+                if (h0 is null) {
+                    var data = input.data;
+                    var batch_sizes = input.batch_sizes;
+                    var N = batch_sizes[0].item<long>();
+                    var D = _bidirectional ? 2 : 1;
+
+                    h0 = torch.zeros(D * _num_layers, N, _hidden_size, dtype: data.dtype, device: data.device);
+                }
+
+                var res = THSNN_GRU_forward_with_packed_input(handle, input.Handle, h0.Handle, out IntPtr hN);
+                if (res.IsInvalid || hN == IntPtr.Zero) { torch.CheckForErrors(); }
+                return (new torch.nn.utils.rnn.PackedSequence(res), new Tensor(hN));
             }
 
             [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/NN/Utils/PackedSequence.cs
+++ b/src/TorchSharp/NN/Utils/PackedSequence.cs
@@ -47,11 +47,34 @@ namespace TorchSharp
                             }
                         }
 
+                        /// <summary>
+                        /// The packed sequences
+                        /// </summary>
+                        public readonly Tensor data;
+
+                        /// <summary>
+                        /// Batch size at each sequence step
+                        /// </summary>
+                        public readonly Tensor batch_sizes;
+
+                        /// <summary>
+                        /// The sorted indices
+                        /// </summary>
+                        public readonly Tensor sorted_indices;
+
+                        /// <summary>
+                        /// The original indices
+                        /// </summary>
+                        public readonly Tensor unsorted_indices;
                         private HType handle;
 
                         internal PackedSequence(HType handle)
                         {
                             this.handle = handle;
+                            this.data = new Tensor(THSNN_PackedSequence_data(handle));
+                            this.batch_sizes = new Tensor(THSNN_PackedSequence_batch_sizes(handle));
+                            this.sorted_indices = new Tensor(THSNN_PackedSequence_sorted_indices(handle));
+                            this.unsorted_indices = new Tensor(THSNN_PackedSequence_unsorted_indices(handle));
                         }
 
                         internal HType Handle => handle;
@@ -61,11 +84,28 @@ namespace TorchSharp
                         /// </summary>
                         public void Dispose()
                         {
+                            this.data.Dispose();
+                            this.batch_sizes.Dispose();
+                            this.sorted_indices.Dispose();
+                            this.unsorted_indices.Dispose();
+
                             if (handle != null && !handle.IsInvalid) {
                                 handle.Dispose();
                                 handle.SetHandleAsInvalid();
                             }
                         }
+
+                        [DllImport("LibTorchSharp")]
+                        private static extern IntPtr THSNN_PackedSequence_data(HType handle);
+
+                        [DllImport("LibTorchSharp")]
+                        private static extern IntPtr THSNN_PackedSequence_batch_sizes(HType handle);
+
+                        [DllImport("LibTorchSharp")]
+                        private static extern IntPtr THSNN_PackedSequence_sorted_indices(HType handle);
+
+                        [DllImport("LibTorchSharp")]
+                        private static extern IntPtr THSNN_PackedSequence_unsorted_indices(HType handle);
                     }
                 }
             }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -3524,7 +3524,25 @@ namespace TorchSharp
                 Assert.Equal(h0.shape, hN.shape);
                 Assert.Equal(new long[] { input.shape[0], input.shape[1], 20 }, output.shape);
             }
+        }
 
+        [Fact]
+        public void TestRNN5()
+        {
+            using (Tensor input = torch.randn(new long[] { 5, 3, 10 }),
+                   lengths = torch.tensor(new long[] { 5, 5, 5 }))
+            using (var rnn = RNN(10, 20, 2)) {
+                rnn.flatten_parameters();
+                var (output, hN) = rnn.forward(input);
+                var packed_input = torch.nn.utils.rnn.pack_padded_sequence(input, lengths);
+                var (packed_output, packed_hN) = rnn.forward(packed_input);
+                float mse;
+                mse = torch.mean(torch.square(hN - packed_hN)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+                var (unpacked_output, unpacked_output_lengths) = torch.nn.utils.rnn.pad_packed_sequence(packed_output);
+                mse = torch.mean(torch.square(output - unpacked_output)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+            }
         }
 
         [Fact]
@@ -3661,6 +3679,39 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestGRU5()
+        {
+            using (Tensor input = torch.randn(new long[] { 5, 3, 10 }).to(torch.float64),
+                   h0 = torch.randn(new long[] { 2, 3, 20 }).to(torch.float64))
+            using (var gru = GRU(10, 20, 2)) {
+                gru.to(torch.float64);
+                gru.flatten_parameters();
+                var (output, hN) = gru.forward(input);
+                Assert.Equal(h0.shape, hN.shape);
+                Assert.Equal(new long[] { input.shape[0], input.shape[1], 20 }, output.shape);
+            }
+        }
+
+        [Fact]
+        public void TestGRU6()
+        {
+            using (Tensor input = torch.randn(new long[] { 5, 3, 10 }),
+                   lengths = torch.tensor(new long[] { 5, 5, 5 }))
+            using (var rnn = GRU(10, 20, 2)) {
+                rnn.flatten_parameters();
+                var (output, hN) = rnn.forward(input);
+                var packed_input = torch.nn.utils.rnn.pack_padded_sequence(input, lengths);
+                var (packed_output, packed_hN) = rnn.forward(packed_input);
+                float mse;
+                mse = torch.mean(torch.square(hN - packed_hN)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+                var (unpacked_output, unpacked_output_lengths) = torch.nn.utils.rnn.pad_packed_sequence(packed_output);
+                mse = torch.mean(torch.square(output - unpacked_output)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+            }
+        }
+
+        [Fact]
         public void TestGRUCell1()
         {
             var seq = 5;
@@ -3746,6 +3797,50 @@ namespace TorchSharp
                 Assert.Equal(new long[] { input.shape[0], input.shape[1], 20 }, output.shape);
             }
 
+        }
+
+        [Fact]
+        public void TestLSTM5()
+        {
+            using (Tensor input = torch.randn(new long[] { 5, 3, 10 }),
+                   lengths = torch.tensor(new long[] { 5, 5, 5 }),
+                   h0 = torch.randn(new long[] { 2, 3, 20 }),
+                   c0 = torch.randn(new long[] { 2, 3, 20 }))
+            using (var rnn = LSTM(10, 20, 2)) {
+                rnn.flatten_parameters();
+                var (output, hN, cN) = rnn.forward(input, (h0, c0));
+                var packed_input = torch.nn.utils.rnn.pack_padded_sequence(input, lengths);
+                var (packed_output, packed_hN, packed_cN) = rnn.forward(packed_input, (h0, c0));
+                float mse;
+                mse = torch.mean(torch.square(hN - packed_hN)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+                mse = torch.mean(torch.square(cN - packed_cN)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+                var (unpacked_output, unpacked_output_lengths) = torch.nn.utils.rnn.pad_packed_sequence(packed_output);
+                mse = torch.mean(torch.square(output - unpacked_output)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+            }
+        }
+
+        [Fact]
+        public void TestLSTM6()
+        {
+            using (Tensor input = torch.randn(new long[] { 5, 3, 10 }),
+                   lengths = torch.tensor(new long[] { 5, 5, 5 }))
+            using (var rnn = LSTM(10, 20, 2)) {
+                rnn.flatten_parameters();
+                var (output, hN, cN) = rnn.forward(input);
+                var packed_input = torch.nn.utils.rnn.pack_padded_sequence(input, lengths);
+                var (packed_output, packed_hN, packed_cN) = rnn.forward(packed_input);
+                float mse;
+                mse = torch.mean(torch.square(hN - packed_hN)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+                mse = torch.mean(torch.square(cN - packed_cN)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+                var (unpacked_output, unpacked_output_lengths) = torch.nn.utils.rnn.pad_packed_sequence(packed_output);
+                mse = torch.mean(torch.square(output - unpacked_output)).item<float>();
+                Assert.InRange(mse, 0, 0.1f);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
- RNN, LSTM, GRU accept `PackedSequence`
- PackedSequence.data, batch_sizes, sorted_indices, unsorted_indices added
- Fixed: RNN, LSTM, GRU fail to process float64 tensors.