### PR TITLE
Update test projects to xUnit 2.4.2

### DIFF
--- a/pkg/FileRestitcher/FileRestitcher.Tests/FileRestitcher.Tests.csproj
+++ b/pkg/FileRestitcher/FileRestitcher.Tests/FileRestitcher.Tests.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -73,6 +73,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit" Version="2.4.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 
 </Project>
 

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -670,62 +670,70 @@ namespace TorchSharp
             {
                 var array = new bool[8];
                 var t = torch.tensor(array);
-                Assert.Equal(1, t.ndim);
-                Assert.Equal(ScalarType.Bool, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(ScalarType.Bool, t.dtype));
             }
 
             {
                 var array = new bool[8];
                 var t = torch.tensor(array, new long[] { 8 });
-                Assert.Equal(1, t.ndim);
-                Assert.Equal(ScalarType.Bool, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(ScalarType.Bool, t.dtype));
             }
 
             {
                 var array = new int[8];
                 var t = torch.tensor(array);
-                Assert.Equal(1, t.ndim);
-                Assert.Equal(ScalarType.Int32, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(ScalarType.Int32, t.dtype));
             }
 
             {
                 var array = new float[8];
                 var t = torch.tensor(array);
-                Assert.Equal(1, t.ndim);
-                Assert.Equal(ScalarType.Float32, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(ScalarType.Float32, t.dtype));
             }
 
             {
                 var array = new double[1, 2];
                 var t = torch.from_array(array);
-                Assert.Equal(2, t.ndim);
-                Assert.Equal(new long[] { 1, 2 }, t.shape);
-                Assert.Equal(ScalarType.Float64, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(2, t.ndim),
+                    () => Assert.Equal(new long[] { 1, 2 }, t.shape),
+                    () => Assert.Equal(ScalarType.Float64, t.dtype));
             }
 
             {
                 var array = new long[1, 2, 3];
                 var t = torch.from_array(array);
-                Assert.Equal(3, t.ndim);
-                Assert.Equal(new long[] { 1, 2, 3 }, t.shape);
-                Assert.Equal(ScalarType.Int64, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(3, t.ndim),
+                    () => Assert.Equal(new long[] { 1, 2, 3 }, t.shape),
+                    () => Assert.Equal(ScalarType.Int64, t.dtype));
             }
 
             {
                 var array = new int[1, 2, 3, 4];
                 var t = torch.from_array(array);
-                Assert.Equal(4, t.ndim);
-                Assert.Equal(new long[] { 1, 2, 3, 4 }, t.shape);
-                Assert.Equal(ScalarType.Int32, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(4, t.ndim),
+                    () => Assert.Equal(new long[] { 1, 2, 3, 4 }, t.shape),
+                    () => Assert.Equal(ScalarType.Int32, t.dtype));
             }
 
             {
                 var array = new double[,,] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
                 var t = torch.from_array(array);
-                Assert.Equal(3, t.ndim);
-                Assert.Equal(new long[] { 2, 2, 2 }, t.shape);
-                Assert.Equal(ScalarType.Float64, t.dtype);
-                Assert.Equal(array.Cast<double>().ToArray(), t.data<double>().ToArray());
+                Assert.Multiple(
+                    () => Assert.Equal(3, t.ndim),
+                    () => Assert.Equal(new long[] { 2, 2, 2 }, t.shape),
+                    () => Assert.Equal(ScalarType.Float64, t.dtype),
+                    () => Assert.Equal(array.Cast<double>().ToArray(), t.data<double>().ToArray()));
             }
         }
 
@@ -735,56 +743,63 @@ namespace TorchSharp
             {
                 var array = new sbyte[8];
                 var t = torch.tensor(array);
-                Assert.Equal(1, t.ndim);
-                Assert.Equal(ScalarType.Int8, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(ScalarType.Int8, t.dtype));
             }
 
             {
                 var array = new sbyte[8];
                 var t = torch.tensor(array, new long[] { 8 });
-                Assert.Equal(1, t.ndim);
-                Assert.Equal(ScalarType.Int8, t.dtype);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(ScalarType.Int8, t.dtype));
             }
 
             {
                 var array = new sbyte[1, 2];
                 var t = torch.tensor(array);
-                Assert.Equal(2, t.ndim);
-                Assert.Equal(new long[] { 1, 2 }, t.shape);
-                Assert.Equal(ScalarType.Int8, t.dtype);
+                Assert.Multiple(
+                () => Assert.Equal(2, t.ndim),
+                () => Assert.Equal(new long[] { 1, 2 }, t.shape),
+                () => Assert.Equal(ScalarType.Int8, t.dtype));
             }
 
             {
                 var array = new sbyte[1, 2, 3];
                 var t = torch.tensor(array);
-                Assert.Equal(3, t.ndim);
-                Assert.Equal(new long[] { 1, 2, 3 }, t.shape);
-                Assert.Equal(ScalarType.Int8, t.dtype);
+                Assert.Multiple(
+                () => Assert.Equal(3, t.ndim),
+                () => Assert.Equal(new long[] { 1, 2, 3 }, t.shape),
+                () => Assert.Equal(ScalarType.Int8, t.dtype));
             }
 
             {
                 var array = new sbyte[1, 2, 3, 4];
                 var t = torch.tensor(array);
-                Assert.Equal(4, t.ndim);
-                Assert.Equal(new long[] { 1, 2, 3, 4 }, t.shape);
-                Assert.Equal(ScalarType.Int8, t.dtype);
+                Assert.Multiple(
+                () => Assert.Equal(4, t.ndim),
+                () => Assert.Equal(new long[] { 1, 2, 3, 4 }, t.shape),
+                () => Assert.Equal(ScalarType.Int8, t.dtype));
             }
 
             {
                 var array = new sbyte[100, 100, 100];
                 var t = torch.tensor(array);
-                Assert.Equal(3, t.ndim);
-                Assert.Equal(new long[] { 100, 100, 100 }, t.shape);
-                Assert.Equal(ScalarType.Int8, t.dtype);
+                Assert.Multiple(
+                () => Assert.Equal(3, t.ndim),
+                () => Assert.Equal(new long[] { 100, 100, 100 }, t.shape),
+                () => Assert.Equal(ScalarType.Int8, t.dtype));
             }
 
             {
                 var array = new sbyte[,,] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
                 var t = torch.tensor(array);
-                Assert.Equal(3, t.ndim);
-                Assert.Equal(new long[] { 2, 2, 2 }, t.shape);
-                Assert.Equal(ScalarType.Int8, t.dtype);
-                Assert.Equal(array.Cast<sbyte>().ToArray(), t.data<sbyte>().ToArray());
+                Assert.Multiple(
+                () => Assert.Equal(3, t.ndim),
+                () => Assert.Equal(new long[] { 2, 2, 2 }, t.shape),
+                () => Assert.Equal(ScalarType.Int8, t.dtype),
+                () => Assert.Equal(array.Cast<sbyte>().ToArray(), t.data<sbyte>().ToArray()));
             }
         }
 
@@ -5238,7 +5253,7 @@ namespace TorchSharp
                 Assert.Equal(new long[] { 10, 1, 10 }, mean.shape);
             }
             {
-                var t = torch.from_array(new float[,]{ { 1f, 2f }, { 3f, 4f } });
+                var t = torch.from_array(new float[,] { { 1f, 2f }, { 3f, 4f } });
                 var stdExpected = torch.std(t);
                 var meanExpected = torch.mean(t);
                 var (std, mean) = torch.std_mean(t);

--- a/test/TorchSharpTest/TorchSharpTest.csproj
+++ b/test/TorchSharpTest/TorchSharpTest.csproj
@@ -65,6 +65,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit" Version="2.4.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Coverage)' == 'true'">
       <CollectCoverage>true</CollectCoverage>


### PR DESCRIPTION
As proposed in #615, now that xUnit version 2.4.2 has been released, we're upgrading so that we can assert more than one thing at a time, catching multiple failures.

Rather than spend energy on converting all unit tests to take advantage of this, I have converted half a handful, as an example. Look for Assert.Multiple() in the source code. Going forward, unit test writers are encouraged to organized assertions such that they take advantage of this new capability.