### PR TITLE
Add `Tensor.repeat_interleave()` and other functions

### DIFF
--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -452,6 +452,20 @@ Tensor THSTensor_repeat(const Tensor tensor, const int64_t* sizes, const int len
     CATCH_TENSOR(tensor->repeat(at::ArrayRef<int64_t>(sizes, length)));
 }
 
+Tensor THSTensor_repeat_interleave(const Tensor tensor, const Tensor repeats, const int64_t dim, const int64_t output_size)
+{
+    auto _dim = dim == INT64_MIN ? c10::optional<int64_t>() : c10::optional<int64_t>(dim);
+    auto _output_size = output_size == INT64_MIN ? c10::optional<int64_t>() : c10::optional<int64_t>(output_size);
+    CATCH_TENSOR(tensor->repeat_interleave(*repeats, _dim, _output_size));
+}
+
+Tensor THSTensor_repeat_interleave_int64(const Tensor tensor, const int64_t repeats, const int64_t dim, const int64_t output_size)
+{
+    auto _dim = dim == INT64_MIN ? c10::optional<int64_t>() : c10::optional<int64_t>(dim);
+    auto _output_size = output_size == INT64_MIN ? c10::optional<int64_t>() : c10::optional<int64_t>(output_size);
+    CATCH_TENSOR(tensor->repeat_interleave(repeats, _dim, _output_size));
+}
+
 Tensor THSTensor_movedim(const Tensor tensor, const int64_t* src, const int src_len, const int64_t* dst, const int dst_len)
 {
     CATCH_TENSOR(tensor->movedim(at::ArrayRef<int64_t>(src, src_len), at::ArrayRef<int64_t>(dst, dst_len)));

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -1022,6 +1022,10 @@ EXPORT_API(Tensor) THSTensor_relu6_(const Tensor tensor);
 
 EXPORT_API(Tensor) THSTensor_repeat(const Tensor tensor, const int64_t* sizes, const int length);
 
+EXPORT_API(Tensor) THSTensor_repeat_interleave(const Tensor tensor, const Tensor repeats, const int64_t dim, const int64_t output_size);
+
+EXPORT_API(Tensor) THSTensor_repeat_interleave_int64(const Tensor tensor, const int64_t repeats, const int64_t dim, const int64_t output_size);
+
 EXPORT_API(int) THSTensor_requires_grad(const Tensor tensor);
 
 EXPORT_API(Tensor) THSTensor_reshape(const Tensor tensor, const int64_t* shape, const int length);

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -1988,7 +1988,7 @@ namespace TorchSharp
             static extern IntPtr THSTensor_all(IntPtr tensor);
 
             /// <summary>
-            ///
+            /// Tests if all elements in input evaluate to true.
             /// </summary>
 
             public Tensor all()
@@ -2003,10 +2003,10 @@ namespace TorchSharp
             static extern IntPtr THSTensor_all_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
 
             /// <summary>
-            ///
+            /// Tests if all elements in input evaluate to true.
             /// </summary>
-            /// <param name="dimension"></param>
-            /// <param name="keepDim"></param>
+            /// <param name="dimension">The dimension to reduce</param>
+            /// <param name="keepDim">Keep the dimension to reduce</param>
 
             public Tensor all(long dimension, bool keepDim = false)
             {
@@ -2128,7 +2128,7 @@ namespace TorchSharp
             static extern IntPtr THSTensor_any(IntPtr tensor);
 
             /// <summary>
-            ///
+            /// Tests if any element in input evaluate to true.
             /// </summary>
 
             public Tensor any()
@@ -2143,10 +2143,10 @@ namespace TorchSharp
             static extern IntPtr THSTensor_any_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
 
             /// <summary>
-            ///
+            /// Tests if any element in input evaluate to true.
             /// </summary>
-            /// <param name="dimension"></param>
-            /// <param name="keepDim"></param>
+            /// <param name="dimension">The dimension to reduce</param>
+            /// <param name="keepDim">Keep the dimension to reduce</param>
 
             public Tensor any(long dimension, bool keepDim = false)
             {
@@ -5104,6 +5104,30 @@ namespace TorchSharp
                         return new Tensor(res);
                     }
                 }
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSTensor_repeat_interleave(IntPtr tensor, IntPtr repeats, long dim, long output_size);
+
+            public Tensor repeat_interleave(Tensor repeats, long? dim = null, long? output_size = null)
+            {
+                long _dim = dim ?? long.MinValue;
+                long _output_size = output_size ?? long.MinValue;
+                var res = THSTensor_repeat_interleave(Handle, repeats.Handle, _dim, _output_size);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            [DllImport("LibTorchSharp")]
+            extern static IntPtr THSTensor_repeat_interleave_int64(IntPtr tensor, long repeats, long dim, long output_size);
+
+            public Tensor repeat_interleave(long repeats, long? dim = null, long? output_size = null)
+            {
+                long _dim = dim ?? long.MinValue;
+                long _output_size = output_size ?? long.MinValue;
+                var res = THSTensor_repeat_interleave_int64(Handle, repeats, _dim, _output_size);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
             }
 
             [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/Tensor/Tensor.torch.cs
+++ b/src/TorchSharp/Tensor/Tensor.torch.cs
@@ -556,5 +556,60 @@ namespace TorchSharp
         /// <param name="value">The scalar multiplier for source</param>
         /// <returns></returns>
         public static Tensor index_fill_(Tensor input, long dim, Tensor index, Scalar value) => input.index_fill_(dim, index, value);
+
+        /// <summary>
+        /// Repeat elements of a tensor.
+        /// </summary>
+        /// <param name="input">The input tensor</param>
+        /// <param name="repeats">The number of repeats</param>
+        /// <param name="dim">The dimension to repeat</param>
+        /// <param name="output_size">The size of output</param>
+        /// <returns></returns>
+        public static Tensor repeat_interleave(Tensor input, long repeats, long? dim = null, long? output_size = null) => input.repeat_interleave(repeats, dim, output_size);
+
+        /// <summary>
+        /// Repeat elements of a tensor.
+        /// </summary>
+        /// <param name="input">The input tensor</param>
+        /// <param name="repeats">The number of repeats</param>
+        /// <param name="dim">The dimension to repeat</param>
+        /// <param name="output_size">The size of output</param>
+        /// <returns></returns>
+        public static Tensor repeat_interleave(Tensor input, Tensor repeats, long? dim = null, long? output_size = null) => input.repeat_interleave(repeats, dim, output_size);
+
+        /// <summary>
+        /// Constructs a tensor by repeating the elements of input. The dims argument specifies the number of repetitions in each dimension.
+        /// </summary>
+        /// <param name="input">The input tensor</param>
+        /// <param name="dims">The number of repetitions per dimension.</param>
+        public static Tensor tile(Tensor input, long[] dims) => input.tile(dims);
+
+        /// <summary>
+        /// Tests if all elements in input evaluate to true.
+        /// <param name="input">The input tensor</param>
+        /// </summary>
+        public static Tensor all(Tensor input) => input.all();
+
+        /// <summary>
+        /// Tests if all elements in input evaluate to true.
+        /// <param name="input">The input tensor</param>
+        /// <param name="dim">The dimension to reduce</param>
+        /// <param name="keepdim">Keep the dimension to reduce</param>
+        /// </summary>
+        public static Tensor all(Tensor input, long dim, bool keepdim = false) => input.all(dim, keepdim);
+
+        /// <summary>
+        /// Tests if all elements in input evaluate to true.
+        /// <param name="input">The input tensor</param>
+        /// </summary>
+        public static Tensor any(Tensor input) => input.any();
+
+        /// <summary>
+        /// Tests if any element in input evaluate to true.
+        /// <param name="input">The input tensor</param>
+        /// <param name="dim">The dimension to reduce</param>
+        /// <param name="keepdim">Keep the dimension to reduce</param>
+        /// </summary>
+        public static Tensor any(Tensor input, long dim, bool keepdim = false) => input.any(dim, keepdim);
     }
 }

--- a/src/TorchSharp/TorchAudio/Functional.cs
+++ b/src/TorchSharp/TorchAudio/Functional.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using System.Diagnostics;
 
-// A number of implementation details in this file have been translated from the Python version or torchvision,
+// A number of implementation details in this file have been translated from the Python version of torchaudio,
 // largely located in the files found in this folder:
 //
 // https://github.com/pytorch/audio/blob/39c2c0a77e11b82ce152d60df3a92f6854d5f52b/torchaudio/functional/functional.py

--- a/src/TorchSharp/TorchAudio/Transforms.cs
+++ b/src/TorchSharp/TorchAudio/Transforms.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 using static TorchSharp.torch;
 
-// A number of implementation details in this file have been translated from the Python version or torchvision,
+// A number of implementation details in this file have been translated from the Python version of torchaudio,
 // largely located in the files found in this folder:
 //
 // https://github.com/pytorch/audio/blob/bb77cbebb620a46fdc0dc7e6dae2253eef3f37e2/torchaudio/transforms/_transforms.py

--- a/src/TorchSharp/TorchVision/Functional.cs
+++ b/src/TorchSharp/TorchVision/Functional.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 using static TorchSharp.torch;
 
-// A number of implementation details in this file have been translated from the Python version or torchvision,
+// A number of implementation details in this file have been translated from the Python version of torchvision,
 // largely located in the files found in this folder:
 //
 // https://github.com/pytorch/vision/tree/993325dd82567f5d4f28ccb321e3a9a16984d2d8/torchvision/transforms

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -5670,6 +5670,56 @@ namespace TorchSharp
         }
 
         [Fact]
+        [TestOf(nameof(Tensor.repeat_interleave))]
+        public void RepeatInterleaveTest()
+        {
+            {
+                var input = torch.tensor(new int[] { 1, 2, 3 });
+                var expected = torch.tensor(new int[] {
+                    1, 1, 1, 2, 2, 2, 3, 3, 3
+                });
+
+                var res = input.repeat_interleave(torch.tensor(new long[] { 3 }));
+                Assert.Equal(res, expected);
+            }
+
+            {
+                var input = torch.tensor(new int[] { 1, 2, 3 });
+                var expected = torch.tensor(new int[] {
+                    1, 1, 1, 2, 2, 2, 3, 3, 3
+                });
+
+                var res = input.repeat_interleave(3, output_size: 9);
+                Assert.Equal(res, expected);
+            }
+
+            {
+                var input = torch.tensor(new int[] { 1, 2, 3, 4, 5, 6 }).reshape(2, 3);
+                var expected = torch.tensor(new int[] {
+                    1, 2, 3,
+                    1, 2, 3,
+                    4, 5, 6,
+                    4, 5, 6,
+                    4, 5, 6
+                }).reshape(5, 3);
+
+                var res = input.repeat_interleave(torch.tensor(new long[] { 2, 3 }), dim: 0);
+                Assert.Equal(res, expected);
+            }
+
+            {
+                var input = torch.tensor(new int[] { 1, 2, 3, 4, 5, 6 }).reshape(2, 3);
+                var expected = torch.tensor(new int[] {
+                    1, 1, 1, 2, 2, 2, 3, 3, 3,
+                    4, 4, 4, 5, 5, 5, 6, 6, 6
+                }).reshape(2, 9);
+
+                var res = input.repeat_interleave(3, dim: 1);
+                Assert.Equal(res, expected);
+            }
+        }
+
+        [Fact]
         [TestOf(nameof(Tensor.fliplr))]
         public void FlipLRTest()
         {


### PR DESCRIPTION
- Add `repeat_interleave()`
- Add static function for `all()`, `any()`, `tile()`, `repeat_interleave()`.
- Fix comments
- Update the arguments of `dropout()` in `Tacotron2`