### PR TITLE
Added modifiable global default for tensor string formatting.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -18,6 +18,7 @@ __API Changes__:
 
 Adding 'append()' to torch.nn.Sequential<br/>
 Adding torch.numel() and torch.__version__<br/>
+Adding modifiable global default for tensor string formatting<br/>
 
 ## NuGet Version 0.97.5
 

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>97</MinorVersion>
-    <PatchVersion>5</PatchVersion>
+    <PatchVersion>6</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -6659,7 +6659,7 @@ namespace TorchSharp
             /// Tensor-specific ToString()
             /// </summary>
             /// <param name="style">
-            /// The style to use -- either 'metadata,' 'julia,' or 'numpy'
+            /// The style to use -- either 'default,' 'metadata,' 'julia,' or 'numpy'
             /// </param>
             /// <param name="fltFormat">The floating point format to use for each individual number.</param>
             /// <param name="width">The line width to enforce</param>

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -6653,7 +6653,7 @@ namespace TorchSharp
                                    string fltFormat = "g5",
                                    int width = 100,
                                    CultureInfo? cultureInfo = null,
-                                   string newLine = "") => disamb ? ToString(TensorStringStyle.Julia, fltFormat, width, cultureInfo, newLine) : ToMetadataString();
+                                   string newLine = "") => disamb ? ToString(torch.TensorStringStyle, fltFormat, width, cultureInfo, newLine) : ToMetadataString();
 
             /// <summary>
             /// Tensor-specific ToString()
@@ -6679,6 +6679,7 @@ namespace TorchSharp
                     return ToMetadataString();
 
                 return style switch {
+                    TensorStringStyle.Default => ToString(torch.TensorStringStyle, fltFormat, width, cultureInfo, newLine),
                     TensorStringStyle.Metadata => ToMetadataString(),
                     TensorStringStyle.Julia => ToJuliaString(fltFormat, width, cultureInfo, newLine),
                     TensorStringStyle.Numpy => ToNumpyString(this, ndim, true, fltFormat, cultureInfo, newLine),

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -14,7 +14,28 @@ namespace TorchSharp
     {
         Metadata,
         Julia,
-        Numpy
+        Numpy,
+        Default,
+    }
+
+    public static partial class torch
+    {
+        /// <summary>
+        /// The default string formatting style used by ToString(), print(), and str()
+        /// </summary>
+        public static TensorStringStyle TensorStringStyle {
+            get {
+                return _style;
+            }
+            set {
+
+                if (value == TensorStringStyle.Default)
+                    throw new ArgumentException("The style cannot be set to 'Default'");
+                _style = value;
+            }
+        }
+
+        private static TensorStringStyle _style = TensorStringStyle.Julia;
     }
 
     /// <summary>
@@ -50,7 +71,7 @@ namespace TorchSharp
         ///
         /// Primarily intended for use in interactive notebooks.
         /// </remarks>
-        public static string str(this Tensor tensor, string fltFormat = "g5", int width = 100, string newLine = "\n", CultureInfo? cultureInfo = null, TensorStringStyle style = TensorStringStyle.Julia)
+        public static string str(this Tensor tensor, string fltFormat = "g5", int width = 100, string newLine = "\n", CultureInfo? cultureInfo = null, TensorStringStyle style = TensorStringStyle.Default)
         {
             return tensor.ToString(style, fltFormat, width, cultureInfo, newLine);
         }
@@ -128,7 +149,7 @@ namespace TorchSharp
         /// The style to use -- either 'metadata,' 'julia,' or 'numpy'
         /// </param>
         /// <returns></returns>
-        public static Tensor print(this Tensor t, string fltFormat = "g5", int width = 100, string newLine = "", CultureInfo? cultureInfo = null, TensorStringStyle style = TensorStringStyle.Julia)
+        public static Tensor print(this Tensor t, string fltFormat = "g5", int width = 100, string newLine = "", CultureInfo? cultureInfo = null, TensorStringStyle style = TensorStringStyle.Default)
         {
             Console.WriteLine(t.ToString(style, fltFormat, width, cultureInfo, newLine));
             return t;
@@ -220,10 +241,10 @@ namespace TorchSharp
 
             // First, write the type
             writer.Encode((int)tensor.dtype); // 4 bytes
-                                                // Then, the shape.
+                                              // Then, the shape.
             writer.Encode(tensor.shape.Length); // 4 bytes
             foreach (var s in tensor.shape) writer.Encode(s); // n * 8 bytes
-                                                                // Then, the data
+                                                              // Then, the data
 #if NETSTANDARD2_0_OR_GREATER
             // TODO: NETSTANDARD2_0_OR_GREATER Try to optimize to avoid the allocation
             writer.Write(tensor.bytes.ToArray()); // ElementSize * NumberOfElements
@@ -360,7 +381,7 @@ namespace TorchSharp
         /// Explicitly convert a singleton tensor to a .NET scalar value.
         /// </summary>
         /// <param name="value">The input tensor</param>
-        public static (float Real,float Imaginary) ToComplexFloat32(this Tensor value) => value.ToScalar().ToComplexFloat32();
+        public static (float Real, float Imaginary) ToComplexFloat32(this Tensor value) => value.ToScalar().ToComplexFloat32();
 
         /// <summary>
         /// Explicitly convert a singleton tensor to a .NET scalar value.

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -12,10 +12,10 @@ namespace TorchSharp
 
     public enum TensorStringStyle
     {
-        Metadata,
-        Julia,
-        Numpy,
-        Default,
+        Metadata,   // Print only shape, dtype, and device
+        Julia,      // Print tensor in the style of Julia
+        Numpy,      // Print tensor in the style of NumPy
+        Default,    // Pick up the style to use from torch.TensorStringStyle
     }
 
     public static partial class torch
@@ -62,7 +62,7 @@ namespace TorchSharp
         /// <param name="newLine">The newline string to use, defaults to system default.</param>
         /// <param name="cultureInfo">The culture info to be used when formatting the numbers.</param>
         /// <param name="style">
-        /// The style to use -- either 'metadata,' 'julia,' or 'numpy'
+        /// The style to use -- either 'default,' 'metadata,' 'julia,' or 'numpy'
         /// </param>
         /// <remarks>
         /// This method does exactly the same as ToString(bool, string, int), but is shorter,
@@ -146,7 +146,7 @@ namespace TorchSharp
         /// <param name="newLine">The newline string to use, defaults to system default.</param>
         /// <param name="cultureInfo">The culture info to be used when formatting the numbers.</param>
         /// <param name="style">
-        /// The style to use -- either 'metadata,' 'julia,' or 'numpy'
+        /// The style to use -- either 'default,' 'metadata,' 'julia,' or 'numpy'
         /// </param>
         /// <returns></returns>
         public static Tensor print(this Tensor t, string fltFormat = "g5", int width = 100, string newLine = "", CultureInfo? cultureInfo = null, TensorStringStyle style = TensorStringStyle.Default)

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -35,6 +35,9 @@ namespace TorchSharp
             }
         }
 
+        public const TensorStringStyle julia = TensorStringStyle.Julia;
+        public const TensorStringStyle numpy = TensorStringStyle.Numpy;
+
         private static TensorStringStyle _style = TensorStringStyle.Julia;
     }
 

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -31,6 +31,7 @@
     <Compile Include="..\TorchSharpTest\TestTorchTensor.cs" Link="TestTorchTensor.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchTensorBugs.cs" Link="TestTorchTensorBugs.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchVision.cs" Link="TestTorchVision.cs" />
+    <Compile Include="..\TorchSharpTest\TestTorchVisionOps.cs" Link="TestTorchVisionOps.cs" />
     <Compile Include="..\TorchSharpTest\TestTraining.cs" Link="TestTraining.cs" />
     <Compile Include="..\TorchSharpTest\TestDisposeScopes.cs" Link="TestDisposeScopes.cs" />
   </ItemGroup>

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -90,7 +90,7 @@ namespace TorchSharp
         {
             {
                 Tensor t = (Tensor)3.14f;
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal("[], type = Float32, device = cpu, value = 3.14", str);
             }
             {
@@ -114,7 +114,7 @@ namespace TorchSharp
         {
             {
                 Tensor t = torch.zeros(4);
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture, newLine: _sep);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture, newLine: _sep);
                 Assert.Equal($"[4], type = Float32, device = cpu{_sep} 0 0 0 0{_sep}", str);
             }
             {
@@ -124,7 +124,7 @@ namespace TorchSharp
             }
             {
                 Tensor t = torch.zeros(4, torch.complex64);
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[4], type = ComplexFloat32, device = cpu{_sep} 0 0 0 0{_sep}", str);
             }
             {
@@ -136,7 +136,7 @@ namespace TorchSharp
             {
                 Tensor t = torch.ones(4, torch.complex64);
                 for (int i = 0; i < t.shape[0]; i++) t[i] = torch.tensor((1.0f * i, 2.43f * i * 2), torch.complex64);
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[4], type = ComplexFloat32, device = cpu{_sep} 0 1+4.86i 2+9.72i 3+14.58i{_sep}", str);
             }
         }
@@ -168,12 +168,12 @@ namespace TorchSharp
             }
             {
                 Tensor t = torch.zeros(2, 4, torch.complex64);
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[2x4], type = ComplexFloat32, device = cpu{_sep} 0 0 0 0{_sep} 0 0 0 0{_sep}", str);
             }
             {
                 Tensor t = torch.ones(2, 4, torch.complex64);
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[2x4], type = ComplexFloat32, device = cpu{_sep} 1 1 1 1{_sep} 1 1 1 1{_sep}", str);
             }
         }
@@ -205,7 +205,7 @@ namespace TorchSharp
                         0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f,
                         0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                     }, 2, 2, 2, 4);
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[2x2x2x4], type = Float32, device = cpu{_sep}[0,0,..,..] ={_sep}        0   3.141 6.2834 3.1415{_sep}" +
                              $" 6.28e-06 -13.142   0.01 4713.1{_sep}{_sep}[0,1,..,..] ={_sep} 0.01 0 0 0{_sep}    0 0 0 0{_sep}{_sep}" +
                              $"[1,0,..,..] ={_sep}        0   3.141 6.2834 3.1415{_sep} 6.28e-06 -13.142   0.01 4713.1{_sep}{_sep}" +
@@ -228,7 +228,7 @@ namespace TorchSharp
                         0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f,
                         0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                     }, new long[] { 2, 2, 2, 2, 4 });
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[2x2x2x2x4], type = Float32, device = cpu{_sep}[0,0,0,..,..] ={_sep}        0   3.141 6.2834 3.1415{_sep}" +
                              $" 6.28e-06 -13.142   0.01 4713.1{_sep}{_sep}[0,0,1,..,..] ={_sep} 0.01 0 0 0{_sep}    0 0 0 0{_sep}{_sep}[0,1,0,..,..] ={_sep}" +
                              $"        0   3.141 6.2834 3.1415{_sep} 6.28e-06 -13.142   0.01 4713.1{_sep}{_sep}[0,1,1,..,..] ={_sep} 0.01 0 0 0{_sep}   " +
@@ -261,7 +261,7 @@ namespace TorchSharp
                         0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f,
                         0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                     }, new long[] { 2, 2, 2, 2, 2, 4 });
-                var str = t.ToString(TensorStringStyle.Julia, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.julia, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[2x2x2x2x2x4], type = Float32, device = cpu{_sep}[0,0,0,0,..,..] ={_sep}        0   3.141 6.2834 3.1415{_sep}" +
                              $" 6.28e-06 -13.142   0.01 4713.1{_sep}{_sep}[0,0,0,1,..,..] ={_sep} 0.01 0 0 0{_sep}    0 0 0 0{_sep}{_sep}[0,0,1,0,..,..] ={_sep}" +
                              $"        0   3.141 6.2834 3.1415{_sep} 6.28e-06 -13.142   0.01 4713.1{_sep}{_sep}[0,0,1,1,..,..] ={_sep} 0.01 0 0 0{_sep}    0 0 0 0{_sep}{_sep}" +
@@ -290,37 +290,37 @@ namespace TorchSharp
         [TestOf(nameof(Tensor.ToString))]
         public void Test1DToNumpyString()
         {
-            Assert.Equal("[0 0 0 0]", torch.zeros(4).ToString(TensorStringStyle.Numpy));
-            Assert.Equal("[0 0 0 0]", torch.zeros(4, torch.complex64).ToString(TensorStringStyle.Numpy));
+            Assert.Equal("[0 0 0 0]", torch.zeros(4).ToString(torch.numpy));
+            Assert.Equal("[0 0 0 0]", torch.zeros(4, torch.complex64).ToString(torch.numpy));
             {
                 Tensor t = torch.ones(4, torch.complex64);
                 for (int i = 0; i < t.shape[0]; i++) t[i] = torch.tensor((1.0f * i, 2.43f * i * 2), torch.complex64);
-                var str = t.ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[0 1+4.86i 2+9.72i 3+14.58i]", str);
             }
-            Assert.Equal("[1 1 1 ... 1 1 1]", torch.ones(100, ScalarType.Int32).ToString(TensorStringStyle.Numpy));
-            Assert.Equal("[1 3 5 ... 195 197 199]", torch.tensor(Enumerable.Range(0, 100).Select(x => 2 * x + 1).ToList(), ScalarType.Float32).ToString(TensorStringStyle.Numpy));
+            Assert.Equal("[1 1 1 ... 1 1 1]", torch.ones(100, ScalarType.Int32).ToString(torch.numpy));
+            Assert.Equal("[1 3 5 ... 195 197 199]", torch.tensor(Enumerable.Range(0, 100).Select(x => 2 * x + 1).ToList(), ScalarType.Float32).ToString(torch.numpy));
         }
 
         [Fact]
         [TestOf(nameof(Tensor.ToString))]
         public void Test2DToNumpyString()
         {
-            Assert.Equal($"[[0 3.141 6.2834 3.1415]{_sep} [6.28e-06 -13.142 0.01 4713.1]]", torch.tensor(new float[] { 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f }, 2, 4).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
+            Assert.Equal($"[[0 3.141 6.2834 3.1415]{_sep} [6.28e-06 -13.142 0.01 4713.1]]", torch.tensor(new float[] { 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f }, 2, 4).ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture));
             {
                 Tensor t = torch.zeros(5, 5, torch.complex64);
                 for (int i = 0; i < t.shape[0]; i++)
                     for (int j = 0; j < t.shape[1]; j++)
                         t[i][j] = torch.tensor((1.24f * i, 2.491f * i * 2), torch.complex64);
-                var str = t.ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture);
+                var str = t.ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[[0 0 0 0 0]{_sep} [1.24+4.982i 1.24+4.982i 1.24+4.982i 1.24+4.982i 1.24+4.982i]{_sep} [2.48+9.964i 2.48+9.964i 2.48+9.964i 2.48+9.964i 2.48+9.964i]{_sep} [3.72+14.946i 3.72+14.946i 3.72+14.946i 3.72+14.946i 3.72+14.946i]{_sep} [4.96+19.928i 4.96+19.928i 4.96+19.928i 4.96+19.928i 4.96+19.928i]]", str);
             }
-            Assert.Equal($"[[0 0 0 0]{_sep} [0 0 0 0]]", torch.zeros(2, 4, torch.complex64).ToString(TensorStringStyle.Numpy));
-            Assert.Equal($"[[1 1 1 1]{_sep} [1 1 1 1]]", torch.ones(2, 4, torch.complex64).ToString(TensorStringStyle.Numpy));
-            Assert.Equal($"[[7 9 11 ... 101 103 105]{_sep} [107 109 111 ... 201 203 205]]", torch.tensor(Enumerable.Range(1, 100).Select(x => x * 2 + 5).ToList(), new long[] { 2, 50 }, ScalarType.Float32).ToString(TensorStringStyle.Numpy));
+            Assert.Equal($"[[0 0 0 0]{_sep} [0 0 0 0]]", torch.zeros(2, 4, torch.complex64).ToString(torch.numpy));
+            Assert.Equal($"[[1 1 1 1]{_sep} [1 1 1 1]]", torch.ones(2, 4, torch.complex64).ToString(torch.numpy));
+            Assert.Equal($"[[7 9 11 ... 101 103 105]{_sep} [107 109 111 ... 201 203 205]]", torch.tensor(Enumerable.Range(1, 100).Select(x => x * 2 + 5).ToList(), new long[] { 2, 50 }, ScalarType.Float32).ToString(torch.numpy));
             Assert.Equal($"[[7 9 11 ... 201 203 205]{_sep} [207 209 211 ... 401 403 405]{_sep} [407 409 411 ... 601 603 605]{_sep} ...{_sep} [19407 19409 19411 ... 19601 19603 19605]{_sep} [19607 19609 19611 ... 19801 19803 19805]{_sep} [19807 19809 19811 ... 20001 20003 20005]]",
                 torch.tensor(Enumerable.Range(1, 10000).Select(x => x * 2 + 5).ToList(), new long[] { 100, 100 },
-                    ScalarType.Float32).ToString(TensorStringStyle.Numpy));
+                    ScalarType.Float32).ToString(torch.numpy));
         }
 
         [Fact]
@@ -334,10 +334,10 @@ namespace TorchSharp
                         new float[] {
                             0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f, 0.01f, 0.0f, 0.0f,
                             0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-                        }, 2, 2, 4).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
-                var actual = torch.tensor(Enumerable.Range(1, 250).Select(x => x * 2 + 5).ToList(), new long[] { 5, 5, 10 }, ScalarType.Float32).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture);
+                        }, 2, 2, 4).ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture));
+                var actual = torch.tensor(Enumerable.Range(1, 250).Select(x => x * 2 + 5).ToList(), new long[] { 5, 5, 10 }, ScalarType.Float32).ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture);
                 Assert.Equal($"[[[7 9 11 ... 21 23 25]{_sep}  [27 29 31 ... 41 43 45]{_sep}  [47 49 51 ... 61 63 65]{_sep}  [67 69 71 ... 81 83 85]{_sep}  [87 89 91 ... 101 103 105]]{_sep}{_sep} [[107 109 111 ... 121 123 125]{_sep}  [127 129 131 ... 141 143 145]{_sep}  [147 149 151 ... 161 163 165]{_sep}  [167 169 171 ... 181 183 185]{_sep}  [187 189 191 ... 201 203 205]]{_sep}{_sep} [[207 209 211 ... 221 223 225]{_sep}  [227 229 231 ... 241 243 245]{_sep}  [247 249 251 ... 261 263 265]{_sep}  [267 269 271 ... 281 283 285]{_sep}  [287 289 291 ... 301 303 305]]{_sep}{_sep} [[307 309 311 ... 321 323 325]{_sep}  [327 329 331 ... 341 343 345]{_sep}  [347 349 351 ... 361 363 365]{_sep}  [367 369 371 ... 381 383 385]{_sep}  [387 389 391 ... 401 403 405]]{_sep}{_sep} [[407 409 411 ... 421 423 425]{_sep}  [427 429 431 ... 441 443 445]{_sep}  [447 449 451 ... 461 463 465]{_sep}  [467 469 471 ... 481 483 485]{_sep}  [487 489 491 ... 501 503 505]]]",
-                    torch.tensor(Enumerable.Range(1, 250).Select(x => x * 2 + 5).ToList(), new long[] { 5, 5, 10 }, ScalarType.Float32).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
+                    torch.tensor(Enumerable.Range(1, 250).Select(x => x * 2 + 5).ToList(), new long[] { 5, 5, 10 }, ScalarType.Float32).ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture));
             }
         }
 
@@ -350,7 +350,7 @@ namespace TorchSharp
                 0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f,
                 0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-            }, 2, 2, 2, 4).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
+            }, 2, 2, 2, 4).ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -367,7 +367,7 @@ namespace TorchSharp
                         6.28e-06f, -13.141529f, 0.01f, 4713.14f, 0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                         3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f, 0.01f, 0.0f, 0.0f, 0.0f,
                         0.0f, 0.0f, 0.0f, 0.0f,
-                    }, new long[] { 2, 2, 2, 2, 4 }).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
+                    }, new long[] { 2, 2, 2, 2, 4 }).ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -389,7 +389,7 @@ namespace TorchSharp
                         3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f, 4713.14f, 0.01f, 0.0f, 0.0f, 0.0f,
                         0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 3.141f, 6.2834f, 3.14152f, 6.28e-06f, -13.141529f, 0.01f,
                         4713.14f, 0.01f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-                    }, new long[] { 2, 2, 2, 2, 2, 4 }).ToString(TensorStringStyle.Numpy, cultureInfo: CultureInfo.InvariantCulture));
+                    }, new long[] { 2, 2, 2, 2, 2, 4 }).ToString(torch.numpy, cultureInfo: CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -7895,9 +7895,6 @@ namespace TorchSharp
                 {
                     var poster = torchvision.transforms.functional.adjust_hue(input, 0.0);
 
-                    var istr = input.ToString(TensorStringStyle.Julia);
-                    var pstr = poster.ToString(TensorStringStyle.Julia);
-
                     Assert.Equal(new long[] { 1, 3, 2, 2 }, poster.shape);
                     Assert.True(poster.allclose(input));
                 }
@@ -7905,9 +7902,7 @@ namespace TorchSharp
                 {
                     var poster = torchvision.transforms.functional.adjust_hue(input, 0.15);
 
-                    var istr = input.ToString(TensorStringStyle.Julia);
-                    var pstr = poster.ToString(TensorStringStyle.Julia);
-
+                    Assert.Equal(new long[] { 1, 3, 2, 2 }, poster.shape);
                     Assert.Equal(new long[] { 1, 3, 2, 2 }, poster.shape);
                     Assert.False(poster.allclose(input));
                 }
@@ -7978,7 +7973,7 @@ namespace TorchSharp
 
                 var poster = torchvision.transforms.functional.perspective(input, startpoints, endpoints);
 
-                var pStr = poster.ToString(TensorStringStyle.Julia);
+                var pStr = poster.ToString(torch.julia);
 
                 Assert.Equal(new long[] { 1, 3, 8, 8 }, poster.shape);
             }

--- a/test/TorchSharpTest/TestTorchVisionOps.cs
+++ b/test/TorchSharpTest/TestTorchVisionOps.cs
@@ -1,3 +1,4 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using static TorchSharp.torchvision.ops;


### PR DESCRIPTION
This PR allows you to set the default tensor string format using `torch.TensorStringStyle = ...`