### PR TITLE
Add `torchaudio.models.WaveRNN()`.

### DIFF
--- a/src/TorchSharp/TorchAudio/Models.cs
+++ b/src/TorchSharp/TorchAudio/Models.cs
@@ -1,4 +1,4 @@
-// Copyright</param>
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 
 using System;
 using static TorchSharp.torch;
@@ -84,6 +84,46 @@ namespace TorchSharp
                     postnet_kernel_size,
                     postnet_embedding_dim,
                     gate_threshold);
+            }
+
+            /// <summary>
+            /// WaveRNN model based on the implementation from `fatchord https://github.com/fatchord/WaveRNN`.
+            /// </summary>
+            /// <param name="upsample_scales">The list of upsample scales.</param>
+            /// <param name="n_classes">The number of output classes.</param>
+            /// <param name="hop_length">The number of samples between the starts of consecutive frames.</param>
+            /// <param name="n_res_block">The number of ResBlock in stack.</param>
+            /// <param name="n_rnn">The dimension of RNN layer.</param>
+            /// <param name="n_fc">The dimension of fully connected layer.</param>
+            /// <param name="kernel_size">The number of kernel size in the first Conv1d layer.</param>
+            /// <param name="n_freq">The number of bins in a spectrogram.</param>
+            /// <param name="n_hidden">The number of hidden dimensions of resblock.</param>
+            /// <param name="n_output">The number of output dimensions of melresnet.</param>
+            /// <returns>The WaveRNN model</returns>
+            public static Modules.WaveRNN WaveRNN(
+                long[] upsample_scales,
+                int n_classes,
+                int hop_length,
+                int n_res_block = 10,
+                int n_rnn = 512,
+                int n_fc = 512,
+                int kernel_size = 5,
+                int n_freq = 128,
+                int n_hidden = 128,
+                int n_output = 128)
+            {
+                return new Modules.WaveRNN(
+                    "wavernn",
+                    upsample_scales,
+                    n_classes,
+                    hop_length,
+                    n_res_block,
+                    n_rnn,
+                    n_fc,
+                    kernel_size,
+                    n_freq,
+                    n_hidden,
+                    n_output);
             }
         }
     }

--- a/src/TorchSharp/TorchAudio/Modules/WaveRNN.cs
+++ b/src/TorchSharp/TorchAudio/Modules/WaveRNN.cs
@@ -1,0 +1,347 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+
+// A number of implementation details in this file have been translated from the Python version of torchaudio,
+// largely located in the files found in this folder:
+//
+// https://github.com/pytorch/audio/blob/c15eee23964098f88ab0afe25a8d5cd9d728af54/torchaudio/models/wavernn.py
+//
+// The origin has the following copyright notice and license:
+//
+// https://github.com/pytorch/audio/blob/main/LICENSE
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using static TorchSharp.torch;
+
+using static TorchSharp.torch.nn;
+using F = TorchSharp.torch.nn.functional;
+
+#nullable enable
+namespace TorchSharp.Modules
+{
+    /// <summary>
+    /// This class is used to represent a WaveRNN module.
+    /// </summary>
+    public class WaveRNN : nn.Module
+    {
+        private readonly int _pad;
+        public readonly nn.Module fc;
+        public readonly nn.Module fc1;
+        public readonly nn.Module fc2;
+        public readonly nn.Module fc3;
+        public readonly int hop_length;
+        public readonly int kernel_size;
+        public readonly int n_aux;
+        public readonly int n_bits;
+        public readonly int n_classes;
+        public readonly int n_rnn;
+        public readonly nn.Module relu1;
+        public readonly nn.Module relu2;
+        public readonly GRU rnn1;
+        public readonly GRU rnn2;
+        internal readonly UpsampleNetwork upsample;
+
+        internal WaveRNN(
+            string name,
+            long[] upsample_scales,
+            int n_classes,
+            int hop_length,
+            int n_res_block = 10,
+            int n_rnn = 512,
+            int n_fc = 512,
+            int kernel_size = 5,
+            int n_freq = 128,
+            int n_hidden = 128,
+            int n_output = 128) : base(name)
+        {
+            this.kernel_size = kernel_size;
+            this._pad = (kernel_size % 2 == 1 ? kernel_size - 1 : kernel_size) / 2;
+            this.n_rnn = n_rnn;
+            this.n_aux = n_output / 4;
+            this.hop_length = hop_length;
+            this.n_classes = n_classes;
+            this.n_bits = (int)(Math.Log(this.n_classes) / Math.Log(2) + 0.5);
+
+            long total_scale = 1;
+            foreach (var upsample_scale in upsample_scales) {
+                total_scale *= upsample_scale;
+            }
+            if (total_scale != this.hop_length) {
+                throw new ArgumentException($"Expected: total_scale == hop_length, but found {total_scale} != {hop_length}");
+            }
+
+            this.upsample = new UpsampleNetwork("upsamplenetwork", upsample_scales, n_res_block, n_freq, n_hidden, n_output, kernel_size);
+            this.fc = nn.Linear(n_freq + this.n_aux + 1, n_rnn);
+
+            this.rnn1 = nn.GRU(n_rnn, n_rnn, batchFirst: true);
+            this.rnn2 = nn.GRU(n_rnn + this.n_aux, n_rnn, batchFirst: true);
+
+            this.relu1 = nn.ReLU(inPlace: true);
+            this.relu2 = nn.ReLU(inPlace: true);
+
+            this.fc1 = nn.Linear(n_rnn + this.n_aux, n_fc);
+            this.fc2 = nn.Linear(n_fc + this.n_aux, n_fc);
+            this.fc3 = nn.Linear(n_fc, this.n_classes);
+
+            this.RegisterComponents();
+        }
+
+        /// <summary>
+        /// Pass the input through the WaveRNN model.
+        /// </summary>
+        /// <param name="waveform">The input waveform to the WaveRNN layer</param>
+        /// <param name="specgram">The input spectrogram to the WaveRNN layer</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public override Tensor forward(Tensor waveform, Tensor specgram)
+        {
+            if (waveform.size(1) != 1) {
+                throw new ArgumentException("Require the input channel of waveform is 1");
+            }
+            if (specgram.size(1) != 1) {
+                throw new ArgumentException("Require the input channel of specgram is 1");
+            }
+            // remove channel dimension until the end
+            waveform = waveform.squeeze(1);
+            specgram = specgram.squeeze(1);
+
+            var batch_size = waveform.size(0);
+            var h1 = torch.zeros(1, batch_size, this.n_rnn, dtype: waveform.dtype, device: waveform.device);
+            var h2 = torch.zeros(1, batch_size, this.n_rnn, dtype: waveform.dtype, device: waveform.device);
+            // output of upsample:
+            // specgram: (n_batch, n_freq, (n_time - kernel_size + 1) * total_scale)
+            // aux: (n_batch, n_output, (n_time - kernel_size + 1) * total_scale)
+            Tensor aux;
+            (specgram, aux) = this.upsample.forward(specgram);
+            specgram = specgram.transpose(1, 2);
+            aux = aux.transpose(1, 2);
+
+            var aux_idx = new long[5];
+            for (int i = 0; i < aux_idx.Length; i++) {
+                aux_idx[i] = this.n_aux * i;
+            }
+            var a1 = aux[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(aux_idx[0], aux_idx[1])];
+            var a2 = aux[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(aux_idx[1], aux_idx[2])];
+            var a3 = aux[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(aux_idx[2], aux_idx[3])];
+            var a4 = aux[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(aux_idx[3], aux_idx[4])];
+
+            var x = torch.cat(new Tensor[] { waveform.unsqueeze(-1), specgram, a1 }, dimension: -1);
+            x = this.fc.forward(x);
+            var res = x;
+            (x, _) = this.rnn1.forward(x, h1);
+
+            x = x + res;
+            res = x;
+            x = torch.cat(new Tensor[] { x, a2 }, dimension: -1);
+            (x, _) = this.rnn2.forward(x, h2);
+
+            x = x + res;
+            x = torch.cat(new Tensor[] { x, a3 }, dimension: -1);
+            x = this.fc1.forward(x);
+            x = this.relu1.forward(x);
+
+            x = torch.cat(new Tensor[] { x, a4 }, dimension: -1);
+            x = this.fc2.forward(x);
+            x = this.relu2.forward(x);
+            x = this.fc3.forward(x);
+
+            // bring back channel dimension
+            return x.unsqueeze(1);
+        }
+
+        /// <summary>
+        /// Inference method of WaveRNN.
+        /// </summary>
+        /// <param name="specgram">Batch of spectrograms.</param>
+        /// <param name="lengths">Indicates the valid length of each audio in the batch.</param>
+        /// <returns>The inferred waveform and the valid length in time axis of the output Tensor.</returns>
+        public virtual (Tensor, Tensor?) infer(Tensor specgram, Tensor? lengths = null)
+        {
+            var device = specgram.device;
+            var dtype = specgram.dtype;
+
+            specgram = torch.nn.functional.pad(specgram, (this._pad, this._pad));
+            Tensor aux;
+            (specgram, aux) = this.upsample.forward(specgram);
+            if (lengths is not null) {
+                lengths = lengths * this.upsample.total_scale;
+            }
+
+            var output = new List<Tensor>();
+            long b_size = specgram.size(0);
+            long seq_len = specgram.size(2);
+
+            var h1 = torch.zeros(new long[] { 1, b_size, this.n_rnn }, device: device, dtype: dtype);
+            var h2 = torch.zeros(new long[] { 1, b_size, this.n_rnn }, device: device, dtype: dtype);
+            var x = torch.zeros(new long[] { b_size, 1 }, device: device, dtype: dtype);
+
+            var aux_split = new Tensor[4];
+            for (int i = 0; i < 4; i++) {
+                aux_split[i] = aux[TensorIndex.Colon, TensorIndex.Slice(this.n_aux * i, this.n_aux * (i + 1)), TensorIndex.Colon];
+            }
+
+            for (int i = 0; i < seq_len; i++) {
+
+                var m_t = specgram[TensorIndex.Colon, TensorIndex.Colon, i];
+
+                var a1_t = aux_split[0][TensorIndex.Colon, TensorIndex.Colon, i];
+                var a2_t = aux_split[1][TensorIndex.Colon, TensorIndex.Colon, i];
+                var a3_t = aux_split[2][TensorIndex.Colon, TensorIndex.Colon, i];
+                var a4_t = aux_split[3][TensorIndex.Colon, TensorIndex.Colon, i];
+
+                x = torch.cat(new Tensor[] { x, m_t, a1_t }, dimension: 1);
+                x = this.fc.forward(x);
+                (_, h1) = this.rnn1.forward(x.unsqueeze(1), h1);
+
+                x = x + h1[0];
+                var inp = torch.cat(new Tensor[] { x, a2_t }, dimension: 1);
+                (_, h2) = this.rnn2.forward(inp.unsqueeze(1), h2);
+
+                x = x + h2[0];
+                x = torch.cat(new Tensor[] { x, a3_t }, dimension: 1);
+                x = F.relu(this.fc1.forward(x));
+
+                x = torch.cat(new Tensor[] { x, a4_t }, dimension: 1);
+                x = F.relu(this.fc2.forward(x));
+
+                var logits = this.fc3.forward(x);
+
+                var posterior = F.softmax(logits, dim: 1);
+
+                x = torch.multinomial(posterior, 1).@float();
+                // Transform label [0, 2 ** n_bits - 1] to waveform [-1, 1]
+
+                x = 2 * x / ((1 << this.n_bits) - 1.0) - 1.0;
+
+                output.Add(x);
+            }
+            return (torch.stack(output).permute(1, 2, 0), lengths);
+        }
+
+        private class ResBlock : nn.Module
+        {
+            public nn.Module resblock_model;
+
+            public ResBlock(string name, int n_freq = 128) : base(name)
+            {
+                this.resblock_model = nn.Sequential(
+                    nn.Conv1d(inputChannel: n_freq, outputChannel: n_freq, kernelSize: 1, bias: false),
+                    nn.BatchNorm1d(n_freq),
+                    nn.ReLU(inPlace: true),
+                    nn.Conv1d(inputChannel: n_freq, outputChannel: n_freq, kernelSize: 1, bias: false),
+                    nn.BatchNorm1d(n_freq));
+                RegisterComponents();
+            }
+
+            public override Tensor forward(Tensor specgram)
+            {
+                return this.resblock_model.forward(specgram) + specgram;
+            }
+        }
+
+        internal class MelResNet : nn.Module
+        {
+            public readonly nn.Module melresnet_model;
+
+            public MelResNet(
+                string name,
+                int n_res_block = 10,
+                int n_freq = 128,
+                int n_hidden = 128,
+                int n_output = 128,
+                int kernel_size = 5) : base(name)
+            {
+                var modules = new List<nn.Module>();
+                modules.Add(nn.Conv1d(inputChannel: n_freq, outputChannel: n_hidden, kernelSize: kernel_size, bias: false));
+                modules.Add(nn.BatchNorm1d(n_hidden));
+                modules.Add(nn.ReLU(inPlace: true));
+                for (int i = 0; i < n_res_block; i++) {
+                    modules.Add(new ResBlock("resblock", n_hidden));
+                }
+                modules.Add(nn.Conv1d(inputChannel: n_hidden, outputChannel: n_output, kernelSize: 1));
+                this.melresnet_model = nn.Sequential(modules);
+                RegisterComponents();
+            }
+
+            public override Tensor forward(Tensor specgram)
+            {
+                return this.melresnet_model.forward(specgram);
+            }
+        }
+
+        public class Stretch2d : nn.Module
+        {
+            public long freq_scale;
+            public long time_scale;
+
+            public Stretch2d(string name, long time_scale, long freq_scale) : base(name)
+            {
+                this.freq_scale = freq_scale;
+                this.time_scale = time_scale;
+                this.RegisterComponents();
+            }
+
+            public override Tensor forward(Tensor specgram)
+            {
+                return specgram.repeat_interleave(this.freq_scale, -2).repeat_interleave(this.time_scale, -1);
+            }
+        }
+
+        internal class UpsampleNetwork : nn.Module
+        {
+            public readonly long indent;
+            public readonly MelResNet resnet;
+            public readonly Stretch2d resnet_stretch;
+            public readonly long total_scale;
+            public readonly nn.Module upsample_layers;
+
+            public UpsampleNetwork(
+                string name,
+                long[] upsample_scales,
+                int n_res_block = 10,
+                int n_freq = 128,
+                int n_hidden = 128,
+                int n_output = 128,
+                int kernel_size = 5) : base(name)
+            {
+                long total_scale = 1;
+                foreach (var upsample_scale in upsample_scales) {
+                    total_scale *= upsample_scale;
+                }
+                this.total_scale = total_scale;
+
+                this.indent = (kernel_size - 1) / 2 * total_scale;
+                this.resnet = new MelResNet("melresnet", n_res_block, n_freq, n_hidden, n_output, kernel_size);
+                this.resnet_stretch = new Stretch2d("stretch2d", total_scale, 1);
+
+                var up_layers = new List<nn.Module>();
+                foreach (var scale in upsample_scales) {
+                    var stretch = new Stretch2d("stretch2d", scale, 1);
+                    var conv = nn.Conv2d(inputChannel: 1, outputChannel: 1, kernelSize: (1, scale * 2 + 1), padding: (0, scale), bias: false);
+                    torch.nn.init.constant_(conv.weight, 1.0 / (scale * 2 + 1));
+                    up_layers.Add(stretch);
+                    up_layers.Add(conv);
+                }
+                this.upsample_layers = nn.Sequential(up_layers);
+                this.RegisterComponents();
+            }
+
+            public new (Tensor, Tensor) forward(Tensor specgram)
+            {
+                var resnet_output = this.resnet.forward(specgram).unsqueeze(1);
+                resnet_output = this.resnet_stretch.forward(resnet_output);
+                resnet_output = resnet_output.squeeze(1);
+
+                specgram = specgram.unsqueeze(1);
+                var upsampling_output = this.upsample_layers.forward(specgram);
+                upsampling_output = upsampling_output.squeeze(1)[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(this.indent, -this.indent)];
+
+                return (upsampling_output, resnet_output);
+            }
+        }
+    }
+}


### PR DESCRIPTION
As we don't have `torchaudio.pipelines` to download pretrained models, we need to manually do it.

```csharp
        private static void Test()
        {
            var tacotron2 = torchaudio.models.Tacotron2(
                mask_padding: false,
                n_mels: 80,
                n_frames_per_step: 1,
                symbol_embedding_dim: 512,
                encoder_embedding_dim: 512,
                encoder_n_convolution: 3,
                encoder_kernel_size: 5,
                decoder_rnn_dim: 1024,
                decoder_max_step: 2000,
                decoder_dropout: 0.1,
                decoder_early_stopping: true,
                attention_rnn_dim: 1024,
                attention_hidden_dim: 128,
                attention_location_n_filter: 32,
                attention_location_kernel_size: 31,
                attention_dropout: 0.1,
                prenet_dim: 256,
                postnet_n_convolution: 5,
                postnet_kernel_size: 5,
                postnet_embedding_dim: 512,
                gate_threshold: 0.5,
                n_symbol: 96);
            var path = Path.Combine(TORCH_HOME, "tacotron2_english_phonemes_1500_epochs_wavernn_ljspeech.bin");
            tacotron2.load(path);
            tacotron2.eval();

            var wavernn = torchaudio.models.WaveRNN(
                upsample_scales: new long[] { 5, 5, 11 },
                n_classes: 1 << 8,  // n_bits = 8
                hop_length: 275,
                n_res_block: 10,
                n_rnn: 512,
                n_fc: 512,
                kernel_size: 5,
                n_freq: 80,
                n_hidden: 128,
                n_output: 128);
            var vocoder = new WaveRNNVocoder("vocoder", wavernn);
            path = Path.Combine(TORCH_HOME, "wavernn_10k_epochs_8bits_ljspeech.bin");
            vocoder.load(path);
            vocoder.eval();

            // HH AH L OW   W ER L D !   T EH K S T   T AH   S P IY CH !
            var data = new int[] {
                54, 20, 65, 69, 11, 92, 44, 65, 38, 2, 11, 81, 40, 64, 79, 81, 11, 81,
                20, 11, 79, 77, 59, 37, 2 };
            var tokens = torch.tensor(data, dimensions: new long[] { 1, data.Length });

            var (mel_spec, mel_spec_len, _) = tacotron2.infer(tokens);

            Tensor waveform;
            (waveform, _) = vocoder.forward(mel_spec, mel_spec_len);

            var waveform_bytes = MemoryMarshal.Cast<float, byte>(
                waveform.data<float>().ToArray()).ToArray();
            File.WriteAllBytes("waveform.bin", waveform_bytes);
        }

        public class WaveRNNVocoder : nn.Module
        {
            private readonly int _sample_rate;
            private readonly Modules.WaveRNN _model;
            private readonly double? _min_level_db;

            public WaveRNNVocoder(string name, Modules.WaveRNN model, double? min_level_db = -100) : base(name)
            {
                this._sample_rate = 22050;
                this._model = model;
                this._min_level_db = min_level_db;
                this.RegisterComponents();
            }

            public int sample_rate => this._sample_rate;

            public override (Tensor, Tensor?) forward(Tensor mel_spec, Tensor? lengths = null)
            {
                mel_spec = torch.exp(mel_spec);
                mel_spec = 20 * torch.log10(torch.clamp(mel_spec, min: 1e-5));
                if (this._min_level_db is not null)
                {
                    mel_spec = (this._min_level_db - mel_spec) / this._min_level_db;
                    mel_spec = torch.clamp(mel_spec, min: 0, max: 1);
                }
                Tensor waveform;
                (waveform, lengths) = this._model.infer(mel_spec, lengths);
                waveform = _unnormalize_waveform(waveform, this._model.n_bits);
                waveform = torchaudio.functional.mu_law_decoding(waveform, this._model.n_classes);
                waveform = waveform.squeeze(1);
                return (waveform, lengths);
            }

            static Tensor _unnormalize_waveform(Tensor waveform, int bits)
            {
                waveform = torch.clamp(waveform, -1, 1);
                waveform = (waveform + 1.0) * ((1 << bits) - 1) / 2;
                return torch.clamp(waveform, 0, (1 << bits) - 1).@int();
            }
        }
```