### PR TITLE
Rationalize how tensors are created from arrays.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,9 +4,31 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 ## NuGet Version 0.97.2
 
+__Breaking Changes:__
+
+This release contains a breaking change__ related to `torch.tensor()` and `torch.from_array()` which were not adhering to the semantics of the Pytorch equivalents (`torch.from_numpy()` in the case of `torch.from_array()`).
+
+With this change, there will be a number of different APIs to create a tensor form a .NET array. The most significant difference between them is whether the underlying storage is shared, or whether a copy is made. Depending on the size of the input array, copying can take orders of magnitude more time in creation than sharing storage, which is done in constant time (a few μs).
+
+The resulting tensors may be reshaped, but not resized.
+
+```C#
+// Never copy:
+public static Tensor from_array(Array input)
+
+// Copy only if dtype or device arguments require it:
+public static Tensor frombuffer(Array input, ScalarType dtype, long count = -1, long offset = 0, bool requiresGrad = false, Device? device = null)
+public static Tensor as_tensor(Array input,  ScalarType? dtype = null, Device? device = null)
+public static Tensor as_tensor(Tensor input, ScalarType? dtype = null, Device? device = null)
+
+// Always copy:
+public static Tensor as_tensor(IList<<VARIOUS TYPES>> input,  ScalarType? dtype = null, Device? device = null)
+public static Tensor tensor(<<VARIOUS TYPES>> input, torch.Device? device = null, bool requiresGrad = false)
+```
+
 __Fixed Bugs:__
 
-#670 Better align methods for creating tensors from .NET arrays with Pytorch APIs.<br/>
+#670 Better align methods for creating tensors from .NET arrays with Pytorch APIs. _This is the breaking change mentioned earlier._<br/>
 #679 The default value of onesided or torch.istft() is not aligned with PyTorch<br/>
 
 __API Changes__:
@@ -14,7 +36,7 @@ __API Changes__:
 Added torch.nn.init.trunc_normal_<br/>
 Added index_add, index_copy, index_fill<br/>
 Added torch.frombuffer()<br/>
-Rationalizing torch.tensor(), torch.as_tensor(), and torch.from_array()<br/>
+Added torch.fft.hfft2, hfftn, ihfft2, ihfftn<br/>
 
 ## NuGet Version 0.97.1
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,12 +2,19 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
-## NuGet Version 0.97.1
+## NuGet Version 0.97.2
+
+__Fixed Bugs:__
+
+#670 Better align methods for creating tensors from .NET arrays with Pytorch APIs.<br/>
+#679 The default value of onesided or torch.istft() is not aligned with PyTorch<br/>
 
 __API Changes__:
 
-Added torch.nn.init.trunc_normal_
-Added index_add, index_copy, index_fill
+Added torch.nn.init.trunc_normal_<br/>
+Added index_add, index_copy, index_fill<br/>
+Added torch.frombuffer()<br/>
+Rationalizing torch.tensor(), torch.as_tensor(), and torch.from_array()<br/>
 
 ## NuGet Version 0.97.1
 

--- a/src/Native/LibTorchSharp/THSFFT.cpp
+++ b/src/Native/LibTorchSharp/THSFFT.cpp
@@ -158,11 +158,12 @@ Tensor THSTensor_stft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t
     CATCH_TENSOR(x->stft(n_fft, _hop_length, _win_length, _window, normalized, onesided, return_complex));
 }
 
-Tensor THSTensor_istft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool center, bool normalized, bool onesided, int64_t length, bool return_complex)
+Tensor THSTensor_istft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool center, bool normalized, int64_t onesided, int64_t length, bool return_complex)
 {
     auto _hop_length = hop_length == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(hop_length);
     auto _win_length = win_length == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(win_length);
     auto _window = window == nullptr ? c10::optional<at::Tensor>() : *window;
     auto _length = length == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(length);
-    CATCH_TENSOR(x->istft(n_fft, _hop_length, _win_length, _window, center, normalized, onesided, _length, return_complex));
+    auto _onesided = (onesided == -1) ? c10::optional<bool>() : c10::optional<bool>((bool)onesided);
+    CATCH_TENSOR(x->istft(n_fft, _hop_length, _win_length, _window, center, normalized, _onesided, _length, return_complex));
 }

--- a/src/Native/LibTorchSharp/THSFFT.cpp
+++ b/src/Native/LibTorchSharp/THSFFT.cpp
@@ -61,11 +61,45 @@ Tensor THSTensor_hfft(const Tensor tensor, const int64_t n, const int64_t dim, i
     CATCH_TENSOR(torch::fft::hfft(*tensor, nArg, dim, normArg));
 }
 
+Tensor THSTensor_hfft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm)
+{
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, 2);
+    CATCH_TENSOR(torch::fft::hfft2(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_hfftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
+    c10::IntArrayRef dArg = (dim == nullptr) ? c10::IntArrayRef({-2, -1}) : c10::IntArrayRef(dim, dim_length);
+
+    CATCH_TENSOR(torch::fft::hfftn(*tensor, sArg, dArg, normArg));
+}
+
 Tensor THSTensor_ihfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm)
 {
     auto nArg = (n == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(n));
     auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
     CATCH_TENSOR(torch::fft::ihfft(*tensor, nArg, dim, normArg));
+}
+
+Tensor THSTensor_ihfft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm)
+{
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, 2));
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, 2);
+    CATCH_TENSOR(torch::fft::ihfft2(*tensor, sArg, dArg, normArg));
+}
+
+Tensor THSTensor_ihfftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm)
+{
+    auto normArg = (norm == 0) ? "backward" : (norm == 1) ? "forward" : "ortho";
+    auto sArg = (s == nullptr) ? c10::nullopt : c10::optional<c10::IntArrayRef>(c10::IntArrayRef(s, s_length));
+    c10::IntArrayRef dArg = (dim == nullptr) ? c10::IntArrayRef({ -2, -1 }) : c10::IntArrayRef(dim, dim_length);
+
+    CATCH_TENSOR(torch::fft::ihfftn(*tensor, sArg, dArg, normArg));
 }
 
 Tensor THSTensor_rfft(const Tensor tensor, const int64_t n, const int64_t dim, int8_t norm)

--- a/src/Native/LibTorchSharp/THSFFT.cpp
+++ b/src/Native/LibTorchSharp/THSFFT.cpp
@@ -150,12 +150,13 @@ Tensor THSTensor_ifftshift(const Tensor tensor, const int64_t* dim, const int di
     CATCH_TENSOR(torch::fft::ifftshift(*tensor, dArg));
 }
 
-Tensor THSTensor_stft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool normalized, bool onesided, bool return_complex)
+Tensor THSTensor_stft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool normalized, int64_t onesided, bool return_complex)
 {
     auto _hop_length = hop_length == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(hop_length);
     auto _win_length = win_length == -1 ? c10::optional<int64_t>() : c10::optional<int64_t>(win_length);
     auto _window = window == nullptr ? c10::optional<at::Tensor>() : *window;
-    CATCH_TENSOR(x->stft(n_fft, _hop_length, _win_length, _window, normalized, onesided, return_complex));
+    auto _onesided = (onesided == -1) ? c10::optional<bool>() : c10::optional<bool>((bool)onesided);
+    CATCH_TENSOR(x->stft(n_fft, _hop_length, _win_length, _window, normalized, _onesided, return_complex));
 }
 
 Tensor THSTensor_istft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool center, bool normalized, int64_t onesided, int64_t length, bool return_complex)

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -1541,4 +1541,4 @@ EXPORT_API(Tensor) THSTensor_kaiser_window(const int64_t len, bool periodic, dou
 
 EXPORT_API(Tensor) THSTensor_stft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool normalized, bool onesided, bool return_complex);
 
-EXPORT_API(Tensor) THSTensor_istft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool center, bool normalized, bool onesided, int64_t length, bool return_complex);
+EXPORT_API(Tensor) THSTensor_istft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool center, bool normalized, int64_t onesided, int64_t length, bool return_complex);

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -885,6 +885,14 @@ EXPORT_API(Tensor) THSTensor_new(
     int8_t scalar_type,
     const bool requires_grad);
 
+EXPORT_API(Tensor) THSTensor_frombuffer(
+    void* data,
+    void (*deleter)(void*),
+    const int64_t count,
+    const ptrdiff_t offset,
+    int8_t scalar_type,
+    const bool requires_grad);
+
 EXPORT_API(Tensor) THSTensor_newInt64(
     int64_t* data,
     void (*deleter)(void*),

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -1530,15 +1530,10 @@ EXPORT_API(Tensor) THSTensor_ifftshift(const Tensor tensor, const int64_t* dim, 
 // Spectral Ops
 
 EXPORT_API(Tensor) THSTensor_bartlett_window(const int64_t len, bool periodic, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);
-
 EXPORT_API(Tensor) THSTensor_blackman_window(const int64_t len, bool periodic, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);
-
 EXPORT_API(Tensor) THSTensor_hamming_window(const int64_t len, bool periodic, double alpha, double beta, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);
-
 EXPORT_API(Tensor) THSTensor_hann_window(const int64_t len, bool periodic, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);
-
 EXPORT_API(Tensor) THSTensor_kaiser_window(const int64_t len, bool periodic, double beta, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);
 
-EXPORT_API(Tensor) THSTensor_stft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool normalized, bool onesided, bool return_complex);
-
+EXPORT_API(Tensor) THSTensor_stft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool normalized, int64_t onesided, bool return_complex);
 EXPORT_API(Tensor) THSTensor_istft(const Tensor x, int64_t n_fft, int64_t hop_length, int64_t win_length, const Tensor window, bool center, bool normalized, int64_t onesided, int64_t length, bool return_complex);

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -1502,6 +1502,12 @@ EXPORT_API(Tensor) THSTensor_fft2(const Tensor tensor, const int64_t* s, const i
 
 EXPORT_API(Tensor) THSTensor_ifft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm);
 
+EXPORT_API(Tensor) THSTensor_hfft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm);
+EXPORT_API(Tensor) THSTensor_ihfft2(const Tensor tensor, const int64_t* s, const int64_t* dim, int8_t norm);
+
+EXPORT_API(Tensor) THSTensor_hfftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm);
+EXPORT_API(Tensor) THSTensor_ihfftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm);
+
 EXPORT_API(Tensor) THSTensor_fftn(const Tensor tensor, const int64_t *s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm);
 
 EXPORT_API(Tensor) THSTensor_ifftn(const Tensor tensor, const int64_t* s, const int s_length, const int64_t* dim, const int dim_length, int8_t norm);

--- a/src/Native/LibTorchSharp/THSTensorFactories.cpp
+++ b/src/Native/LibTorchSharp/THSTensorFactories.cpp
@@ -167,6 +167,22 @@ Tensor THSTensor_new(
     CATCH_TENSOR(torch::from_blob(data, at::ArrayRef<int64_t>(sizes, szlength), deleter, options));
 }
 
+Tensor THSTensor_frombuffer(
+    void* data,
+    void (*deleter)(void*),
+    const int64_t count,
+    const ptrdiff_t offset,
+    int8_t scalar_type,
+    const bool requires_grad)
+{
+    auto options = at::TensorOptions()
+        .dtype(at::ScalarType(scalar_type))
+        .requires_grad(requires_grad);
+
+    auto dataPtr = reinterpret_cast<char*>(data);
+    CATCH_TENSOR(torch::from_blob(dataPtr+offset, at::ArrayRef<int64_t>(count), deleter, options));
+}
+
 Tensor THSTensor_newInt64(
     int64_t* data,
     void (*deleter)(void*),

--- a/src/TorchSharp/FFT.cs
+++ b/src/TorchSharp/FFT.cs
@@ -447,6 +447,129 @@ namespace TorchSharp
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(handle);
             }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSTensor_hfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+            /// <summary>
+            /// Computes the 2-dimensional discrete Fourier transform of a Hermitian symmetric input signal.
+            ///
+            /// Equivalent to hfftn() but only transforms the last two dimensions by default.
+            /// input is interpreted as a one-sided Hermitian signal in the time domain.
+            /// By the Hermitian property, the Fourier transform will be real-valued.
+            /// </summary>
+            /// <param name="input">The input tensor</param>
+            /// <param name="s">
+            /// Signal size in the transformed dimensions.
+            /// If given, each dimension dim[i] will either be zero-padded or trimmed to the length s[i] before computing the IFFT.
+            /// If a length -1 is specified, no padding is done in that dimension.
+            /// </param>
+            /// <param name="dim">Dimensions to be transformed</param>
+            /// <param name="norm">Normalization mode.</param>
+            public static Tensor hfft2(Tensor input, long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+            {
+                if (input.Dimensions < 2) throw new ArgumentException("hfft2() input should be at least 2D");
+                if (dim == null) dim = new long[] { -2, -1 };
+                unsafe {
+                    fixed (long* ps = s, pDim = dim) {
+                        var res = THSTensor_hfft2(input.Handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
+                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                        return new Tensor(res);
+                    }
+                }
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSTensor_ihfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+            /// <summary>
+            /// Computes the 2-dimensional inverse discrete Fourier transform of a Hermitian symmetric input signal.
+            ///
+            /// Equivalent to hfftn() but only transforms the last two dimensions by default.
+            /// input is interpreted as a one-sided Hermitian signal in the time domain.
+            /// By the Hermitian property, the Fourier transform will be real-valued.
+            /// </summary>
+            /// <param name="input">The input tensor</param>
+            /// <param name="s">
+            /// Signal size in the transformed dimensions.
+            /// If given, each dimension dim[i] will either be zero-padded or trimmed to the length s[i] before computing the IFFT.
+            /// If a length -1 is specified, no padding is done in that dimension.
+            /// </param>
+            /// <param name="dim">Dimensions to be transformed</param>
+            /// <param name="norm">Normalization mode.</param>
+            public static Tensor ihfft2(Tensor input, long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+            {
+                if (input.Dimensions < 2) throw new ArgumentException("ihfft2() input should be at least 2D");
+                if (dim == null) dim = new long[] { -2, -1 };
+                unsafe {
+                    fixed (long* ps = s, pDim = dim) {
+                        var res = THSTensor_ihfft2(input.Handle, (IntPtr)ps, (IntPtr)pDim, (sbyte)norm);
+                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                        return new Tensor(res);
+                    }
+                }
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSTensor_hfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+            /// <summary>
+            /// Computes the n-dimensional discrete Fourier transform of a Herimitian symmetric input signal.
+            ///
+            /// input is interpreted as a one-sided Hermitian signal in the time domain.
+            /// By the Hermitian property, the Fourier transform will be real-valued.
+            /// </summary>
+            /// <param name="input">The input tensor</param>
+            /// <param name="s">
+            /// Signal size in the transformed dimensions.
+            /// If given, each dimension dim[i] will either be zero-padded or trimmed to the length s[i] before computing the IFFT.
+            /// If a length -1 is specified, no padding is done in that dimension.
+            /// </param>
+            /// <param name="dim">Dimensions to be transformed</param>
+            /// <param name="norm">Normalization mode.</param>
+            public static Tensor hfftn(Tensor input, long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+            {
+                if (input.Dimensions < 2) throw new ArgumentException("hfftn() input should be at least 2D");
+                var slen = (s == null) ? 0 : s.Length;
+                var dlen = (dim == null) ? 0 : dim.Length;
+                unsafe {
+                    fixed (long* ps = s, pDim = dim) {
+                        var res = THSTensor_hfftn(input.Handle, (IntPtr)ps, slen, (IntPtr)pDim, dlen, (sbyte)norm);
+                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                        return new Tensor(res);
+                    }
+                }
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSTensor_ihfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+            /// <summary>
+            /// Computes the n-dimensional inverse discrete Fourier transform of a Herimitian symmetric input signal.
+            ///
+            /// input is interpreted as a one-sided Hermitian signal in the time domain.
+            /// By the Hermitian property, the Fourier transform will be real-valued.
+            /// </summary>
+            /// <param name="input">The input tensor</param>
+            /// <param name="s">
+            /// Signal size in the transformed dimensions.
+            /// If given, each dimension dim[i] will either be zero-padded or trimmed to the length s[i] before computing the IFFT.
+            /// If a length -1 is specified, no padding is done in that dimension.
+            /// </param>
+            /// <param name="dim">Dimensions to be transformed</param>
+            /// <param name="norm">Normalization mode.</param>
+            public static Tensor ihfftn(Tensor input, long[] s = null, long[] dim = null, FFTNormType norm = FFTNormType.Backward)
+            {
+                if (input.Dimensions < 2) throw new ArgumentException("ihfftn() input should be at least 2D");
+                var slen = (s == null) ? 0 : s.Length;
+                var dlen = (dim == null) ? 0 : dim.Length;
+                unsafe {
+                    fixed (long* ps = s, pDim = dim) {
+                        var res = THSTensor_ihfftn(input.Handle, (IntPtr)ps, slen, (IntPtr)pDim, dlen, (sbyte)norm);
+                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                        return new Tensor(res);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -99,58 +99,58 @@ namespace TorchSharp
             if (dtype != null && device != null && (data.dtype != dtype || data.device != device)) {
                 return data.clone().to(dtype.Value, device).requires_grad_(data.requires_grad);
             } else {
-                return data;
+                return data.alias();
             }
         }
 
         public static Tensor as_tensor(IList<bool> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<byte> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<sbyte> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<short> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<int> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<long> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<float> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<double> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<(float, float)> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         public static Tensor as_tensor(IList<System.Numerics.Complex> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
-            return torch.tensor(rawArray, dtype, device);
+            return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
         // randperm()
@@ -1363,7 +1363,7 @@ namespace TorchSharp
         /// <remarks>The Torch runtime does not take ownership of the data, so there is no device argument.</remarks>
         public static Tensor tensor(IList<bool> rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), dimensions, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), dimensions, (sbyte)ScalarType.Bool, dtype, device, requiresGrad, false);
         }
 
         /// <summary>
@@ -1380,7 +1380,7 @@ namespace TorchSharp
             return _tensor_generic(rawArray, dimensions, (sbyte)ScalarType.Bool, dtype, device, requiresGrad);
         }
 
-        private static Tensor _tensor_generic(Array rawArray, ReadOnlySpan<long> dimensions, sbyte origType, ScalarType? dtype, Device? device, bool requiresGrad)
+        private static Tensor _tensor_generic(Array rawArray, ReadOnlySpan<long> dimensions, sbyte origType, ScalarType? dtype, Device? device, bool requiresGrad, bool clone = true)
         {
             {
                 // Validate the sizes before handing over storage to native code...
@@ -1395,6 +1395,8 @@ namespace TorchSharp
             }
 
             torch.InitializeDeviceType(DeviceType.CPU);
+
+            if (clone) { rawArray = (Array)rawArray.Clone(); } 
 
             var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
             var dataArrayAddr = dataHandle.AddrOfPinnedObject();
@@ -1511,7 +1513,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<byte> rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), dimensions, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), dimensions, (sbyte)ScalarType.Byte, dtype, device, requiresGrad, false);
         }
 
         /// <summary>
@@ -1613,7 +1615,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<sbyte> rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), dimensions, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), dimensions, (sbyte)ScalarType.Int8, dtype, device, requiresGrad, false);
         }
 
         /// <summary>
@@ -1715,7 +1717,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<short> rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), dimensions, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), dimensions, (sbyte)ScalarType.Int16, dtype, device, requiresGrad, false);
         }
 
         /// <summary>
@@ -1816,7 +1818,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<int> rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), dimensions, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), dimensions, (sbyte)ScalarType.Int32, dtype, device, requiresGrad, false);
         }
 
         /// <summary>
@@ -1916,7 +1918,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<long> rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), dimensions, dtype, device, requiresGrad);
+            return _tensor_i64(rawArray.ToArray(), dimensions, dtype, device, requiresGrad, false);
         }
 
         /// <summary>
@@ -1938,7 +1940,7 @@ namespace TorchSharp
         }
 
         [System.Diagnostics.Contracts.Pure]
-        private static Tensor _tensor_i64(Array rawArray, ReadOnlySpan<long> dimensions, ScalarType? dtype, Device? device, bool requiresGrad) =>
+        private static Tensor _tensor_i64(Array rawArray, ReadOnlySpan<long> dimensions, ScalarType? dtype, Device? device, bool requiresGrad, bool clone = false) =>
             _tensor_generic(rawArray, dimensions, (sbyte)ScalarType.Int64, dtype, device, requiresGrad);
 
         /// <summary>
@@ -2021,7 +2023,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<float> rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), dimensions, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), dimensions, (sbyte)ScalarType.Float32, dtype, device, requiresGrad, false);
         }
 
         /// <summary>
@@ -2123,7 +2125,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<double> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), dtype: dtype, device: device, requiresGrad: requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), stackalloc long[] { rawArray.Count }, (sbyte)ScalarType.Float64, dtype: dtype, device: device, requiresGrad: requiresGrad, false);
         }
 
         /// <summary>
@@ -2153,7 +2155,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<double> rawArray, long rows, long columns, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), stackalloc long[] { rows, columns }, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), stackalloc long[] { rows, columns }, (sbyte)ScalarType.Float64, dtype, device, requiresGrad);
         }
 
         /// <summary>
@@ -2165,7 +2167,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<double> rawArray, long dim0, long dim1, long dim2, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), stackalloc long[] { dim0, dim1, dim2 }, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), stackalloc long[] { dim0, dim1, dim2 }, (sbyte)ScalarType.Float64, dtype, device, requiresGrad);
         }
 
         /// <summary>
@@ -2177,7 +2179,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(IList<double> rawArray, long dim0, long dim1, long dim2, long dim3, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return tensor(rawArray.ToArray(), stackalloc long[] { dim0, dim1, dim2, dim3 }, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray.ToArray(), stackalloc long[] { dim0, dim1, dim2, dim3 }, (sbyte)ScalarType.Float64, dtype, device, requiresGrad);
         }
 
         /// <summary>
@@ -2186,7 +2188,6 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(double[,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
             return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1) }, (sbyte)ScalarType.Float64, dtype, device, requiresGrad);
         }
 
@@ -2196,17 +2197,15 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(double[,,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
             return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2) }, (sbyte)ScalarType.Float64, dtype, device, requiresGrad);
         }
 
         /// <summary>
-        /// Create a four-dimensional tensor from a four-dimensional array of values.
+        /// Create a four-dimensional tensor from a four-dimensional array of values.from
         /// </summary>
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(double[,,,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
             return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2), rawArray.GetLongLength(3) }, (sbyte)ScalarType.Float64, dtype, device, requiresGrad);
         }
 
@@ -2458,10 +2457,11 @@ namespace TorchSharp
         /// Creates a <see cref="torch.Tensor">torch tensor</see> from an arbitrary <see cref="Array">array</see>.
         /// </summary>
         /// <param name="rawArray">The arbitrary array to create the tensor from.</param>
-        /// <param name="dtype">The torch data type.</param>
-        /// <param name="device">The torch device.</param>
-        /// <param name="requiresGrad">Set <value>true</value> if gradients need to be computed for this Tensor; <value>false</value> otherwise.</param>
         /// <returns>A <see cref="torch.Tensor">torch tensor</see></returns>
+        /// <remarks>
+        /// This function roughly corresponds to torch.from_numpy(). It shares the underlying buffer between the input and output.
+        /// torch.tensor() always makes a copy, which can be orders of magnitude slower.
+        /// </remarks>
         /// <exception cref="InvalidOperationException">
         /// When <see cref="Type.GetElementType()">Array.GetType().GetElementType()</see> does not return the .NET element type.
         /// </exception>
@@ -2489,7 +2489,44 @@ namespace TorchSharp
         /// </code>
         /// </example>
         [System.Diagnostics.Contracts.Pure]
-        public static Tensor from_array(Array rawArray, ScalarType? dtype = null, Device? device = null, bool requiresGrad = false)
+        public static Tensor from_array(Array rawArray)
+        {
+            var dtype = ToScalarType(rawArray.GetType().GetElementType()!);
+
+            return from_array(rawArray, dtype, CPU, false);
+        }
+
+        private static ScalarType ToScalarType(Type t)
+        {
+            switch (true) {
+            case bool _ when t == typeof(bool):
+                return ScalarType.Bool;
+            case bool _ when t == typeof(byte):
+                return ScalarType.Byte;
+            case bool _ when t == typeof(byte):
+                return ScalarType.Byte;
+            case bool _ when t == typeof(sbyte):
+                return ScalarType.Int8;
+            case bool _ when t == typeof(short):
+                return ScalarType.Int16;
+            case bool _ when t == typeof(int):
+                return ScalarType.Int32;
+            case bool _ when t == typeof(long):
+                return ScalarType.Int64;
+            case bool _ when t == typeof(float):
+                return ScalarType.Float32;
+            case bool _ when t == typeof(double):
+                return ScalarType.Float64;
+            case bool _ when t == typeof((float,float)):
+                return ScalarType.ComplexFloat32;
+            case bool _ when t == typeof(System.Numerics.Complex):
+                return ScalarType.ComplexFloat64;
+            }
+            throw new NotSupportedException($"The type {t.FullName} is not supported.");
+        }
+
+        [System.Diagnostics.Contracts.Pure]
+        internal static Tensor from_array(Array rawArray, ScalarType? dtype, Device? device = null, bool requiresGrad = false)
         {
             // enumerates over all dimensions of the arbitrary array
             // and returns the length of the dimension
@@ -2510,45 +2547,12 @@ namespace TorchSharp
 
             if (t == typeof((float, float))) return tensor(rawArray.Cast<(float, float)>().ToArray(), shape, dtype, device, requiresGrad);
 
-            if (t == typeof(bool)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Bool, dtype, device, requiresGrad);
-            }
-            if (t == typeof(byte)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Byte, dtype, device, requiresGrad);
-            }
-            if (t == typeof(sbyte)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Int8, dtype, device, requiresGrad);
-            }
-            if (t == typeof(short)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Int16, dtype, device, requiresGrad);
-            }
-            if (t == typeof(int)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Int32, dtype, device, requiresGrad);
-            }
-            if (t == typeof(long)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Int64, dtype, device, requiresGrad);
-            }
-#if NET50_OR_GREATER
-            // TODO: implement the required factory method
-            // if (t == typeof(half)) return tensor(rawArray.Cast<half>().ToArray(), shape, dtype, device, requiresGrad);
-#endif
-            if (t == typeof(float)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Float32, dtype, device, requiresGrad);
-            }
-            if (t == typeof(double)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Float64, dtype, device, requiresGrad);
-            }
-            if (t == typeof(System.Numerics.Complex)) {
-                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
-            }
-
-            throw new NotSupportedException($"The type {t.FullName} is not supported.");
+            var origType = ToScalarType(t);
+            return _tensor_generic(rawArray, shape, (sbyte)origType, dtype, device, requiresGrad, false);
         }
 
         // https://pytorch.org/docs/stable/generated/torch.as_tensor
-        static Tensor as_tensor(Array data, ScalarType? dtype = null, Device? device = null)
-            => from_array(data, dtype, device, false);
-
+        public static Tensor as_tensor(Array data, ScalarType? dtype = null, Device? device = null) => from_array(data, dtype, device, false);
 
         /// <summary>
         /// Creates a 1-dimensional Tensor from an array of n dimensions.
@@ -2564,6 +2568,7 @@ namespace TorchSharp
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="IndexOutOfRangeException"></exception>
+        /// <remarks>The returned tensor and buffer share the same memory. Modifications to the tensor will be reflected in the buffer and vice versa.</remarks>
         public static Tensor frombuffer(Array rawArray, ScalarType dtype, long count = -1, long offset = 0, bool requiresGrad = false, Device? device = null)
         {
             torch.InitializeDeviceType(DeviceType.CPU);
@@ -2581,36 +2586,27 @@ namespace TorchSharp
             }
 
             var t = rawArray.GetType().GetElementType();
-            ScalarType origType = ScalarType.Bool;
+            ScalarType origType = ToScalarType(t!);
 
-            if (t == typeof(bool)) {
-                origType = ScalarType.Bool;
-            } else if (t == typeof(byte)) {
-                origType = ScalarType.Byte;
-            } else if (t == typeof(sbyte)) {
-                origType = ScalarType.Int8;
-            } else if (t == typeof(short)) {
-                origType = ScalarType.Int16;
+            switch(origType) {
+            case ScalarType.Int16:
                 offset *= 2;
-            } else if (t == typeof(int)) {
-                origType = ScalarType.Int32;
+                break;
+            case ScalarType.Int32:
+            case ScalarType.Float32:
                 offset *= 4;
-            } else if (t == typeof(long)) {
-                origType = ScalarType.Int64;
+                break;
+            case ScalarType.Int64:
+            case ScalarType.Float64:
                 offset *= 8;
-            } else if (t == typeof(float)) {
-                origType = ScalarType.Float32;
-                offset *= 4;
-            } else if (t == typeof(double)) {
-                origType = ScalarType.Float64;
-                offset *= 8;
-            } else if (t == typeof((float, float))) {
+                break;
+            case ScalarType.ComplexFloat64:
+                offset *= 16;
+                break;
+            case ScalarType.ComplexFloat32:
                 // Since we are not allowed to make a copy of the buffer, it's currently not
                 // feasible to support complex types, which GCHandle.Alloc() doesn't like.
                 throw new NotImplementedException("frombuffer(ComplexFloat32)");
-            } else if (t == typeof(System.Numerics.Complex)) {
-                origType = ScalarType.ComplexFloat64;
-                offset *= 16;
             }
 
             var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
@@ -2645,6 +2641,7 @@ namespace TorchSharp
                 return tensor;
             }
         }
+
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -2370,12 +2370,6 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            //var dataArray = new double[rawArray.Length * 2];
-            //for (var i = 0; i < rawArray.Length; i++) {
-            //    dataArray[i * 2] = rawArray[i].Real;
-            //    dataArray[i * 2 + 1] = rawArray[i].Imaginary;
-            //}
-
             return _tensor_generic(rawArray, stackalloc long[] { rawArray.LongLength }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
@@ -2385,12 +2379,6 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[] rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            //var dataArray = new double[rawArray.Length * 2];
-            //for (var i = 0; i < rawArray.Length; i++) {
-            //    dataArray[i * 2] = rawArray[i].Real;
-            //    dataArray[i * 2 + 1] = rawArray[i].Imaginary;
-            //}
-
             return _tensor_generic(rawArray, dimensions, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
@@ -2445,14 +2433,6 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            //var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1) * 2];
-            //for (var i = 0; i < rawArray.GetLongLength(0); i++) {
-            //    for (var j = 0; j < rawArray.GetLongLength(1); j++) {
-            //        dataArray[i, j * 2] = rawArray[i, j].Real;
-            //        dataArray[i, j * 2 + 1] = rawArray[i, j].Imaginary;
-            //    }
-            //}
-
             return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
@@ -2462,16 +2442,6 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[,,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            //var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2) * 2];
-            //for (var i = 0; i < rawArray.GetLongLength(0); i++) {
-            //    for (var j = 0; j < rawArray.GetLongLength(1); j++) {
-            //        for (var k = 0; k < rawArray.GetLongLength(2); k++) {
-            //            dataArray[i, j, k * 2] = rawArray[i, j, k].Real;
-            //            dataArray[i, j, k * 2 + 1] = rawArray[i, j, k].Imaginary;
-            //        }
-            //    }
-            //}
-
             return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
@@ -2481,18 +2451,6 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[,,,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            //var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2), rawArray.GetLongLength(3) * 2];
-            //for (var i = 0; i < rawArray.GetLongLength(0); i++) {
-            //    for (var j = 0; j < rawArray.GetLongLength(1); j++) {
-            //        for (var k = 0; k < rawArray.GetLongLength(2); k++) {
-            //            for (var l = 0; l < rawArray.GetLongLength(3); l++) {
-            //                dataArray[i, j, k, l * 2] = rawArray[i, j, k, l].Real;
-            //                dataArray[i, j, k, l * 2 + 1] = rawArray[i, j, k, l].Imaginary;
-            //            }
-            //        }
-            //    }
-            //}
-
             return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2), rawArray.GetLongLength(3) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -97,8 +97,12 @@ namespace TorchSharp
         public static Tensor as_tensor(Tensor data, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
             if (dtype != null && device != null && (data.dtype != dtype || data.device != device)) {
-                return data.clone().to(dtype.Value, device).requires_grad_(data.requires_grad);
-            } else {
+                return data.to(dtype.Value, device).requires_grad_(data.requires_grad);
+            } else if (dtype != null && data.dtype != dtype) {
+                return data.to(dtype.Value).requires_grad_(data.requires_grad);
+            } else if (device != null && data.device != device) {
+                return data.to(device).requires_grad_(data.requires_grad);
+            } else { 
                 return data.alias();
             }
         }
@@ -2491,38 +2495,13 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor from_array(Array rawArray)
         {
-            var dtype = ToScalarType(rawArray.GetType().GetElementType()!);
+            var t = rawArray.GetType().GetElementType();
+            if (t == typeof((float, float)))
+                throw new NotImplementedException("from_array() for (float,float) elements.");
+
+            var dtype = ToScalarType(t!);
 
             return from_array(rawArray, dtype, CPU, false);
-        }
-
-        private static ScalarType ToScalarType(Type t)
-        {
-            switch (true) {
-            case bool _ when t == typeof(bool):
-                return ScalarType.Bool;
-            case bool _ when t == typeof(byte):
-                return ScalarType.Byte;
-            case bool _ when t == typeof(byte):
-                return ScalarType.Byte;
-            case bool _ when t == typeof(sbyte):
-                return ScalarType.Int8;
-            case bool _ when t == typeof(short):
-                return ScalarType.Int16;
-            case bool _ when t == typeof(int):
-                return ScalarType.Int32;
-            case bool _ when t == typeof(long):
-                return ScalarType.Int64;
-            case bool _ when t == typeof(float):
-                return ScalarType.Float32;
-            case bool _ when t == typeof(double):
-                return ScalarType.Float64;
-            case bool _ when t == typeof((float,float)):
-                return ScalarType.ComplexFloat32;
-            case bool _ when t == typeof(System.Numerics.Complex):
-                return ScalarType.ComplexFloat64;
-            }
-            throw new NotSupportedException($"The type {t.FullName} is not supported.");
         }
 
         [System.Diagnostics.Contracts.Pure]

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -1372,7 +1372,7 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(bool[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            return _tensor_generic(rawArray, stackalloc long[] { rawArray.LongLength }, (sbyte)ScalarType.Bool, dtype, device, requiresGrad); 
+            return _tensor_generic(rawArray, stackalloc long[] { rawArray.LongLength }, (sbyte)ScalarType.Bool, dtype, device, requiresGrad);
         }
 
         public static Tensor tensor(bool[] rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
@@ -1387,7 +1387,7 @@ namespace TorchSharp
                 var prod = 1L;
                 foreach (var sz in dimensions) prod *= sz;
 
-                if (origType == (sbyte)ScalarType.ComplexFloat32 || origType == (sbyte)ScalarType.ComplexFloat64)
+                if (origType == (sbyte)ScalarType.ComplexFloat32)
                     prod *= 2;
 
                 if (prod != rawArray.LongLength)
@@ -1419,10 +1419,12 @@ namespace TorchSharp
                     if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                     var tensor = new Tensor(handle);
 
+                    var needsConversion = dtype.HasValue && dtype.Value != (ScalarType)origType;
+
                     if (device is not null) {
-                        tensor = dtype.HasValue ? tensor.to(dtype.Value, device) : tensor.to(device);
-                    } else if (dtype.HasValue) {
-                        tensor = tensor.to_type(dtype.Value);
+                        tensor = needsConversion ? tensor.to(dtype!.Value, device) : tensor.to(device);
+                    } else if (needsConversion) {
+                        tensor = tensor.to_type(dtype!.Value);
                     }
                     return tensor;
                 }
@@ -2368,13 +2370,13 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            var dataArray = new double[rawArray.Length * 2];
-            for (var i = 0; i < rawArray.Length; i++) {
-                dataArray[i * 2] = rawArray[i].Real;
-                dataArray[i * 2 + 1] = rawArray[i].Imaginary;
-            }
+            //var dataArray = new double[rawArray.Length * 2];
+            //for (var i = 0; i < rawArray.Length; i++) {
+            //    dataArray[i * 2] = rawArray[i].Real;
+            //    dataArray[i * 2 + 1] = rawArray[i].Imaginary;
+            //}
 
-            return _tensor_generic(dataArray, stackalloc long[] { rawArray.LongLength }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray, stackalloc long[] { rawArray.LongLength }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
         /// <summary>
@@ -2383,13 +2385,13 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[] rawArray, ReadOnlySpan<long> dimensions, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            var dataArray = new double[rawArray.Length * 2];
-            for (var i = 0; i < rawArray.Length; i++) {
-                dataArray[i * 2] = rawArray[i].Real;
-                dataArray[i * 2 + 1] = rawArray[i].Imaginary;
-            }
+            //var dataArray = new double[rawArray.Length * 2];
+            //for (var i = 0; i < rawArray.Length; i++) {
+            //    dataArray[i * 2] = rawArray[i].Real;
+            //    dataArray[i * 2 + 1] = rawArray[i].Imaginary;
+            //}
 
-            return _tensor_generic(dataArray, dimensions, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray, dimensions, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
         /// <summary>
@@ -2443,15 +2445,15 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1) * 2];
-            for (var i = 0; i < rawArray.GetLongLength(0); i++) {
-                for (var j = 0; j < rawArray.GetLongLength(1); j++) {
-                    dataArray[i, j * 2] = rawArray[i, j].Real;
-                    dataArray[i, j * 2 + 1] = rawArray[i, j].Imaginary;
-                }
-            }
+            //var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1) * 2];
+            //for (var i = 0; i < rawArray.GetLongLength(0); i++) {
+            //    for (var j = 0; j < rawArray.GetLongLength(1); j++) {
+            //        dataArray[i, j * 2] = rawArray[i, j].Real;
+            //        dataArray[i, j * 2 + 1] = rawArray[i, j].Imaginary;
+            //    }
+            //}
 
-            return _tensor_generic(dataArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
         /// <summary>
@@ -2460,17 +2462,17 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[,,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2) * 2];
-            for (var i = 0; i < rawArray.GetLongLength(0); i++) {
-                for (var j = 0; j < rawArray.GetLongLength(1); j++) {
-                    for (var k = 0; k < rawArray.GetLongLength(2); k++) {
-                        dataArray[i, j, k * 2] = rawArray[i, j, k].Real;
-                        dataArray[i, j, k * 2 + 1] = rawArray[i, j, k].Imaginary;
-                    }
-                }
-            }
+            //var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2) * 2];
+            //for (var i = 0; i < rawArray.GetLongLength(0); i++) {
+            //    for (var j = 0; j < rawArray.GetLongLength(1); j++) {
+            //        for (var k = 0; k < rawArray.GetLongLength(2); k++) {
+            //            dataArray[i, j, k * 2] = rawArray[i, j, k].Real;
+            //            dataArray[i, j, k * 2 + 1] = rawArray[i, j, k].Imaginary;
+            //        }
+            //    }
+            //}
 
-            return _tensor_generic(dataArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
         /// <summary>
@@ -2479,19 +2481,19 @@ namespace TorchSharp
         [System.Diagnostics.Contracts.Pure]
         public static Tensor tensor(System.Numerics.Complex[,,,] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null, bool requiresGrad = false)
         {
-            var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2), rawArray.GetLongLength(3) * 2];
-            for (var i = 0; i < rawArray.GetLongLength(0); i++) {
-                for (var j = 0; j < rawArray.GetLongLength(1); j++) {
-                    for (var k = 0; k < rawArray.GetLongLength(2); k++) {
-                        for (var l = 0; l < rawArray.GetLongLength(3); l++) {
-                            dataArray[i, j, k, l * 2] = rawArray[i, j, k, l].Real;
-                            dataArray[i, j, k, l * 2 + 1] = rawArray[i, j, k, l].Imaginary;
-                        }
-                    }
-                }
-            }
+            //var dataArray = new double[rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2), rawArray.GetLongLength(3) * 2];
+            //for (var i = 0; i < rawArray.GetLongLength(0); i++) {
+            //    for (var j = 0; j < rawArray.GetLongLength(1); j++) {
+            //        for (var k = 0; k < rawArray.GetLongLength(2); k++) {
+            //            for (var l = 0; l < rawArray.GetLongLength(3); l++) {
+            //                dataArray[i, j, k, l * 2] = rawArray[i, j, k, l].Real;
+            //                dataArray[i, j, k, l * 2 + 1] = rawArray[i, j, k, l].Imaginary;
+            //            }
+            //        }
+            //    }
+            //}
 
-            return _tensor_generic(dataArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2), rawArray.GetLongLength(3) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
+            return _tensor_generic(rawArray, stackalloc long[] { rawArray.GetLongLength(0), rawArray.GetLongLength(1), rawArray.GetLongLength(2), rawArray.GetLongLength(3) }, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
         }
 
         /// <summary>
@@ -2549,7 +2551,6 @@ namespace TorchSharp
             // call the existing factory methods to construct the tensor
 
             if (t == typeof((float, float))) return tensor(rawArray.Cast<(float, float)>().ToArray(), shape, dtype, device, requiresGrad);
-            if (t == typeof(System.Numerics.Complex)) return tensor(rawArray.Cast<System.Numerics.Complex>().ToArray(), shape, dtype, device, requiresGrad);
 
             if (t == typeof(bool)) {
                 return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Bool, dtype, device, requiresGrad);
@@ -2579,6 +2580,9 @@ namespace TorchSharp
             if (t == typeof(double)) {
                 return _tensor_generic(rawArray, shape, (sbyte)ScalarType.Float64, dtype, device, requiresGrad);
             }
+            if (t == typeof(System.Numerics.Complex)) {
+                return _tensor_generic(rawArray, shape, (sbyte)ScalarType.ComplexFloat64, dtype, device, requiresGrad);
+            }
 
             throw new NotSupportedException($"The type {t.FullName} is not supported.");
         }
@@ -2587,6 +2591,102 @@ namespace TorchSharp
         static Tensor as_tensor(Array data, ScalarType? dtype = null, Device? device = null)
             => from_array(data, dtype, device, false);
 
+
+        /// <summary>
+        /// Creates a 1-dimensional Tensor from an array of n dimensions.
+        /// 
+        /// Skips the first offset bytes in the buffer, and interprets the rest of the raw bytes as a 1-dimensional tensor of type dtype with count elements.
+        /// </summary>
+        /// <param name="rawArray">The input array</param>
+        /// <param name="dtype">The torch data type.</param>
+        /// <param name="count"></param>
+        /// <param name="offset"></param>
+        /// <param name="requiresGrad">Set <value>true</value> if gradients need to be computed for this Tensor; <value>false</value> otherwise.</param>
+        /// <param name="device">The torch device.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        /// <exception cref="IndexOutOfRangeException"></exception>
+        public static Tensor frombuffer(Array rawArray, ScalarType dtype, long count = -1, long offset = 0, bool requiresGrad = false, Device? device = null)
+        {
+            torch.InitializeDeviceType(DeviceType.CPU);
+
+            var lLength = rawArray.LongLength;
+
+            if (offset < 0 || offset >= lLength) {
+                throw new ArgumentException($"invalid value for 'offset': {offset}");
+            }
+
+            if (count < 0) { count = lLength - offset; }
+
+            if (count > lLength - offset) {
+                throw new IndexOutOfRangeException($"element count is too large: {count}");
+            }
+
+            var t = rawArray.GetType().GetElementType();
+            ScalarType origType = ScalarType.Bool;
+
+            if (t == typeof(bool)) {
+                origType = ScalarType.Bool;
+            } else if (t == typeof(byte)) {
+                origType = ScalarType.Byte;
+            } else if (t == typeof(sbyte)) {
+                origType = ScalarType.Int8;
+            } else if (t == typeof(short)) {
+                origType = ScalarType.Int16;
+                offset *= 2;
+            } else if (t == typeof(int)) {
+                origType = ScalarType.Int32;
+                offset *= 4;
+            } else if (t == typeof(long)) {
+                origType = ScalarType.Int64;
+                offset *= 8;
+            } else if (t == typeof(float)) {
+                origType = ScalarType.Float32;
+                offset *= 4;
+            } else if (t == typeof(double)) {
+                origType = ScalarType.Float64;
+                offset *= 8;
+            } else if (t == typeof((float, float))) {
+                // Since we are not allowed to make a copy of the buffer, it's currently not
+                // feasible to support complex types, which GCHandle.Alloc() doesn't like.
+                throw new NotImplementedException("frombuffer(ComplexFloat32)");
+            } else if (t == typeof(System.Numerics.Complex)) {
+                origType = ScalarType.ComplexFloat64;
+                offset *= 16;
+            }
+
+            var dataHandle = GCHandle.Alloc(rawArray, GCHandleType.Pinned);
+            var dataArrayAddr = dataHandle.AddrOfPinnedObject();
+            var gchp = GCHandle.ToIntPtr(dataHandle);
+            GCHandleDeleter deleter = null!;
+            deleter = new GCHandleDeleter((IntPtr ptr) => {
+                GCHandle.FromIntPtr(gchp).Free();
+                deleters.TryRemove(deleter, out deleter!);
+            });
+            deleters.TryAdd(deleter, deleter); // keep the delegate alive
+
+            unsafe {
+                var handle = THSTensor_frombuffer(dataArrayAddr, deleter, count, offset, (sbyte)origType, requiresGrad);
+
+                if (handle == IntPtr.Zero) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    handle = THSTensor_frombuffer(dataArrayAddr, deleter, count, offset, (sbyte)origType, requiresGrad);
+                }
+
+                if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
+                var tensor = new Tensor(handle);
+
+                var needsConversion = dtype != origType;
+
+                if (device is not null) {
+                    tensor = needsConversion ? tensor.to(dtype, device) : tensor.to(device);
+                } else if (needsConversion) {
+                    tensor = tensor.to_type(dtype);
+                }
+                return tensor;
+            }
+        }
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, bool requiresGrad);
 
@@ -2866,6 +2966,9 @@ namespace TorchSharp
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_newComplexFloat64Scalar(double real, double imaginary, int deviceType, int deviceIndex, bool requiresGrad);
+
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THSTensor_frombuffer(IntPtr rawArray, GCHandleDeleter deleter, long count, long offset, sbyte type, bool requiresGrad);
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, sbyte type, bool requiresGrad);

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -6998,7 +6998,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_stft(IntPtr x, long n_fft, long hop_length, long win_length, IntPtr window, bool normalized, bool onesided, bool return_complex);
+            extern static IntPtr THSTensor_stft(IntPtr x, long n_fft, long hop_length, long win_length, IntPtr window, bool normalized, long onesided, bool return_complex);
 
             /// <summary>
             /// Short-time Fourier transform (STFT).
@@ -7017,7 +7017,11 @@ namespace TorchSharp
             {
                 IntPtr _input = Handle;
                 IntPtr _window = (window is null) ? IntPtr.Zero : window.Handle;
-                bool _onesided = onesided.HasValue ? onesided.Value : !is_complex();
+
+                long _onesided = -1; // encoding of null
+                if (onesided.HasValue) {
+                    _onesided = (onesided.Value ? 1 : 0);
+                }
                 bool _return_complex = return_complex.HasValue ? return_complex.Value : is_complex();
 
                 if (center) {
@@ -7068,11 +7072,9 @@ namespace TorchSharp
                 var fft_size = shape[1];
                 IntPtr _window = (window is null) ? IntPtr.Zero : window.Handle;
 
-                int _onesided = -1; // encoding of Python 'None'
+                long _onesided = -1; // encoding of null
                 if (onesided.HasValue) {
                     _onesided = (onesided.Value ? 1 : 0);
-                } else if (n_fft != fft_size) {
-                    _onesided = 1;
                 }
 
                 var res = THSTensor_istft(Handle, n_fft, hop_length, win_length, _window, center, normalized, _onesided, length, return_complex);

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -7176,6 +7176,35 @@ namespace TorchSharp
             BFloat16 = 15
         }
 
+        internal static ScalarType ToScalarType(Type t)
+        {
+            switch (true) {
+            case bool _ when t == typeof(bool):
+                return ScalarType.Bool;
+            case bool _ when t == typeof(byte):
+                return ScalarType.Byte;
+            case bool _ when t == typeof(byte):
+                return ScalarType.Byte;
+            case bool _ when t == typeof(sbyte):
+                return ScalarType.Int8;
+            case bool _ when t == typeof(short):
+                return ScalarType.Int16;
+            case bool _ when t == typeof(int):
+                return ScalarType.Int32;
+            case bool _ when t == typeof(long):
+                return ScalarType.Int64;
+            case bool _ when t == typeof(float):
+                return ScalarType.Float32;
+            case bool _ when t == typeof(double):
+                return ScalarType.Float64;
+            case bool _ when t == typeof((float, float)):
+                return ScalarType.ComplexFloat32;
+            case bool _ when t == typeof(System.Numerics.Complex):
+                return ScalarType.ComplexFloat64;
+            }
+            throw new NotSupportedException($"The type {t.FullName} is not supported.");
+        }
+
         public struct FInfo
         {
             public int bits;

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -7046,7 +7046,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_istft(IntPtr x, long n_fft, long hop_length, long win_length, IntPtr window, bool center, bool normalized, bool onesided, long length, bool return_complex);
+            extern static IntPtr THSTensor_istft(IntPtr x, long n_fft, long hop_length, long win_length, IntPtr window, bool center, bool normalized, long onesided, long length, bool return_complex);
 
             /// <summary>
             /// Inverse short time Fourier Transform. This is expected to be the inverse of stft().
@@ -7065,8 +7065,16 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor istft(long n_fft, long hop_length = -1, long win_length = -1, Tensor? window = null, bool center = true, bool normalized = false, bool? onesided = null, long length = -1, bool return_complex = false)
             {
+                var fft_size = shape[1];
                 IntPtr _window = (window is null) ? IntPtr.Zero : window.Handle;
-                bool _onesided = onesided.HasValue ? onesided.Value : !is_complex();
+
+                int _onesided = -1; // encoding of Python 'None'
+                if (onesided.HasValue) {
+                    _onesided = (onesided.Value ? 1 : 0);
+                } else if (n_fft != fft_size) {
+                    _onesided = 1;
+                }
+
                 var res = THSTensor_istft(Handle, n_fft, hop_length, win_length, _window, center, normalized, _onesided, length, return_complex);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -23,6 +23,10 @@
     <Compile Include="..\TorchSharpTest\TestDataLoader.cs" Link="TestDataLoader.cs" />
     <Compile Include="..\TorchSharpTest\TestDistributions.cs" Link="TestDistributions.cs" />
     <Compile Include="..\TorchSharpTest\TestLoadSave.cs" Link="TestLoadSave.cs" />
+    <Compile Include="..\TorchSharpTest\TestNNUtils.cs" Link="TestNNUtils.cs" />
+    <Compile Include="..\TorchSharpTest\TestSaveSD.cs" Link="TestSaveSD.cs" />
+    <Compile Include="..\TorchSharpTest\TestTorchAudio.cs" Link="TestTorchAudio.cs" />
+    <Compile Include="..\TorchSharpTest\TestTorchAudioModels.cs" Link="TestTorchAudioModels.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchSharp.cs" Link="TestTorchSharp.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchTensor.cs" Link="TestTorchTensor.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchTensorBugs.cs" Link="TestTorchTensorBugs.cs" />

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -728,6 +728,15 @@ namespace TorchSharp
             }
 
             {
+                var array = new System.Numerics.Complex[1, 2, 3, 4];
+                var t = torch.from_array(array);
+                Assert.Multiple(
+                    () => Assert.Equal(4, t.ndim),
+                    () => Assert.Equal(new long[] { 1, 2, 3, 4 }, t.shape),
+                    () => Assert.Equal(ScalarType.ComplexFloat64, t.dtype));
+            }
+
+            {
                 var array = new double[,,] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
                 var t = torch.from_array(array);
                 Assert.Multiple(
@@ -735,6 +744,76 @@ namespace TorchSharp
                     () => Assert.Equal(new long[] { 2, 2, 2 }, t.shape),
                     () => Assert.Equal(ScalarType.Float64, t.dtype),
                     () => Assert.Equal(array.Cast<double>().ToArray(), t.data<double>().ToArray()));
+            }
+        }
+
+        [Fact]
+        public void TestFromBufferFactory()
+        {
+            {
+                var array = new double[8];
+                var t = torch.frombuffer(array, ScalarType.Bool);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(8, t.shape[0]),
+                    () => Assert.Equal(ScalarType.Bool, t.dtype));
+            }
+            {
+                var array = new double[8];
+                var t = torch.frombuffer(array, ScalarType.Bool, 5, 2);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(5, t.shape[0]),
+                    () => Assert.Equal(ScalarType.Bool, t.dtype));
+            }
+            {
+                var array = new double[] { 0, 1, 2, 3, 4, 5, 6, 7};
+                var t = torch.frombuffer(array, ScalarType.Float64, 5, 2);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(5, t.shape[0]),
+                    () => Assert.Equal(3, t[1].item<double>()),
+                    () => Assert.Equal(6, t[4].item<double>()),
+                    () => Assert.Equal(ScalarType.Float64, t.dtype)); ;
+            }
+            {
+                var array = new double[] { 0, 1, 2, 3, 4, 5, 6, 7 };
+                var t = torch.frombuffer(array, ScalarType.Float64, 5, 2);
+                t[4] = 15.0;
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(5, t.shape[0]),
+                    () => Assert.Equal(3, t[1].item<double>()),
+                    () => Assert.Equal(15, array[6]),
+                    () => Assert.Equal(ScalarType.Float64, t.dtype)); ;
+            }
+            {
+                var array = new System.Numerics.Complex[8];
+                for (var i = 0; i < array.Length; i++) { array[i] = new System.Numerics.Complex(i, -i); }
+                var t = torch.frombuffer(array, ScalarType.ComplexFloat64, 5, 2);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(5, t.shape[0]),
+                    () => Assert.Equal(3, t.real[1].item<double>()),
+                    () => Assert.Equal(6, t.real[4].item<double>()),
+                    () => Assert.Equal(-3, t.imag[1].item<double>()),
+                    () => Assert.Equal(-6, t.imag[4].item<double>()),
+                    () => Assert.Equal(ScalarType.ComplexFloat64, t.dtype)); ;
+            }
+            {
+                var array = new System.Numerics.Complex[8];
+                for (var i = 0; i < array.Length; i++) { array[i] = new System.Numerics.Complex(i, -i); }
+                var t = torch.frombuffer(array, ScalarType.ComplexFloat64, 5, 2);
+                t.real[4] = 15.0;
+                t.imag[4] = 25.0;
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(5, t.shape[0]),
+                    () => Assert.Equal(3, t.real[1].item<double>()),
+                    () => Assert.Equal(15, array[6].Real),
+                    () => Assert.Equal(-3, t.imag[1].item<double>()),
+                    () => Assert.Equal(25.0, array[6].Imaginary),
+                    () => Assert.Equal(ScalarType.ComplexFloat64, t.dtype)); ;
             }
         }
 
@@ -1208,6 +1287,34 @@ namespace TorchSharp
                 Assert.Equal(3, t.ndim);
                 Assert.Equal(new long[] { 100, 500, 125 }, t.shape);
                 Assert.Equal(ScalarType.ComplexFloat64, t.dtype);
+            }
+            {
+                var array = new System.Numerics.Complex[8];
+                for (var i = 0; i < array.Length; i++) { array[i] = new System.Numerics.Complex(i, -i); }
+                var t = torch.tensor(array);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(8, t.shape[0]),
+                    () => Assert.Equal(3, t.real[3].item<double>()),
+                    () => Assert.Equal(6, t.real[6].item<double>()),
+                    () => Assert.Equal(-3, t.imag[3].item<double>()),
+                    () => Assert.Equal(-6, t.imag[6].item<double>()),
+                    () => Assert.Equal(ScalarType.ComplexFloat64, t.dtype)); ;
+            }
+            {
+                var array = new System.Numerics.Complex[8];
+                for (var i = 0; i < array.Length; i++) { array[i] = new System.Numerics.Complex(i, -i); }
+                var t = torch.tensor(array);
+                t.real[6] = 17;
+                t.imag[6] = 15;
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(8, t.shape[0]),
+                    () => Assert.Equal(3, t.real[3].item<double>()),
+                    () => Assert.Equal(17, t.real[6].item<double>()),
+                    () => Assert.Equal(-3, t.imag[3].item<double>()),
+                    () => Assert.Equal(15, t.imag[6].item<double>()),
+                    () => Assert.Equal(ScalarType.ComplexFloat64, t.dtype)); ;
             }
         }
 

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -767,6 +767,15 @@ namespace TorchSharp
                     () => Assert.Equal(ScalarType.Bool, t.dtype));
             }
             {
+                // The number of input dimensions shouldn't matter.
+                var array = new double[2,4];
+                var t = torch.frombuffer(array, ScalarType.Bool, 5, 2);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(5, t.shape[0]),
+                    () => Assert.Equal(ScalarType.Bool, t.dtype));
+            }
+            {
                 var array = new double[] { 0, 1, 2, 3, 4, 5, 6, 7};
                 var t = torch.frombuffer(array, ScalarType.Float64, 5, 2);
                 Assert.Multiple(

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -1284,6 +1284,18 @@ namespace TorchSharp
                 Assert.Equal(1, t.ndim);
                 Assert.Equal(ScalarType.ComplexFloat64, t.dtype);
             }
+            {
+                var array = new System.Numerics.Complex[8];
+                var t = torch.tensor(array);
+                Assert.Equal(1, t.ndim);
+                Assert.Equal(ScalarType.ComplexFloat64, t.dtype);
+
+                var s = t.reshape(2, 4);
+                Assert.Multiple(
+                    () => Assert.Equal(2, s.ndim),
+                    () => Assert.Equal(2, s.shape[0]),
+                    () => Assert.Equal(4, s.shape[1]));
+            }
 
             {
                 var array = new System.Numerics.Complex[1, 2];
@@ -1339,8 +1351,8 @@ namespace TorchSharp
                     () => Assert.Equal(1, t.ndim),
                     () => Assert.Equal(8, t.shape[0]),
                     () => Assert.Equal(3, t.real[3].item<double>()),
-                    () => Assert.Equal(17, array[6].Real),
-                    () => Assert.Equal(15, array[6].Imaginary),
+                    () => Assert.Equal(6, array[6].Real),
+                    () => Assert.Equal(-6, array[6].Imaginary),
                     () => Assert.Equal(ScalarType.ComplexFloat64, t.dtype)); ;
             }
         }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -1238,6 +1238,34 @@ namespace TorchSharp
                 Assert.Equal(new long[] { 1, 2, 3, 4 }, t.shape);
                 Assert.Equal(ScalarType.ComplexFloat32, t.dtype);
             }
+            {
+                var array = new (float Real, float Imaginary)[8];
+                for (var i = 0; i < array.Length; i++) { array[i] = (i, -i); }
+                var t = torch.tensor(array);
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(8, t.shape[0]),
+                    () => Assert.Equal(3, t.real[3].item<float>()),
+                    () => Assert.Equal(6, t.real[6].item<float>()),
+                    () => Assert.Equal(-3, t.imag[3].item<float>()),
+                    () => Assert.Equal(-6, t.imag[6].item<float>()),
+                    () => Assert.Equal(ScalarType.ComplexFloat32, t.dtype)); ;
+            }
+            {
+                var array = new (float Real, float Imaginary)[8];
+                for (var i = 0; i < array.Length; i++) { array[i] = (i, -i); }
+                var t = torch.tensor(array);
+                t.real[6] = 17;
+                t.imag[6] = 15;
+                Assert.Multiple(
+                    () => Assert.Equal(1, t.ndim),
+                    () => Assert.Equal(8, t.shape[0]),
+                    () => Assert.Equal(3, t.real[3].item<float>()),
+                    () => Assert.Equal(6, array[6].Real),
+                    () => Assert.Equal(-3, t.imag[3].item<float>()),
+                    () => Assert.Equal(-6, array[6].Imaginary),
+                    () => Assert.Equal(ScalarType.ComplexFloat32, t.dtype)); ;
+            }
         }
 
         [Fact]
@@ -1311,9 +1339,8 @@ namespace TorchSharp
                     () => Assert.Equal(1, t.ndim),
                     () => Assert.Equal(8, t.shape[0]),
                     () => Assert.Equal(3, t.real[3].item<double>()),
-                    () => Assert.Equal(17, t.real[6].item<double>()),
-                    () => Assert.Equal(-3, t.imag[3].item<double>()),
-                    () => Assert.Equal(15, t.imag[6].item<double>()),
+                    () => Assert.Equal(17, array[6].Real),
+                    () => Assert.Equal(15, array[6].Imaginary),
                     () => Assert.Equal(ScalarType.ComplexFloat64, t.dtype)); ;
             }
         }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -6984,7 +6984,8 @@ namespace TorchSharp
             var inverted = fft.ifft2(output);
             Assert.Equal(ScalarType.ComplexFloat64, inverted.dtype);
         }
-#if false
+
+#if true
         [Fact]
         public void Float32FFTN()
         {
@@ -7033,6 +7034,7 @@ namespace TorchSharp
             Assert.Equal(ScalarType.ComplexFloat64, inverted.dtype);
         }
 #endif
+
         [Fact]
         public void Float32RFFTN()
         {
@@ -7055,6 +7057,63 @@ namespace TorchSharp
 
             var inverted = fft.irfftn(output);
             Assert.Equal(ScalarType.Float64, inverted.dtype);
+        }
+
+        [Fact]
+        public void Float32HFFT2()
+        {
+            var input = torch.rand(new long[] { 5, 5, 5, 5 });
+            var output = fft.hfft2(input);
+            Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
+            Assert.Equal(input.dtype, output.dtype);
+
+            var inverted = fft.ihfft2(output);
+            Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.dtype);
+        }
+
+        [Fact]
+        public void Float64HFFT2()
+        {
+            var input = torch.rand(new long[] { 5, 5, 5, 5 }, float64);
+            var output = fft.hfft2(input);
+            Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
+            Assert.Equal(input.dtype, output.dtype);
+
+            var inverted = fft.ihfft2(output);
+            Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
+            Assert.Equal(ScalarType.ComplexFloat64, inverted.dtype);
+        }
+
+        [Fact]
+        public void Float32HFFTN()
+        {
+            var input = torch.rand(new long[] { 5, 5, 5, 5 });
+            var output = fft.hfft2(input);
+            Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
+            Assert.Equal(input.dtype, output.dtype);
+
+            var inverted = fft.ihfft2(output);
+            Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
+            Assert.Equal(ScalarType.ComplexFloat32, inverted.dtype);
+        }
+
+        [Fact]
+        public void Float64HFFTN()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+
+                // TODO: Something in this test makes if fail on Windows / Release
+
+                var input = torch.rand(new long[] { 5, 5, 5, 5 }, float64);
+                var output = fft.hfftn(input);
+                Assert.Equal(new long[] { 5, 5, 5, 8 }, output.shape);
+                Assert.Equal(input.dtype, output.dtype);
+
+                var inverted = fft.ihfftn(output);
+                Assert.Equal(new long[] { 5, 5, 5, 5 }, inverted.shape);
+                Assert.Equal(ScalarType.ComplexFloat64, inverted.dtype);
+            }
         }
 
         [Fact]

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -745,5 +745,32 @@ namespace TorchSharp
             var z = x.to(y);
             Assert.Equal(torch.float64, z.dtype);
         }
+
+        [Fact]
+        public void ValidateBug679()
+        {
+            // Per bug report.
+            // https://github.com/dotnet/TorchSharp/issues/679
+            //
+            var dtype = torch.float32;
+            var spec = torch.rand(1, 1024, 500, 2, dtype: dtype);
+            Assert.Throws<System.Runtime.InteropServices.ExternalException>(() => torch.istft(spec, 512, 160, 400, null));
+
+            spec = torch.rand(1, 512, 500, 2, dtype: dtype);
+            var x = torch.istft(spec, 512, 160, 400, null);
+
+            spec = torch.rand(1, 257, 500, 2, dtype: dtype);
+            x = torch.istft(spec, 512, 160, 400, null);
+
+            dtype = torch.complex64;
+            spec = torch.rand(1, 1024, 500, dtype: dtype);
+            Assert.Throws<System.Runtime.InteropServices.ExternalException>(() => torch.istft(spec, 512, 160, 400, null));
+
+            spec = torch.rand(1, 512, 500, dtype: dtype);
+            x = torch.istft(spec, 512, 160, 400, null);
+
+            spec = torch.rand(1, 257, 500, dtype: dtype);
+            x = torch.istft(spec, 512, 160, 400, null);
+        }
     }
 }


### PR DESCRIPTION
Per discussion in #670, the following will be how to create a tensor from arrays, aligned with Pytorch, treating `from_array()` as the equivalent of `from_numpy()`:

```C#
// Never copy:
public static Tensor from_array(Array rawArray)

// Copy if necessary:
public static Tensor frombuffer(Array rawArray, ScalarType dtype, long count = -1, long offset = 0, bool requiresGrad = false, Device? device = null)
public static Tensor as_tensor(Array data, ScalarType? dtype = null, Device? device = null)
public static Tensor as_tensor(Tensor data, ScalarType? dtype = null, Device? device = null)

// Always copy:
public static Tensor tensor(<<VARIOUS>>, torch.Device? device = null, bool requiresGrad = false)
```

This PR also addresses #679.