### PR TITLE
Inconsistent parameter names.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,9 +4,14 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 ## NuGet Version 0.97.6
 
+__Breaking Changes:__
+
+Some parameter names were changed to align with PyTorch. This affects names like 'dimension,' 'probability,' and 'keepDims' and will break code that is passing these parameters by name.
+
 __Fixed Bugs:__
 
 #749 functional.linear is wrong<br/>
+#744 Some of functions with inconsistent argument names<br/>
 
 __API Changes__:
 

--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -18,17 +18,17 @@ namespace TorchSharp.Examples
         {
             features = Sequential(
                 ("c1", Conv2d(3, 64, kernelSize: 3, stride: 2, padding: 1)),
-                ("r1", ReLU(inPlace: true)),
+                ("r1", ReLU(inplace: true)),
                 ("mp1", MaxPool2d(kernelSize: new long[] { 2, 2 })),
                 ("c2", Conv2d(64, 192, kernelSize: 3, padding: 1)),
-                ("r2", ReLU(inPlace: true)),
+                ("r2", ReLU(inplace: true)),
                 ("mp2", MaxPool2d(kernelSize: new long[] { 2, 2 })),
                 ("c3", Conv2d(192, 384, kernelSize: 3, padding: 1)),
-                ("r3", ReLU(inPlace: true)),
+                ("r3", ReLU(inplace: true)),
                 ("c4", Conv2d(384, 256, kernelSize: 3, padding: 1)),
-                ("r4", ReLU(inPlace: true)),
+                ("r4", ReLU(inplace: true)),
                 ("c5", Conv2d(256, 256, kernelSize: 3, padding: 1)),
-                ("r5", ReLU(inPlace: true)),
+                ("r5", ReLU(inplace: true)),
                 ("mp3", MaxPool2d(kernelSize: new long[] { 2, 2 })));
 
             avgPool = AdaptiveAvgPool2d(new long[] { 2, 2 });
@@ -36,10 +36,10 @@ namespace TorchSharp.Examples
             classifier = Sequential(
                 ("d1", Dropout()),
                 ("l1", Linear(256 * 2 * 2, 4096)),
-                ("r1", ReLU(inPlace: true)),
+                ("r1", ReLU(inplace: true)),
                 ("d2", Dropout()),
                 ("l2", Linear(4096, 4096)),
-                ("r3", ReLU(inPlace: true)),
+                ("r3", ReLU(inplace: true)),
                 ("d3", Dropout()),
                 ("l3", Linear(4096, numClasses))
             );

--- a/src/Examples/ResNet.cs
+++ b/src/Examples/ResNet.cs
@@ -74,7 +74,7 @@ namespace TorchSharp.Examples
 
             modules.Add(($"conv2d-first", Conv2d(3, 64, kernelSize: 3, stride: 1, padding: 1, bias: false)));
             modules.Add(($"bnrm2d-first", BatchNorm2d(64)));
-            modules.Add(($"relu-first", ReLU(inPlace:true)));
+            modules.Add(($"relu-first", ReLU(inplace:true)));
             MakeLayer(modules, block, expansion, 64, num_blocks[0], 1);
             MakeLayer(modules, block, expansion, 128, num_blocks[1], 2);
             MakeLayer(modules, block, expansion, 256, num_blocks[2], 2);
@@ -117,7 +117,7 @@ namespace TorchSharp.Examples
 
                 modules.Add(($"{name}-conv2d-1", Conv2d(in_planes, planes, kernelSize: 3, stride: stride, padding: 1, bias: false)));
                 modules.Add(($"{name}-bnrm2d-1", BatchNorm2d(planes)));
-                modules.Add(($"{name}-relu-1", ReLU(inPlace: true)));
+                modules.Add(($"{name}-relu-1", ReLU(inplace: true)));
                 modules.Add(($"{name}-conv2d-2", Conv2d(planes, planes, kernelSize: 3, stride: 1, padding: 1, bias: false)));
                 modules.Add(($"{name}-bnrm2d-2", BatchNorm2d(planes)));
 
@@ -132,7 +132,7 @@ namespace TorchSharp.Examples
                     shortcut = Sequential();
                 }
 
-                modules.Add(($"{name}-relu-2", ReLU(inPlace: true)));
+                modules.Add(($"{name}-relu-2", ReLU(inplace: true)));
 
                 RegisterComponents();
             }
@@ -158,10 +158,10 @@ namespace TorchSharp.Examples
 
                 modules.Add(($"{name}-conv2d-1", Conv2d(in_planes, planes, kernelSize: 1, bias: false)));
                 modules.Add(($"{name}-bnrm2d-1", BatchNorm2d(planes)));
-                modules.Add(($"{name}relu-1", ReLU(inPlace:true)));
+                modules.Add(($"{name}relu-1", ReLU(inplace:true)));
                 modules.Add(($"{name}-conv2d-2", Conv2d(planes, planes, kernelSize: 3, stride: stride, padding: 1, bias: false)));
                 modules.Add(($"{name}-bnrm2d-2", BatchNorm2d(planes)));
-                modules.Add(($"{name}relu-2", ReLU(inPlace: true)));
+                modules.Add(($"{name}relu-2", ReLU(inplace: true)));
                 modules.Add(($"{name}-conv2d-3", Conv2d(planes, expansion * planes, kernelSize: 1, bias: false)));
                 modules.Add(($"{name}-bnrm2d-3", BatchNorm2d(expansion * planes)));
 

--- a/src/Examples/SpeechCommands.cs
+++ b/src/Examples/SpeechCommands.cs
@@ -269,7 +269,7 @@ namespace TorchSharp.Examples
                 x = avg_pool1d(x, x.shape[x.dim() - 1]);
                 x = x.permute(0, 2, 1);
                 x = fc1.forward(x);
-                return log_softmax(x, dimension: 2);
+                return log_softmax(x, dim: 2);
             }
         }
     }

--- a/src/Examples/VGG.cs
+++ b/src/Examples/VGG.cs
@@ -42,7 +42,7 @@ namespace TorchSharp.Examples
                 } else {
                     modules.Add(($"conv2d-{i}a", Conv2d(in_channels, channels[i], kernelSize: 3, padding: 1)));
                     modules.Add(($"bnrm2d-{i}a", BatchNorm2d(channels[i])));
-                    modules.Add(($"relu-{i}b", ReLU(inPlace: true)));
+                    modules.Add(($"relu-{i}b", ReLU(inplace: true)));
                     in_channels = channels[i];
                 }
             }

--- a/src/FSharp.Examples/AlexNet.fs
+++ b/src/FSharp.Examples/AlexNet.fs
@@ -47,26 +47,26 @@ type Model(name,device:torch.Device) as this =
     inherit Module(name)
 
     let features = Sequential(("c1", Conv2d(3L, 64L, kernelSize=3L, stride=2L, padding=1L) :> Module),
-                              ("r1", ReLU(inPlace=true) :> Module),
+                              ("r1", ReLU(inplace=true) :> Module),
                               ("mp1", MaxPool2d(kernelSize=[|2L; 2L|]) :> Module),
                               ("c2", Conv2d(64L, 192L, kernelSize=3L, padding=1L) :> Module),
-                              ("r2", ReLU(inPlace=true) :> Module),
+                              ("r2", ReLU(inplace=true) :> Module),
                               ("mp2", MaxPool2d(kernelSize=[|2L; 2L|]) :> Module),
                               ("c3", Conv2d(192L, 384L, kernelSize=3L, padding=1L) :> Module),
-                              ("r3", ReLU(inPlace=true) :> Module),
+                              ("r3", ReLU(inplace=true) :> Module),
                               ("c4", Conv2d(384L, 256L, kernelSize=3L, padding=1L) :> Module),
-                              ("r4", ReLU(inPlace=true) :> Module),
+                              ("r4", ReLU(inplace=true) :> Module),
                               ("c5", Conv2d(256L, 256L, kernelSize=3L, padding=1L) :> Module),
-                              ("r5", ReLU(inPlace=true) :> Module),
+                              ("r5", ReLU(inplace=true) :> Module),
                               ("mp3", MaxPool2d(kernelSize=[|2L; 2L|]) :> Module),
                               ("avg", AdaptiveAvgPool2d([|2L; 2L|]) :> Module))
 
     let classifier = Sequential(("d1", Dropout() :> Module),
                                 ("l1", Linear(256L * 2L * 2L, 4096L) :> Module),
-                                ("r6", ReLU(inPlace=true) :> Module),
+                                ("r6", ReLU(inplace=true) :> Module),
                                 ("d2", Dropout() :> Module),
                                 ("l2", Linear(4096L, 4096L) :> Module),
-                                ("r7", ReLU(inPlace=true) :> Module),
+                                ("r7", ReLU(inplace=true) :> Module),
                                 ("d3", Dropout() :> Module),
                                 ("l3", Linear(4096L, numClasses) :> Module),
                                 ("logsm", LogSoftmax(1L) :> Module))

--- a/src/TorchSharp/Distributions/Constraints.cs
+++ b/src/TorchSharp/Distributions/Constraints.cs
@@ -357,7 +357,7 @@ namespace TorchSharp
                     public override Tensor check(Tensor value)
                     {
                         var is_positive = value >= 0;
-                        return is_positive.all(dimension: -1) & ((value.sum(-1) - 1).abs() < 1e-6);
+                        return is_positive.all(dim: -1) & ((value.sum(-1) - 1).abs() < 1e-6);
                     }
                 }
 
@@ -375,7 +375,7 @@ namespace TorchSharp
 
                     public override Tensor check(Tensor x)
                     {
-                        return (x >= 0).all(dimension: -1) & (x.sum(dim: -1) <= upper_bound);
+                        return (x >= 0).all(dim: -1) & (x.sum(dim: -1) <= upper_bound);
                     }
 
                     public override string ToString()
@@ -435,7 +435,7 @@ namespace TorchSharp
                     {
                         var tol = torch.finfo(value.dtype).eps * value.size(-1) * 10;  // 10 is an adjustable fudge factor
                         var row_norm = torch.linalg.norm(value.detach(), dims: new[] { -1L });
-                        var unit_row_norm = (row_norm - 1.0).abs().le(tol).all(dimension: -1);
+                        var unit_row_norm = (row_norm - 1.0).abs().le(tol).all(dim: -1);
                         return lc.check(value) & unit_row_norm;
                     }
 

--- a/src/TorchSharp/NN/Activation/CELU.cs
+++ b/src/TorchSharp/NN/Activation/CELU.cs
@@ -45,11 +45,11 @@ namespace TorchSharp
             /// Continuously Differentiable Exponential Linear Unit
             /// </summary>
             /// <param name="alpha">The α value for the CELU formulation. Default: 1.0</param>
-            /// <param name="inPlace">Do the operation in-place. Default: False</param>
+            /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public CELU CELU(double alpha = 1.0, bool inPlace = false)
+            static public CELU CELU(double alpha = 1.0, bool inplace = false)
             {
-                var handle = THSNN_CELU_ctor(alpha, inPlace, out var boxedHandle);
+                var handle = THSNN_CELU_ctor(alpha, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new CELU(handle, boxedHandle);
             }
@@ -61,11 +61,11 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <param name="alpha">The α value for the CELU formulation. Default: 1.0</param>
-                /// <param name="inPlace">Do the operation in-place. Default: False</param>
+                /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor celu(Tensor x, double alpha, bool inPlace = false)
+                static public Tensor celu(Tensor x, double alpha, bool inplace = false)
                 {
-                    using (var m = nn.CELU(alpha, inPlace)) {
+                    using (var m = nn.CELU(alpha, inplace)) {
                         return m.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/Activation/ELU.cs
+++ b/src/TorchSharp/NN/Activation/ELU.cs
@@ -44,11 +44,11 @@ namespace TorchSharp
             /// Exponential Linear Unit
             /// </summary>
             /// <param name="alpha">The α value for the ELU formulation. Default: 1.0</param>
-            /// <param name="inPlace">Do the operation in-place. Default: False</param>
+            /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public ELU ELU(double alpha = 1.0, bool inPlace = false)
+            static public ELU ELU(double alpha = 1.0, bool inplace = false)
             {
-                var handle = THSNN_ELU_ctor(alpha, inPlace, out var boxedHandle);
+                var handle = THSNN_ELU_ctor(alpha, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new ELU(handle, boxedHandle);
             }
@@ -60,11 +60,11 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <param name="alpha">The α value for the ELU formulation. Default: 1.0</param>
-                /// <param name="inPlace">Do the operation in-place. Default: False</param>
+                /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor elu(Tensor x, double alpha, bool inPlace = false)
+                static public Tensor elu(Tensor x, double alpha, bool inplace = false)
                 {
-                    using (var m = nn.ELU(alpha, inPlace)) {
+                    using (var m = nn.ELU(alpha, inplace)) {
                         return m.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/Activation/GLU.cs
+++ b/src/TorchSharp/NN/Activation/GLU.cs
@@ -60,7 +60,7 @@ namespace TorchSharp
                 /// <param name="dim">the dimension on which to split the input. Default: -1</param>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor GLU(Tensor x, int dim = -1)
+                static public Tensor glu(Tensor x, int dim = -1)
                 {
                     using (var m = nn.GLU(dim)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/LeakyReLU.cs
+++ b/src/TorchSharp/NN/Activation/LeakyReLU.cs
@@ -44,11 +44,11 @@ namespace TorchSharp
             /// Continuously Differentiable Exponential Linear Unit
             /// </summary>
             /// <param name="negativeSlope">The α value for the LeakyReLU formulation. Default: 1.0</param>
-            /// <param name="inPlace">Do the operation in-place. Default: False</param>
+            /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public LeakyReLU LeakyReLU(double negativeSlope = 1.0, bool inPlace = false)
+            static public LeakyReLU LeakyReLU(double negativeSlope = 1.0, bool inplace = false)
             {
-                var handle = THSNN_LeakyReLU_ctor(negativeSlope, inPlace, out var boxedHandle);
+                var handle = THSNN_LeakyReLU_ctor(negativeSlope, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new LeakyReLU(handle, boxedHandle);
             }
@@ -60,11 +60,11 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <param name="negativeSlope">The α value for the LeakyReLU formulation. Default: 1.0</param>
-                /// <param name="inPlace">Do the operation in-place. Default: False</param>
+                /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor leaky_relu(Tensor x, double negativeSlope, bool inPlace = false)
+                static public Tensor leaky_relu(Tensor x, double negativeSlope, bool inplace = false)
                 {
-                    using (var m = nn.LeakyReLU(negativeSlope, inPlace)) {
+                    using (var m = nn.LeakyReLU(negativeSlope, inplace)) {
                         return m.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/Activation/LogSoftMax.cs
+++ b/src/TorchSharp/NN/Activation/LogSoftMax.cs
@@ -35,20 +35,20 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LogSoftmax_ctor(long dimension, out IntPtr pBoxedModule);
+            extern static IntPtr THSNN_LogSoftmax_ctor(long dim, out IntPtr pBoxedModule);
 
-            static public LogSoftmax LogSoftmax(long dimension)
+            static public LogSoftmax LogSoftmax(long dim)
             {
-                var handle = THSNN_LogSoftmax_ctor(dimension, out var boxedHandle);
+                var handle = THSNN_LogSoftmax_ctor(dim, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new LogSoftmax(handle, boxedHandle);
             }
 
             public static partial class functional
             {
-                static public Tensor log_softmax(Tensor x, long dimension)
+                static public Tensor log_softmax(Tensor x, long dim)
                 {
-                    using (var l = nn.LogSoftmax(dimension)) {
+                    using (var l = nn.LogSoftmax(dim)) {
                         return l.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/Activation/RReLU.cs
+++ b/src/TorchSharp/NN/Activation/RReLU.cs
@@ -45,11 +45,11 @@ namespace TorchSharp
             /// </summary>
             /// <param name="lower">Lower bound of the uniform distribution. Default: 1/8</param>
             /// <param name="upper">Upper bound of the uniform distribution. Default: 1/3</param>
-            /// <param name="inPlace">Do the operation in-place. Default: False</param>
+            /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public RReLU RReLU(double lower = one_eighth, double upper = one_third, bool inPlace = false)
+            static public RReLU RReLU(double lower = one_eighth, double upper = one_third, bool inplace = false)
             {
-                var handle = THSNN_RReLU_ctor(lower, upper, inPlace, out var boxedHandle);
+                var handle = THSNN_RReLU_ctor(lower, upper, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new RReLU(handle, boxedHandle);
             }
@@ -65,11 +65,11 @@ namespace TorchSharp
                 /// <param name="x">The input tensor</param>
                 /// <param name="lower">Lower bound of the uniform distribution. Default: 1/8</param>
                 /// <param name="upper">Upper bound of the uniform distribution. Default: 1/3</param>
-                /// <param name="inPlace">Do the operation in-place. Default: False</param>
+                /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor rrelu(Tensor x, double lower, double upper, bool inPlace = false)
+                static public Tensor rrelu(Tensor x, double lower, double upper, bool inplace = false)
                 {
-                    using (var m = nn.RReLU(lower, upper, inPlace)) {
+                    using (var m = nn.RReLU(lower, upper, inplace)) {
                         return m.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/Activation/ReLU6.cs
+++ b/src/TorchSharp/NN/Activation/ReLU6.cs
@@ -45,11 +45,11 @@ namespace TorchSharp
             ///
             /// This ReLU version caps positive values at 6.
             /// </summary>
-            /// <param name="inPlace">Do the operation in-place. Default: False</param>
+            /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public ReLU6 ReLU6(bool inPlace = false)
+            static public ReLU6 ReLU6(bool inplace = false)
             {
-                var handle = THSNN_ReLU6_ctor(inPlace, out var boxedHandle);
+                var handle = THSNN_ReLU6_ctor(inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new ReLU6(handle, boxedHandle);
             }
@@ -62,11 +62,11 @@ namespace TorchSharp
                 /// This ReLU version caps positive values at 6.
                 /// </summary>
                 /// <param name="x">The input tensor</param>
-                /// <param name="inPlace">Do the operation in-place. Default: False</param>
+                /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor relu6(Tensor x, bool inPlace = false)
+                static public Tensor relu6(Tensor x, bool inplace = false)
                 {
-                    using (var m = nn.ReLU6(inPlace)) {
+                    using (var m = nn.ReLU6(inplace)) {
                         return m.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/Activation/ReLu.cs
+++ b/src/TorchSharp/NN/Activation/ReLu.cs
@@ -42,11 +42,11 @@ namespace TorchSharp
             /// <summary>
             /// Rectified Linear Unit
             /// </summary>
-            /// <param name="inPlace">Do the operation in-place. Default: False</param>
+            /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public ReLU ReLU(bool inPlace = false)
+            static public ReLU ReLU(bool inplace = false)
             {
-                var handle = THSNN_ReLU_ctor(inPlace, out var boxedHandle);
+                var handle = THSNN_ReLU_ctor(inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new ReLU(handle, boxedHandle);
             }
@@ -57,11 +57,11 @@ namespace TorchSharp
                 /// Rectified Linear Unit
                 /// </summary>
                 /// <param name="x">The input tensor</param>
-                /// <param name="inPlace">Do the operation in-place. Default: False</param>
+                /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor relu(Tensor x, bool inPlace = false)
+                static public Tensor relu(Tensor x, bool inplace = false)
                 {
-                    using (var m = nn.ReLU(inPlace)) {
+                    using (var m = nn.ReLU(inplace)) {
                         return m.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/Activation/SELU.cs
+++ b/src/TorchSharp/NN/Activation/SELU.cs
@@ -43,11 +43,11 @@ namespace TorchSharp
             /// <summary>
             /// Scaled Exponential Linear Unit
             /// </summary>
-            /// <param name="inPlace">Do the operation in-place. Default: False</param>
+            /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public SELU SELU(bool inPlace = false)
+            static public SELU SELU(bool inplace = false)
             {
-                var handle = THSNN_SELU_ctor(inPlace, out var boxedHandle);
+                var handle = THSNN_SELU_ctor(inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new SELU(handle, boxedHandle);
             }
@@ -58,11 +58,11 @@ namespace TorchSharp
                 /// Scaled Exponential Linear Unit
                 /// </summary>
                 /// <param name="x">The input tensor</param>
-                /// <param name="inPlace">Do the operation in-place. Default: False</param>
+                /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor selu(Tensor x, bool inPlace = false)
+                static public Tensor selu(Tensor x, bool inplace = false)
                 {
-                    using (var m = nn.SELU(inPlace)) {
+                    using (var m = nn.SELU(inplace)) {
                         return m.forward(x);
                     }
                 }

--- a/src/TorchSharp/NN/AlphaDropout.cs
+++ b/src/TorchSharp/NN/AlphaDropout.cs
@@ -43,34 +43,34 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AlphaDropout_ctor(double probability, [MarshalAs(UnmanagedType.U1)] bool inPlace, out IntPtr pBoxedModule);
+            extern static IntPtr THSNN_AlphaDropout_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
 
             /// <summary>
             /// Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor \text{input}[i, j]input[i,j] ).
             /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
             /// </summary>
-            /// <param name="probability">Probability of an element to be zeroed. Default: 0.5</param>
-            /// <param name="inPlace">If set to true, will do this operation in-place. Default: false</param>
+            /// <param name="p">Probability of an element to be zeroed. Default: 0.5</param>
+            /// <param name="inplace">If set to true, will do this operation in-place. Default: false</param>
             /// <returns></returns>
-            static public AlphaDropout AlphaDropout(double probability = 0.5, bool inPlace = false)
+            static public AlphaDropout AlphaDropout(double p = 0.5, bool inplace = false)
             {
-                var handle = THSNN_AlphaDropout_ctor(probability, inPlace, out var boxedHandle);
+                var handle = THSNN_AlphaDropout_ctor(p, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new AlphaDropout(handle, boxedHandle);
             }
             public static partial class functional
             {
                 [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_alpha_dropout(IntPtr input, double probability, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inPlace);
+                extern static IntPtr THSNN_alpha_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
 
                 /// <summary>
                 /// Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor \text{input}[i, j]input[i,j] ).
                 /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
                 /// </summary>
                 /// <returns></returns>
-                static public Tensor alpha_dropout(Tensor input, double probability = 0.5, bool training = false, bool inPlace = false)
+                static public Tensor alpha_dropout(Tensor input, double p = 0.5, bool training = false, bool inplace = false)
                 {
-                    var res = THSNN_alpha_dropout(input.Handle, probability, training, inPlace);
+                    var res = THSNN_alpha_dropout(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
                 }

--- a/src/TorchSharp/NN/Dropout.cs
+++ b/src/TorchSharp/NN/Dropout.cs
@@ -38,18 +38,18 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Dropout_ctor(double probability, [MarshalAs(UnmanagedType.U1)] bool inPlace, out IntPtr pBoxedModule);
+            extern static IntPtr THSNN_Dropout_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
 
             /// <summary>
             /// During training, randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution.
             /// Each channel will be zeroed out independently on every forward call.
             /// </summary>
-            /// <param name="probability">Probability of an element to be zeroed. Default: 0.5</param>
-            /// <param name="inPlace">If set to true, will do this operation in-place. Default: false</param>
+            /// <param name="p">Probability of an element to be zeroed. Default: 0.5</param>
+            /// <param name="inplace">If set to true, will do this operation in-place. Default: false</param>
             /// <returns></returns>
-            static public Dropout Dropout(double probability = 0.5, bool inPlace = false)
+            static public Dropout Dropout(double p = 0.5, bool inplace = false)
             {
-                var handle = THSNN_Dropout_ctor(probability, inPlace, out var boxedHandle);
+                var handle = THSNN_Dropout_ctor(p, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Dropout(handle, boxedHandle);
             }
@@ -57,16 +57,16 @@ namespace TorchSharp
             public static partial class functional
             {
                 [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_dropout(IntPtr input, double probability, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inPlace);
+                extern static IntPtr THSNN_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
 
                 /// <summary>
                 /// During training, randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution.
                 /// Each channel will be zeroed out independently on every forward call.
                 /// </summary>
                 /// <returns></returns>
-                static public Tensor dropout(Tensor input, double probability = 0.5, bool training = true, bool inPlace = false)
+                static public Tensor dropout(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
                 {
-                    var res = THSNN_dropout(input.Handle, probability, training, inPlace);
+                    var res = THSNN_dropout(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
                 }

--- a/src/TorchSharp/NN/Dropout2d.cs
+++ b/src/TorchSharp/NN/Dropout2d.cs
@@ -33,18 +33,18 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Dropout2d_ctor(double probability, [MarshalAs(UnmanagedType.U1)] bool inPlace, out IntPtr pBoxedModule);
+            extern static IntPtr THSNN_Dropout2d_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
 
             /// <summary>
             /// Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor).
             /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
             /// </summary>
-            /// <param name="probability">Probability of an element to be zeroed. Default: 0.5</param>
-            /// <param name="inPlace">If set to true, will do this operation in-place. Default: false</param>
+            /// <param name="p">Probability of an element to be zeroed. Default: 0.5</param>
+            /// <param name="inplace">If set to true, will do this operation in-place. Default: false</param>
             /// <returns></returns>
-            static public Dropout2d Dropout2d(double probability = 0.5, bool inPlace = false)
+            static public Dropout2d Dropout2d(double p = 0.5, bool inplace = false)
             {
-                var handle = THSNN_Dropout2d_ctor(probability, inPlace, out var boxedHandle);
+                var handle = THSNN_Dropout2d_ctor(p, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Dropout2d(handle, boxedHandle);
             }
@@ -52,16 +52,16 @@ namespace TorchSharp
             public static partial class functional
             {
                 [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_dropout2d(IntPtr input, double probability, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inPlace);
+                extern static IntPtr THSNN_dropout2d(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
 
                 /// <summary>
                 /// Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor).
                 /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
                 /// </summary>
                 /// <returns></returns>
-                static public Tensor dropout2d(Tensor input, double probability = 0.5, bool training = true, bool inPlace = false)
+                static public Tensor dropout2d(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
                 {
-                    var res = THSNN_dropout2d(input.Handle, probability, training, inPlace);
+                    var res = THSNN_dropout2d(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
                 }

--- a/src/TorchSharp/NN/Dropout3d.cs
+++ b/src/TorchSharp/NN/Dropout3d.cs
@@ -33,18 +33,18 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Dropout3d_ctor(double probability, [MarshalAs(UnmanagedType.U1)] bool inPlace, out IntPtr pBoxedModule);
+            extern static IntPtr THSNN_Dropout3d_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
 
             /// <summary>
             /// Randomly zero out entire channels (a channel is a 3D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 3D tensor \text{input}[i, j]input[i,j] ).
             /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
             /// </summary>
-            /// <param name="probability">Probability of an element to be zeroed. Default: 0.5</param>
-            /// <param name="inPlace">If set to true, will do this operation in-place. Default: false</param>
+            /// <param name="p">Probability of an element to be zeroed. Default: 0.5</param>
+            /// <param name="inplace">If set to true, will do this operation in-place. Default: false</param>
             /// <returns></returns>
-            static public Dropout3d Dropout3d(double probability = 0.5, bool inPlace = false)
+            static public Dropout3d Dropout3d(double p = 0.5, bool inplace = false)
             {
-                var handle = THSNN_Dropout3d_ctor(probability, inPlace, out var boxedHandle);
+                var handle = THSNN_Dropout3d_ctor(p, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Dropout3d(handle, boxedHandle);
             }
@@ -52,15 +52,15 @@ namespace TorchSharp
             public static partial class functional
             {
                 [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_dropout3d(IntPtr input, double probability, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inPlace);
+                extern static IntPtr THSNN_dropout3d(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
 
                 /// <summary>
                 /// Randomly zero out entire channels (a channel is a 3D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 3D tensor \text{input}[i, j]input[i,j] ).
                 /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
                 /// </summary>
-                static public Tensor dropout3d(Tensor input, double probability = 0.5, bool training = true, bool inPlace = false)
+                static public Tensor dropout3d(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
                 {
-                    var res = THSNN_dropout3d(input.Handle, probability, training, inPlace);
+                    var res = THSNN_dropout3d(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
                 }

--- a/src/TorchSharp/NN/FeatureDropout.cs
+++ b/src/TorchSharp/NN/FeatureDropout.cs
@@ -35,7 +35,7 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_FeatureAlphaDropout_ctor(double probability, out IntPtr pBoxedModule);
+            extern static IntPtr THSNN_FeatureAlphaDropout_ctor(double p, out IntPtr pBoxedModule);
 
             /// <summary>
             /// Randomly masks out entire channels (a channel is a feature map, e.g. the j-th channel of the i-th sample in the batch input is a tensor input[i,j]) of the input tensor.
@@ -54,7 +54,7 @@ namespace TorchSharp
             public static partial class functional
             {
                 [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_feature_alpha_dropout(IntPtr input, double probability, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inPlace);
+                extern static IntPtr THSNN_feature_alpha_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
 
                 /// <summary>
                 /// Randomly masks out entire channels (a channel is a feature map, e.g. the j-th channel of the i-th sample in the batch input is a tensor input[i,j]) of the input tensor.

--- a/src/TorchSharp/Tensor/Tensor.Math.cs
+++ b/src/TorchSharp/Tensor/Tensor.Math.cs
@@ -703,19 +703,19 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_cummax(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
+            static extern void THSTensor_cummax(IntPtr tensor, AllocatePinnedArray allocator, long dim);
 
             /// <summary>
             /// Returns a tuple (values, indices) where values is the cumulative maximum of elements of input in the dimension dim.
             /// Indices is the index location of each maximum value found in the dimension dim.
             /// </summary>
-            /// <param name="dimension">The dimension to do the operation over</param>
-            public (Tensor values, Tensor indexes) cummax(long dimension)
+            /// <param name="dim">The dimension to do the operation over</param>
+            public (Tensor values, Tensor indexes) cummax(long dim)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_cummax(Handle, pa.CreateArray, dimension);
+                    THSTensor_cummax(Handle, pa.CreateArray, dim);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -724,19 +724,19 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_cummin(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
+            static extern void THSTensor_cummin(IntPtr tensor, AllocatePinnedArray allocator, long dim);
 
             /// <summary>
             /// Returns a tuple (values, indices) where values is the cumulative minimum of elements of input in the dimension dim.
             /// Indices is the index location of each minimum value found in the dimension dim.
             /// </summary>
-            /// <param name="dimension">The dimension to do the operation over</param>
-            public (Tensor values, Tensor indexes) cummin(long dimension)
+            /// <param name="dim">The dimension to do the operation over</param>
+            public (Tensor values, Tensor indexes) cummin(long dim)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_cummin(Handle, pa.CreateArray, dimension);
+                    THSTensor_cummin(Handle, pa.CreateArray, dim);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -745,35 +745,35 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cumsum(IntPtr tensor, long dimension, bool has_type, sbyte scalar_type);
+            static extern IntPtr THSTensor_cumsum(IntPtr tensor, long dim, bool has_type, sbyte scalar_type);
 
             /// <summary>
             /// Returns the cumulative sum of elements of input in the dimension dim.
             /// </summary>
-            /// <param name="dimension">The dimension to do the operation over</param>
+            /// <param name="dim">The dimension to do the operation over</param>
             /// <param name="type">The desired data type of returned tensor. If specified, the input tensor is casted to dtype before the operation is performed.
             /// This is useful for preventing data type overflows.</param>
             /// <returns></returns>
-            public Tensor cumsum(long dimension, ScalarType? type = null)
+            public Tensor cumsum(long dim, ScalarType? type = null)
             {
-                var res = THSTensor_cumsum(Handle, dimension, type.HasValue, (sbyte)type.GetValueOrDefault());
+                var res = THSTensor_cumsum(Handle, dim, type.HasValue, (sbyte)type.GetValueOrDefault());
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cumprod(IntPtr tensor, long dimension, bool has_type, sbyte scalar_type);
+            static extern IntPtr THSTensor_cumprod(IntPtr tensor, long dim, bool has_type, sbyte scalar_type);
 
             /// <summary>
             /// Returns the cumulative product of elements of input in the dimension dim.
             /// </summary>
-            /// <param name="dimension">The dimension to do the operation over</param>
+            /// <param name="dim">The dimension to do the operation over</param>
             /// <param name="type">The desired data type of returned tensor. If specified, the input tensor is casted to dtype before the operation is performed.
             /// This is useful for preventing data type overflows.</param>
             /// <returns></returns>
-            public Tensor cumprod(long dimension, ScalarType? type = null)
+            public Tensor cumprod(long dim, ScalarType? type = null)
             {
-                var res = THSTensor_cumprod(Handle, dimension, type.HasValue, (sbyte)type.GetValueOrDefault());
+                var res = THSTensor_cumprod(Handle, dim, type.HasValue, (sbyte)type.GetValueOrDefault());
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -2563,10 +2563,10 @@ namespace TorchSharp
         /// Returns the cumulative sum of elements of input in the dimension dim.
         /// </summary>
         /// <param name="input">The input tensor.</param>
-        /// <param name="dimension">The dimension to do the operation over</param>
+        /// <param name="dim">The dimension to do the operation over</param>
         /// <param name="type">The desired data type of returned tensor. If specified, the input tensor is casted to dtype before the operation is performed.
         /// This is useful for preventing data type overflows.</param>
-        public static Tensor cumsum(Tensor input, long dimension, ScalarType? type = null) => input.cumsum(dimension, type);
+        public static Tensor cumsum(Tensor input, long dim, ScalarType? type = null) => input.cumsum(dim, type);
 
         /// <summary>
         /// Divides each element of the input by the corresponding element of other.
@@ -3132,11 +3132,11 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The input tensor</param>
         /// <param name="dim">the dimension to reduce.</param>
-        /// <param name="keepDim">whether the output tensor has dim retained or not. Default: false.</param>
-        /// <remarks>If keepDim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
+        /// <param name="keepdim">whether the output tensor has dim retained or not. Default: false.</param>
+        /// <remarks>If keepdim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
         /// Otherwise, dim is squeezed(see torch.squeeze()), resulting in the output tensors having 1 fewer dimension than input.</remarks>
 
-        static public (Tensor values, Tensor indexes) max(Tensor input, long dim, bool keepDim = false) => input.max(dim, keepDim);
+        static public (Tensor values, Tensor indexes) max(Tensor input, long dim, bool keepdim = false) => input.max(dim, keepdim);
 
         /// <summary>
         /// Returns the mean value of all elements in the input tensor.
@@ -3148,13 +3148,13 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The input tensor</param>
         /// <param name="dimensions">The dimension or dimensions to reduce.</param>
-        /// <param name="keepDimension">Whether the output tensor has dim retained or not.</param>
+        /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
         /// <param name="type">The desired data type of returned tensor. If specified, the input tensor is cast to dtype before the operation is performed. This is useful for preventing data type overflows.</param>
         /// <remarks>
         /// If keepdim is True, the output tensor is of the same size as input except in the dimension(s) dim where it is of size 1.
         /// Otherwise, dim is squeezed(see torch.squeeze()), resulting in the output tensor having 1 (or len(dim)) fewer dimension(s).
         /// </remarks>
-        public static Tensor mean(Tensor input, long[] dimensions, bool keepDimension = false, ScalarType? type = null) => input.mean(dimensions, keepDimension, type);
+        public static Tensor mean(Tensor input, long[] dimensions, bool keepdim = false, ScalarType? type = null) => input.mean(dimensions, keepdim, type);
 
         /// <summary>
         /// Returns the minimum value of all elements in the input tensor.
@@ -3175,10 +3175,10 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The input tensor</param>
         /// <param name="dim">the dimension to reduce.</param>
-        /// <param name="keepDim">whether the output tensor has dim retained or not. Default: false.</param>
-        /// <remarks>If keepDim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
+        /// <param name="keepdim">whether the output tensor has dim retained or not. Default: false.</param>
+        /// <remarks>If keepdim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
         /// Otherwise, dim is squeezed(see torch.squeeze()), resulting in the output tensors having 1 fewer dimension than input.</remarks>
-        static public (Tensor values, Tensor indexes) min(Tensor input, long dim, bool keepDim = false) => input.min(dim, keepDim);
+        static public (Tensor values, Tensor indexes) min(Tensor input, long dim, bool keepdim = false) => input.min(dim, keepdim);
 
         /// <summary>
         /// Multiplies each element of the input by the corresponding element of other.
@@ -3464,11 +3464,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
-        public static Tensor std(Tensor input, long[] dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std(dimensions, unbiased, keepDimension, type);
+        public static Tensor std(Tensor input, long[] dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance of all elements in the tensor.</summary>
         /// <remarks>
@@ -3478,11 +3478,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
-        public static Tensor var(Tensor input, long[] dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var(dimensions, unbiased, keepDimension, type);
+        public static Tensor var(Tensor input, long[] dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the standard deviation of all elements in the tensor.</summary>
         /// <remarks>
@@ -3492,11 +3492,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
-        public static Tensor std(Tensor input, long dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std(dimensions, unbiased, keepDimension, type);
+        public static Tensor std(Tensor input, long dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance of all elements in the tensor.</summary>
         /// <remarks>
@@ -3506,11 +3506,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
-        public static Tensor var(Tensor input, long dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var(dimensions, unbiased, keepDimension, type);
+        public static Tensor var(Tensor input, long dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the standard deviation of all elements in the tensor.</summary>
         /// <remarks>
@@ -3520,11 +3520,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
-        public static Tensor std(Tensor input, (long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std(dimensions, unbiased, keepDimension, type);
+        public static Tensor std(Tensor input, (long, long) dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance of all elements in the tensor.</summary>
         /// <remarks>
@@ -3534,11 +3534,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
-        public static Tensor var(Tensor input, (long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var(dimensions, unbiased, keepDimension, type);
+        public static Tensor var(Tensor input, (long, long) dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the standard deviation of all elements in the tensor.</summary>
         /// <remarks>
@@ -3548,11 +3548,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
-        public static Tensor std(Tensor input, (long, long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std(dimensions, unbiased, keepDimension, type);
+        public static Tensor std(Tensor input, (long, long, long) dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance of all elements in the tensor.</summary>
         /// <remarks>
@@ -3562,11 +3562,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
-        public static Tensor var(Tensor input, (long, long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var(dimensions, unbiased, keepDimension, type);
+        public static Tensor var(Tensor input, (long, long, long) dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3576,11 +3576,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
-        public static (Tensor std, Tensor mean) std_mean(Tensor input, long[] dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor std, Tensor mean) std_mean(Tensor input, long[] dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3590,11 +3590,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the variance and the mean.</returns>
-        public static (Tensor @var, Tensor mean) var_mean(Tensor input, long[] dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor @var, Tensor mean) var_mean(Tensor input, long[] dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3604,11 +3604,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
-        public static (Tensor std, Tensor mean) std_mean(Tensor input, ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor std, Tensor mean) std_mean(Tensor input, ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3618,11 +3618,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the variance and the mean.</returns>
-        public static (Tensor @var, Tensor mean) var_mean(Tensor input, ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor @var, Tensor mean) var_mean(Tensor input, ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3632,11 +3632,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
-        public static (Tensor std, Tensor mean) std_mean(Tensor input, long dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor std, Tensor mean) std_mean(Tensor input, long dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3646,11 +3646,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the variance and the mean.</returns>
-        public static (Tensor @var, Tensor mean) var_mean(Tensor input, long dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor @var, Tensor mean) var_mean(Tensor input, long dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3660,11 +3660,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
-        public static (Tensor std, Tensor mean) std_mean(Tensor input, (long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor std, Tensor mean) std_mean(Tensor input, (long, long) dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3674,11 +3674,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the variance and the mean.</returns>
-        public static (Tensor @var, Tensor mean) var_mean(Tensor input, (long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor @var, Tensor mean) var_mean(Tensor input, (long, long) dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3688,11 +3688,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
-        public static (Tensor std, Tensor mean) std_mean(Tensor input, (long, long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.std_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor std, Tensor mean) std_mean(Tensor input, (long, long, long) dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.std_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
         /// <remarks>
@@ -3702,11 +3702,11 @@ namespace TorchSharp
         /// <param name="input">The input tensor.</param>
         /// <param name="dimensions">The dimensions to reduce.</param>
         /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-        /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+        /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
         /// <param name="type"></param>
         /// <returns>A <see cref="Tensor">tensor</see> tuple of the variance and the mean.</returns>
-        public static (Tensor @var, Tensor mean) var_mean(Tensor input, (long, long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-            => input.var_mean(dimensions, unbiased, keepDimension, type);
+        public static (Tensor @var, Tensor mean) var_mean(Tensor input, (long, long, long) dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+            => input.var_mean(dimensions, unbiased, keepdim, type);
 
         /// <summary>
         /// Element-wise subtraction

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -833,12 +833,12 @@ namespace TorchSharp
             public Tensor to(Tensor other) => to(other.dtype, other.device);
 
             [DllImport("LibTorchSharp")]
-            static extern long THSTensor_size(IntPtr handle, long dimension);
+            static extern long THSTensor_size(IntPtr handle, long dim);
 
             /// <summary>
             ///  Retrieves the size of the specified dimension in the tensor.
             /// </summary>
-            /// <param name="dim"></param>
+            /// <param name="dim">The dimension for which to retrieve the size.</param>
             public long size(int dim)
             {
                 var res = THSTensor_size(Handle, dim);
@@ -928,7 +928,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern long THSTensor_stride(IntPtr handle, long dimension);
+            static extern long THSTensor_stride(IntPtr handle, long dim);
 
             [DllImport("LibTorchSharp")]
             static extern long THSTensor_strides(IntPtr handle, AllocatePinnedArray allocator);
@@ -1434,24 +1434,24 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_select(IntPtr tensor, long dimension, IntPtr index);
+            static extern IntPtr THSTensor_index_select(IntPtr tensor, long dim, IntPtr index);
 
             /// <summary>
             /// Returns a new tensor which indexes the input tensor along dimension dim using the entries in index which is a LongTensor.
             /// </summary>
-            /// <param name="dimension"></param>
-            /// <param name="index"></param>
+            /// <param name="dim">The dimension in which we index</param>
+            /// <param name="index">The 1-D tensor containing the indices to index</param>
 
-            public Tensor index_select(long dimension, Tensor index)
+            public Tensor index_select(long dim, Tensor index)
             {
-                var res = THSTensor_index_select(Handle, dimension, index.Handle);
+                var res = THSTensor_index_select(Handle, dim, index.Handle);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_select(IntPtr tensor, long dimension, long index);
+            static extern IntPtr THSTensor_select(IntPtr tensor, long dim, long index);
 
             /// <summary>
             /// Slices the self tensor along the selected dimension at the given index.
@@ -1517,12 +1517,12 @@ namespace TorchSharp
             /// Selects values from input at the 1-dimensional indices from indices along the given dim.
             /// </summary>
             /// <param name="indices">The indices into input. Must have long dtype.</param>
-            /// <param name="dimension">Dimension to select along.</param>
+            /// <param name="dim">Dimension to select along.</param>
 
             /// <remarks>Functions that return indices along a dimension, like torch.argmax() and torch.argsort(), are designed to work with this function.</remarks>
-            public Tensor take_along_dim(Tensor indices, long dimension)
+            public Tensor take_along_dim(Tensor indices, long dim)
             {
-                var res = THSTensor_take_along_dim(Handle, indices.Handle, dimension);
+                var res = THSTensor_take_along_dim(Handle, indices.Handle, dim);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -1712,7 +1712,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unflatten(IntPtr tensor, long dimension, IntPtr shape, int length);
+            static extern IntPtr THSTensor_unflatten(IntPtr tensor, long dim, IntPtr shape, int length);
 
             /// <summary>
             /// Expands the dimension dim of the self tensor over multiple dimensions of sizes given by sizes.
@@ -1797,7 +1797,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_squeeze(IntPtr tensor, long dimension);
+            static extern IntPtr THSTensor_squeeze(IntPtr tensor, long dim);
 
             [DllImport("LibTorchSharp")]
             static extern IntPtr THSTensor_squeeze_no_dim(IntPtr tensor);
@@ -2042,17 +2042,17 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_all_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
+            static extern IntPtr THSTensor_all_along_dimension(IntPtr tensor, long dim, bool keep_dim);
 
             /// <summary>
             /// Tests if all elements in input evaluate to true.
             /// </summary>
-            /// <param name="dimension">The dimension to reduce</param>
-            /// <param name="keepDim">Keep the dimension to reduce</param>
+            /// <param name="dim">The dimension to reduce</param>
+            /// <param name="keepdim">Keep the dimension to reduce</param>
 
-            public Tensor all(long dimension, bool keepDim = false)
+            public Tensor all(long dim, bool keepdim = false)
             {
-                var res = THSTensor_all_along_dimension(Handle, dimension, keepDim);
+                var res = THSTensor_all_along_dimension(Handle, dim, keepdim);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -2068,15 +2068,15 @@ namespace TorchSharp
             /// Returns the maximum value of each slice of the input tensor in the given dimension(s) dim.
             /// </summary>
             /// <param name="dims">The dimension or dimensions to reduce.</param>
-            /// <param name="keepDim">Whether the output tensor has dim retained or not.</param>
+            /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
             /// <param name="out">The output tensor -- optional.</param>
-            public Tensor amax(ReadOnlySpan<long> dims, bool keepDim = false, Tensor? @out = null)
+            public Tensor amax(ReadOnlySpan<long> dims, bool keepdim = false, Tensor? @out = null)
             {
                 unsafe {
                     fixed (long* pdims = dims) {
                         var res = @out is null ?
-                            THSTensor_amax(Handle, (IntPtr)pdims, dims.Length, keepDim) :
-                            THSTensor_amax_out(Handle, (IntPtr)pdims, dims.Length, keepDim, @out.Handle);
+                            THSTensor_amax(Handle, (IntPtr)pdims, dims.Length, keepdim) :
+                            THSTensor_amax_out(Handle, (IntPtr)pdims, dims.Length, keepdim, @out.Handle);
                         if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                         return new Tensor(res);
                     }
@@ -2087,12 +2087,12 @@ namespace TorchSharp
             /// Returns the maximum value of each slice of the input tensor in the given dimension(s) dim.
             /// </summary>
             /// <param name="dims">The dimension or dimensions to reduce.</param>
-            /// <param name="keepDim">Whether the output tensor has dim retained or not.</param>
+            /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
             /// <param name="out">The output tensor -- optional.</param>
-            public Tensor amax(long[] dims, bool keepDim = false, Tensor? @out = null)
+            public Tensor amax(long[] dims, bool keepdim = false, Tensor? @out = null)
 
             {
-                return amax((ReadOnlySpan<long>)dims, keepDim, @out);
+                return amax((ReadOnlySpan<long>)dims, keepdim, @out);
             }
 
             /// <summary>
@@ -2113,15 +2113,15 @@ namespace TorchSharp
             /// Returns the minimum value of each slice of the input tensor in the given dimension(s) dim.
             /// </summary>
             /// <param name="dims">The dimension or dimensions to reduce.</param>
-            /// <param name="keepDim">Whether the output tensor has dim retained or not.</param>
+            /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
             /// <param name="out">The output tensor -- optional.</param>
-            public Tensor amin(ReadOnlySpan<long> dims, bool keepDim = false, Tensor? @out = null)
+            public Tensor amin(ReadOnlySpan<long> dims, bool keepdim = false, Tensor? @out = null)
             {
                 unsafe {
                     fixed (long* pdims = dims) {
                         var res = @out is null ?
-                            THSTensor_amin(Handle, (IntPtr)pdims, dims.Length, keepDim) :
-                            THSTensor_amin_out(Handle, (IntPtr)pdims, dims.Length, keepDim, @out.Handle);
+                            THSTensor_amin(Handle, (IntPtr)pdims, dims.Length, keepdim) :
+                            THSTensor_amin_out(Handle, (IntPtr)pdims, dims.Length, keepdim, @out.Handle);
                         if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                         return new Tensor(res);
                     }
@@ -2132,11 +2132,11 @@ namespace TorchSharp
             /// Returns the minimum value of each slice of the input tensor in the given dimension(s) dim.
             /// </summary>
             /// <param name="dims">The dimension or dimensions to reduce.</param>
-            /// <param name="keepDim">Whether the output tensor has dim retained or not.</param>
+            /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
             /// <param name="out">The output tensor -- optional.</param>
-            public Tensor amin(long[] dims, bool keepDim = false, Tensor? @out = null)
+            public Tensor amin(long[] dims, bool keepdim = false, Tensor? @out = null)
             {
-                return amin((ReadOnlySpan<long>)dims, keepDim, @out);
+                return amin((ReadOnlySpan<long>)dims, keepdim, @out);
 
             }
 
@@ -2157,11 +2157,11 @@ namespace TorchSharp
             /// Computes the minimum and maximum values of the input tensor.
             /// </summary>
             /// <param name="dim">The dimension along which to compute the values. If null, computes the values over the entire input tensor</param>
-            /// <param name="keepDim"> If true, the reduced dimensions will be kept in the output tensor as dimensions with size 1 for broadcasting.</param>
+            /// <param name="keepdim"> If true, the reduced dimensions will be kept in the output tensor as dimensions with size 1 for broadcasting.</param>
 
-            public (Tensor min, Tensor max) aminmax(long? dim = null, bool keepDim = false)
+            public (Tensor min, Tensor max) aminmax(long? dim = null, bool keepdim = false)
             {
-                var res = THSTensor_aminmax(Handle, (dim is null) ? -1 : dim.Value, keepDim, out IntPtr maxHandle);
+                var res = THSTensor_aminmax(Handle, (dim is null) ? -1 : dim.Value, keepdim, out IntPtr maxHandle);
                 if (res == IntPtr.Zero || maxHandle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return (new Tensor(res), new Tensor(maxHandle));
             }
@@ -2182,17 +2182,17 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_any_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
+            static extern IntPtr THSTensor_any_along_dimension(IntPtr tensor, long dim, bool keep_dim);
 
             /// <summary>
             /// Tests if any element in input evaluate to true.
             /// </summary>
-            /// <param name="dimension">The dimension to reduce</param>
-            /// <param name="keepDim">Keep the dimension to reduce</param>
+            /// <param name="dim">The dimension to reduce</param>
+            /// <param name="keepdim">Keep the dimension to reduce</param>
 
-            public Tensor any(long dimension, bool keepDim = false)
+            public Tensor any(long dim, bool keepdim = false)
             {
-                var res = THSTensor_any_along_dimension(Handle, dimension, keepDim);
+                var res = THSTensor_any_along_dimension(Handle, dim, keepdim);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -2214,17 +2214,17 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_argmax_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
+            static extern IntPtr THSTensor_argmax_along_dimension(IntPtr tensor, long dim, bool keep_dim);
 
             /// <summary>
             /// Returns the indices of the maximum value of all elements in the input tensor.
             /// </summary>
-            /// <param name="dimension"></param>
-            /// <param name="keepDim"></param>
+            /// <param name="dim"></param>
+            /// <param name="keepdim"></param>
 
-            public Tensor argmax(long dimension, bool keepDim = false)
+            public Tensor argmax(long dim, bool keepdim = false)
             {
-                var res = THSTensor_argmax_along_dimension(Handle, dimension, keepDim);
+                var res = THSTensor_argmax_along_dimension(Handle, dim, keepdim);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -2246,34 +2246,34 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_argmin_along_dimension(IntPtr tensor, long dimension, bool keep_dim);
+            static extern IntPtr THSTensor_argmin_along_dimension(IntPtr tensor, long dim, bool keep_dim);
 
             /// <summary>
             /// Returns the indices of the minimum value of all elements in the input tensor.
             /// </summary>
-            /// <param name="dimension"></param>
-            /// <param name="keepDim"></param>
+            /// <param name="dim"></param>
+            /// <param name="keepdim"></param>
 
-            public Tensor argmin(long dimension, bool keepDim = false)
+            public Tensor argmin(long dim, bool keepdim = false)
             {
-                var res = THSTensor_argmin_along_dimension(Handle, dimension, keepDim);
+                var res = THSTensor_argmin_along_dimension(Handle, dim, keepdim);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_argsort(IntPtr tensor, long dimension, bool descending);
+            static extern IntPtr THSTensor_argsort(IntPtr tensor, long dim, bool descending);
 
             /// <summary>
             /// Returns the indices that sort a tensor along a given dimension in ascending order by value.
             /// </summary>
-            /// <param name="dimension">The dimension to sort along</param>
+            /// <param name="dim">The dimension to sort along</param>
             /// <param name="descending">Controls the sorting order (ascending or descending)</param>
 
-            public Tensor argsort(long dimension = -1, bool descending = false)
+            public Tensor argsort(long dim = -1, bool descending = false)
             {
-                var res = THSTensor_argsort(Handle, dimension, descending);
+                var res = THSTensor_argsort(Handle, dim, descending);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -3223,7 +3223,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_diag(IntPtr tensor, long dimension);
+            static extern IntPtr THSTensor_diag(IntPtr tensor, long dim);
 
             /// <summary>
             /// If input is a vector (1-D tensor), then returns a 2-D square tensor with the elements of input as the diagonal.
@@ -3750,15 +3750,14 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_topk(IntPtr tensor, AllocatePinnedArray allocator, int k,
-                long dimension, bool largest, bool sorted);
+            static extern void THSTensor_topk(IntPtr tensor, AllocatePinnedArray allocator, int k, long dim, bool largest, bool sorted);
 
-            public (Tensor values, Tensor indexes) topk(int k, int dimension = -1, bool largest = true, bool sorted = true)
+            public (Tensor values, Tensor indexes) topk(int k, int dim = -1, bool largest = true, bool sorted = true)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_topk(Handle, pa.CreateArray, k, dimension, largest, sorted);
+                    THSTensor_topk(Handle, pa.CreateArray, k, dim, largest, sorted);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -3768,7 +3767,7 @@ namespace TorchSharp
 
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_unbind(IntPtr tensor, AllocatePinnedArray allocator, long dimension);
+            static extern void THSTensor_unbind(IntPtr tensor, AllocatePinnedArray allocator, long dim);
 
             /// <summary>
             /// Removes a tensor dimension.
@@ -3789,7 +3788,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unfold(IntPtr tensor, long dimension, long size, long step);
+            static extern IntPtr THSTensor_unfold(IntPtr tensor, long dim, long size, long step);
 
             /// <summary>
             /// Returns a view of the original tensor which contains all slices of size 'size' from the tensor in the given dimension.
@@ -3805,20 +3804,20 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dimension);
+            static extern void THSTensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dim);
 
             /// <summary>
             /// Splits the tensor into chunks. Each chunk is a view of the original tensor.
             /// </summary>
             /// <param name="size">The size of a single chunk</param>
-            /// <param name="dimension">The dimension along which to split the tensor.</param>
+            /// <param name="dim">The dimension along which to split the tensor.</param>
 
-            public Tensor[] split(long size, int dimension = 0)
+            public Tensor[] split(long size, int dim = 0)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_split_with_size(Handle, pa.CreateArray, size, dimension);
+                    THSTensor_split_with_size(Handle, pa.CreateArray, size, dim);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -3827,22 +3826,22 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dimension);
+            static extern void THSTensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dim);
 
             /// <summary>
             /// Splits the tensor into chunks. Each chunk is a view of the original tensor.
             /// </summary>
             /// <param name="sizes">A list of sizes for each chunk</param>
-            /// <param name="dimension">The dimension along which to split the tensor.</param>
+            /// <param name="dim">The dimension along which to split the tensor.</param>
 
-            public Tensor[] split(ReadOnlySpan<long> sizes, int dimension = 0)
+            public Tensor[] split(ReadOnlySpan<long> sizes, int dim = 0)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
                     unsafe {
                         fixed (long* psizes = sizes) {
-                            THSTensor_split_with_sizes(Handle, pa.CreateArray, (IntPtr)psizes, sizes.Length, dimension);
+                            THSTensor_split_with_sizes(Handle, pa.CreateArray, (IntPtr)psizes, sizes.Length, dim);
                             torch.CheckForErrors();
                         }
                     }
@@ -3856,11 +3855,11 @@ namespace TorchSharp
             /// Splits the tensor into chunks. Each chunk is a view of the original tensor.
             /// </summary>
             /// <param name="sizes">A list of sizes for each chunk</param>
-            /// <param name="dimension">The dimension along which to split the tensor.</param>
+            /// <param name="dim">The dimension along which to split the tensor.</param>
 
-            public Tensor[] split(long[] sizes, int dimension = 0)
+            public Tensor[] split(long[] sizes, int dim = 0)
             {
-                return split((ReadOnlySpan<long>)sizes, dimension);
+                return split((ReadOnlySpan<long>)sizes, dim);
             }
 
             /// <summary>
@@ -3874,14 +3873,20 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_tensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dimension);
+            static extern void THSTensor_tensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dim);
 
-            public Tensor[] tensor_split(long size, int dimension = 0)
+            /// <summary>
+            /// Splits a tensor into multiple sub-tensors, all of which are views of input, along dimension dim according to the indices or number of sections specified by indices_or_sections.
+            /// </summary>
+            /// <param name="size"></param>
+            /// <param name="dim"></param>
+            /// <returns></returns>
+            public Tensor[] tensor_split(long size, int dim = 0)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_tensor_split_with_size(Handle, pa.CreateArray, size, dimension);
+                    THSTensor_tensor_split_with_size(Handle, pa.CreateArray, size, dim);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -3890,16 +3895,22 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_tensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dimension);
+            static extern void THSTensor_tensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dim);
 
-            public Tensor[] tensor_split(long[] sizes, int dimension = 0)
+            /// <summary>
+            /// Splits a tensor into multiple sub-tensors, all of which are views of input, along dimension dim according to the indices or number of sections specified by indices_or_sections.
+            /// </summary>
+            /// <param name="sizes"></param>
+            /// <param name="dim"></param>
+            /// <returns></returns>
+            public Tensor[] tensor_split(long[] sizes, int dim = 0)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
                     unsafe {
                         fixed (long* psizes = sizes) {
-                            THSTensor_tensor_split_with_sizes(Handle, pa.CreateArray, (IntPtr)psizes, sizes.Length, dimension);
+                            THSTensor_tensor_split_with_sizes(Handle, pa.CreateArray, (IntPtr)psizes, sizes.Length, dim);
                             torch.CheckForErrors();
                         }
                     }
@@ -3910,15 +3921,15 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_tensor_split_with_tensor_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr indices, long dimension);
+            static extern void THSTensor_tensor_split_with_tensor_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr indices, long dim);
 
-            public Tensor[] tensor_split(Tensor indices, int dimension = 0)
+            public Tensor[] tensor_split(Tensor indices, int dim = 0)
             {
                 if (indices.dtype != ScalarType.Int64) throw new ArgumentException("Tensor indices should be Int64 in 'tensor_split");
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_tensor_split_with_tensor_sizes(Handle, pa.CreateArray, indices.Handle, dimension);
+                    THSTensor_tensor_split_with_tensor_sizes(Handle, pa.CreateArray, indices.Handle, dim);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -4162,23 +4173,22 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_max_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dimension,
-                bool keep_dim);
+            static extern void THSTensor_max_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dim, bool keep_dim);
 
             /// <summary>
             /// Returns a named tuple (values, indexes) where values is the maximum value of each row of the input tensor in the given dimension dim.
             /// And indices is the index location of each maximum value found (argmax).
             /// </summary>
             /// <param name="dim">the dimension to reduce.</param>
-            /// <param name="keepDim">whether the output tensor has dim retained or not. Default: false.</param>
-            /// <remarks>If keepDim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
+            /// <param name="keepdim">whether the output tensor has dim retained or not. Default: false.</param>
+            /// <remarks>If keepdim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
             /// Otherwise, dim is squeezed(see torch.squeeze()), resulting in the output tensors having 1 fewer dimension than input.</remarks>
-            public (Tensor values, Tensor indexes) max(long dim, bool keepDim = false)
+            public (Tensor values, Tensor indexes) max(long dim, bool keepdim = false)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_max_along_dimension(Handle, pa.CreateArray, dim, keepDim);
+                    THSTensor_max_along_dimension(Handle, pa.CreateArray, dim, keepdim);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -4269,28 +4279,28 @@ namespace TorchSharp
             /// Returns the mean value of each row of the input tensor in the given dimension dim. If dim is a list of dimensions, reduce over all of them.
             /// </summary>
             /// <param name="dimensions">The dimension or dimensions to reduce.</param>
-            /// <param name="keepDimension">Whether the output tensor has dim retained or not.</param>
+            /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
             /// <param name="type">The desired data type of returned tensor. If specified, the input tensor is cast to dtype before the operation is performed. This is useful for preventing data type overflows.</param>
             /// <remarks>
             /// If keepdim is True, the output tensor is of the same size as input except in the dimension(s) dim where it is of size 1.
             /// Otherwise, dim is squeezed(see torch.squeeze()), resulting in the output tensor having 1 (or len(dim)) fewer dimension(s).
             /// </remarks>
-            public Tensor mean(long[] dimensions, bool keepDimension = false, ScalarType? type = null)
+            public Tensor mean(long[] dimensions, bool keepdim = false, ScalarType? type = null)
             {
                 unsafe {
                     fixed (long* pdims = dimensions) {
-                        var res = THSTensor_mean_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, keepDimension, type.HasValue, (sbyte)type.GetValueOrDefault());
+                        var res = THSTensor_mean_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, keepdim, type.HasValue, (sbyte)type.GetValueOrDefault());
                         if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                         return new Tensor(res);
                     }
                 }
             }
 
-            public Tensor var(long[] dimensions, bool keepDimension = false, ScalarType? type = null)
+            public Tensor var(long[] dimensions, bool keepdim = false, ScalarType? type = null)
             {
                 unsafe {
                     fixed (long* pdims = dimensions) {
-                        var res = THSTensor_var_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, keepDimension, type.HasValue, (sbyte)type.GetValueOrDefault());
+                        var res = THSTensor_var_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, keepdim, type.HasValue, (sbyte)type.GetValueOrDefault());
                         if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                         return new Tensor(res);
                     }
@@ -4338,25 +4348,24 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern void THSTensor_min_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dimension,
-                bool keep_dim);
+            static extern void THSTensor_min_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dim, bool keep_dim);
 
             /// <summary>
             /// Returns a named tuple (values, indexes) where values is the minimum value of each row of the input tensor in the given dimension dim.
             /// And indices is the index location of each minimum value found (argmin).
             /// </summary>
             /// <param name="dim">the dimension to reduce.</param>
-            /// <param name="keepDim">whether the output tensor has dim retained or not. Default: false.</param>
+            /// <param name="keepdim">whether the output tensor has dim retained or not. Default: false.</param>
             /// <remarks>
-            /// If keepDim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
+            /// If keepdim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
             /// Otherwise, dim is squeezed(see torch.squeeze()), resulting in the output tensors having 1 fewer dimension than input.
             /// </remarks>
-            public (Tensor values, Tensor indexes) min(long dim, bool keepDim = false)
+            public (Tensor values, Tensor indexes) min(long dim, bool keepdim = false)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_min_along_dimension(Handle, pa.CreateArray, dim, keepDim);
+                    THSTensor_min_along_dimension(Handle, pa.CreateArray, dim, keepdim);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -4470,14 +4479,14 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_norm_along_dimension(IntPtr tensor, int dimension, bool keepdim, float p);
+            static extern IntPtr THSTensor_norm_along_dimension(IntPtr tensor, int dim, bool keepdim, float p);
 
             /// <summary>
             /// Returns the matrix norm or vector norm of a given tensor.
             /// </summary>
-            public Tensor norm(int dimension, bool keepdim = false, float p = 2.0f)
+            public Tensor norm(int dim, bool keepdim = false, float p = 2.0f)
             {
-                var res = THSTensor_norm_along_dimension(Handle, dimension, keepdim, p);
+                var res = THSTensor_norm_along_dimension(Handle, dim, keepdim, p);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -4657,13 +4666,13 @@ namespace TorchSharp
             /// </remarks>
             /// <param name="dimensions">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor std(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            public Tensor std(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
-                return _std(dimensions, unbiased, keepDimension, type);
+                return _std(dimensions, unbiased, keepdim, type);
             }
 
             ///<summary>Calculates the variance of all elements in the input tensor.</summary>
@@ -4673,13 +4682,13 @@ namespace TorchSharp
             /// </remarks>
             /// <param name="dimensions">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor var(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            public Tensor var(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
-                return _var(dimensions, unbiased, keepDimension, type);
+                return _var(dimensions, unbiased, keepdim, type);
             }
 
             /// <summary>Calculates the standard deviation of all elements in the tensor.</summary>
@@ -4689,13 +4698,13 @@ namespace TorchSharp
             /// </remarks>
             /// <param name="dimensions">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor std(long[] dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            public Tensor std(long[] dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
-                return _std(dimensions, unbiased, keepDimension, type);
+                return _std(dimensions, unbiased, keepdim, type);
             }
 
             ///<summary>Calculates the variance of all elements in the input tensor.</summary>
@@ -4705,30 +4714,30 @@ namespace TorchSharp
             /// </remarks>
             /// <param name="dimensions">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor var(long[] dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            public Tensor var(long[] dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
-                return _var(dimensions, unbiased, keepDimension, type);
+                return _var(dimensions, unbiased, keepdim, type);
             }
 
             // private, shared implementation
-            private unsafe Tensor _std(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            private unsafe Tensor _std(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
                 fixed (long* pdims = dimensions) {
-                    var res = THSTensor_std_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, unbiased, keepDimension);
+                    var res = THSTensor_std_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, unbiased, keepdim);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
                 }
             }
 
             // private, shared implementation
-            private unsafe Tensor _var(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            private unsafe Tensor _var(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
                 fixed (long* pdims = dimensions) {
-                    var res = THSTensor_var_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, unbiased, keepDimension);
+                    var res = THSTensor_var_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, unbiased, keepdim);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
                 }
@@ -4739,84 +4748,84 @@ namespace TorchSharp
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample deviation is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimension">The dimension to reduce.</param>
+            /// <param name="dim">The dimension to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimension" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor std(long dimension, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => std(stackalloc[] { dimension }, unbiased, keepDimension, type);
+            public Tensor std(long dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => std(stackalloc[] { dim }, unbiased, keepdim, type);
 
             /// <summary>Calculates the variance of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample variance is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimension">The dimension to reduce.</param>
+            /// <param name="dim">The dimension to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimension" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor var(long dimension, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => var(stackalloc[] { dimension }, unbiased, keepDimension, type);
+            public Tensor var(long dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => var(stackalloc[] { dim }, unbiased, keepdim, type);
 
             /// <summary>Calculates the standard deviation of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample deviation is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimensions">The dimensions to reduce.</param>
+            /// <param name="dim">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimensions" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor std((long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => std(stackalloc[] { dimensions.Item1, dimensions.Item2 }, unbiased, keepDimension, type);
+            public Tensor std((long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => std(stackalloc[] { dim.Item1, dim.Item2 }, unbiased, keepdim, type);
 
             /// <summary>Calculates the variance of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample variance is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimensions">The dimensions to reduce.</param>
+            /// <param name="dim">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimensions" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor var((long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => var(stackalloc[] { dimensions.Item1, dimensions.Item2 }, unbiased, keepDimension, type);
+            public Tensor var((long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => var(stackalloc[] { dim.Item1, dim.Item2 }, unbiased, keepdim, type);
 
             /// <summary>Calculates the standard deviation of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample deviation is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimensions">The dimensions to reduce.</param>
+            /// <param name="dim">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimensions" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor std((long, long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => std(stackalloc[] { dimensions.Item1, dimensions.Item2, dimensions.Item3 }, unbiased, keepDimension, type);
+            public Tensor std((long, long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => std(stackalloc[] { dim.Item1, dim.Item2, dim.Item3 }, unbiased, keepdim, type);
 
             /// <summary>Calculates the variance of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample deviation is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimensions">The dimensions to reduce.</param>
+            /// <param name="dim">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimensions" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>The <see cref="Tensor">output tensor</see>.</returns>
             [Pure]
-            public Tensor var((long, long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => var(stackalloc[] { dimensions.Item1, dimensions.Item2, dimensions.Item3 }, unbiased, keepDimension, type);
+            public Tensor var((long, long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => var(stackalloc[] { dim.Item1, dim.Item2, dim.Item3 }, unbiased, keepdim, type);
 
             [DllImport("LibTorchSharp")]
             static extern IntPtr THSTensor_std_mean(IntPtr tensor, bool unbiased, out IntPtr mean);
@@ -4865,13 +4874,13 @@ namespace TorchSharp
             /// </remarks>
             /// <param name="dimensions">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
             [Pure]
-            public (Tensor std, Tensor mean) std_mean(long[] dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            public (Tensor std, Tensor mean) std_mean(long[] dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
-                return _std_mean(dimensions, unbiased, keepDimension, type);
+                return _std_mean(dimensions, unbiased, keepdim, type);
             }
 
             /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
@@ -4881,14 +4890,14 @@ namespace TorchSharp
             /// </remarks>
             /// <param name="dimensions">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
 
             [Pure]
-            public (Tensor std, Tensor mean) var_mean(long[] dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            public (Tensor std, Tensor mean) var_mean(long[] dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
-                return _var_mean(dimensions, unbiased, keepDimension, type);
+                return _var_mean(dimensions, unbiased, keepdim, type);
             }
 
             /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
@@ -4898,13 +4907,13 @@ namespace TorchSharp
             /// </remarks>
             /// <param name="dimensions">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
             [Pure]
-            public (Tensor std, Tensor mean) std_mean(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            public (Tensor std, Tensor mean) std_mean(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
-                return _std_mean(dimensions, unbiased, keepDimension, type);
+                return _std_mean(dimensions, unbiased, keepdim, type);
             }
 
             /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
@@ -4914,30 +4923,30 @@ namespace TorchSharp
             /// </remarks>
             /// <param name="dimensions">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has dim retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
             [Pure]
-            public (Tensor std, Tensor mean) var_mean(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            public (Tensor std, Tensor mean) var_mean(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
-                return _var_mean(dimensions, unbiased, keepDimension, type);
+                return _var_mean(dimensions, unbiased, keepdim, type);
             }
 
             // private, shared implementation
-            private unsafe (Tensor std, Tensor mean) _std_mean(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            private unsafe (Tensor std, Tensor mean) _std_mean(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
                 fixed (long* pdims = dimensions) {
-                    var res = THSTensor_std_mean_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, unbiased, keepDimension, out var mean);
+                    var res = THSTensor_std_mean_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, unbiased, keepdim, out var mean);
                     if (res == IntPtr.Zero || mean == IntPtr.Zero) { torch.CheckForErrors(); }
                     return (new Tensor(res), new Tensor(mean));
                 }
             }
 
             // private, shared implementation
-            private unsafe (Tensor @var, Tensor mean) _var_mean(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
+            private unsafe (Tensor @var, Tensor mean) _var_mean(ReadOnlySpan<long> dimensions, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
             {
                 fixed (long* pdims = dimensions) {
-                    var res = THSTensor_var_mean_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, unbiased, keepDimension, out var @var);
+                    var res = THSTensor_var_mean_along_dimensions(Handle, (IntPtr)pdims, dimensions.Length, unbiased, keepdim, out var @var);
                     if (res == IntPtr.Zero || @var == IntPtr.Zero) { torch.CheckForErrors(); }
                     return (new Tensor(res), new Tensor(@var));
                 }
@@ -4948,84 +4957,84 @@ namespace TorchSharp
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample deviation is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimension">The dimension to reduce.</param>
+            /// <param name="dim">The dimension to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimension" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
             [Pure]
-            public (Tensor std, Tensor mean) std_mean(long dimension, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => std_mean(new[] { dimension }, unbiased, keepDimension, type);
+            public (Tensor std, Tensor mean) std_mean(long dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => std_mean(new[] { dim }, unbiased, keepdim, type);
 
             /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample variance is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimension">The dimension to reduce.</param>
+            /// <param name="dim">The dimension to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimension" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the variance and the mean.</returns>
             [Pure]
-            public (Tensor @var, Tensor mean) var_mean(long dimension, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => var_mean(new[] { dimension }, unbiased, keepDimension, type);
+            public (Tensor @var, Tensor mean) var_mean(long dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => var_mean(new[] { dim }, unbiased, keepdim, type);
 
             /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample deviation is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimensions">The dimensions to reduce.</param>
+            /// <param name="dim">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimensions" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
             [Pure]
-            public (Tensor std, Tensor mean) std_mean((long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => std_mean(stackalloc[] { dimensions.Item1, dimensions.Item2 }, unbiased, keepDimension, type);
+            public (Tensor std, Tensor mean) std_mean((long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => std_mean(stackalloc[] { dim.Item1, dim.Item2 }, unbiased, keepdim, type);
 
             /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample variance is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimensions">The dimensions to reduce.</param>
+            /// <param name="dim">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimensions" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the variance and the mean.</returns>
             [Pure]
-            public (Tensor @var, Tensor mean) var_mean((long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => var_mean(stackalloc[] { dimensions.Item1, dimensions.Item2 }, unbiased, keepDimension, type);
+            public (Tensor @var, Tensor mean) var_mean((long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => var_mean(stackalloc[] { dim.Item1, dim.Item2 }, unbiased, keepdim, type);
 
             /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample deviation is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimensions">The dimensions to reduce.</param>
+            /// <param name="dim">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimensions" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the standard deviation and the mean.</returns>
             [Pure]
-            public (Tensor std, Tensor mean) std_mean((long, long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => std_mean(stackalloc[] { dimensions.Item1, dimensions.Item2, dimensions.Item3 }, unbiased, keepDimension, type);
+            public (Tensor std, Tensor mean) std_mean((long, long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => std_mean(stackalloc[] { dim.Item1, dim.Item2, dim.Item3 }, unbiased, keepdim, type);
 
             /// <summary>Calculates the variance and mean of all elements in the tensor.</summary>
             /// <remarks>
             /// If <paramref name="unbiased" /> is <value>true</value>, Bessel’s correction will be used.
             /// Otherwise, the sample variance is calculated, without any correction.
             /// </remarks>
-            /// <param name="dimensions">The dimensions to reduce.</param>
+            /// <param name="dim">The dimensions to reduce.</param>
             /// <param name="unbiased">Whether to use Bessel’s correction (δN=1).</param>
-            /// <param name="keepDimension">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dimensions" /> retained or not.</param>
+            /// <param name="keepdim">Whether the <see cref="Tensor">output tensor</see> has <paramref name="dim" /> retained or not.</param>
             /// <param name="type"></param>
             /// <returns>A <see cref="Tensor">tensor</see> tuple of the variance and the mean.</returns>
             [Pure]
-            public (Tensor @var, Tensor mean) var_mean((long, long, long) dimensions, bool unbiased = true, bool keepDimension = false, ScalarType? type = null)
-                => var_mean(stackalloc[] { dimensions.Item1, dimensions.Item2, dimensions.Item3 }, unbiased, keepDimension, type);
+            public (Tensor @var, Tensor mean) var_mean((long, long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
+                => var_mean(stackalloc[] { dim.Item1, dim.Item2, dim.Item3 }, unbiased, keepdim, type);
 
             [DllImport("LibTorchSharp")]
             static extern IntPtr THSTensor_sum(IntPtr tensor, bool has_type, sbyte scalar_type);
@@ -5086,9 +5095,9 @@ namespace TorchSharp
             /// <summary>
             ///  Returns the sum of each row of the input tensor in the given dimensions.
             /// </summary>
-            public Tensor sum(long dim0, long dim1, long dim2, bool keepDimension = false, ScalarType? type = null)
+            public Tensor sum(long dim0, long dim1, long dim2, bool keepdim = false, ScalarType? type = null)
             {
-                return _sum(stackalloc long[] { dim0, dim1, dim2 }, keepDimension, type);
+                return _sum(stackalloc long[] { dim0, dim1, dim2 }, keepdim, type);
             }
 
             [DllImport("LibTorchSharp")]
@@ -5995,25 +6004,25 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_scatter(IntPtr tensor, long dimension, IntPtr index, IntPtr source);
+            extern static IntPtr THSTensor_scatter(IntPtr tensor, long dim, IntPtr index, IntPtr source);
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_scatter_(IntPtr tensor, long dimension, IntPtr index, IntPtr source);
+            extern static IntPtr THSTensor_scatter_(IntPtr tensor, long dim, IntPtr index, IntPtr source);
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_scatter_add(IntPtr tensor, long dimension, IntPtr index, IntPtr source);
+            extern static IntPtr THSTensor_scatter_add(IntPtr tensor, long dim, IntPtr index, IntPtr source);
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_scatter_add_(IntPtr tensor, long dimension, IntPtr index, IntPtr source);
+            extern static IntPtr THSTensor_scatter_add_(IntPtr tensor, long dim, IntPtr index, IntPtr source);
 
             /// <summary>
             ///  Writes all values from the tensor src into self at the indices specified in the index tensor. For each
             ///  value in src, its output index is specified by its index in src for dimension != dim and by the #
             ///  corresponding value in index for dimension = dim.
             /// </summary>
-            public Tensor scatter(long dimension, Tensor index, Tensor src)
+            public Tensor scatter(long dim, Tensor index, Tensor src)
             {
-                var res = THSTensor_scatter(Handle, dimension, index.Handle, src.Handle);
+                var res = THSTensor_scatter(Handle, dim, index.Handle, src.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -6023,9 +6032,9 @@ namespace TorchSharp
             /// For each value in src, it is added to an index in self which is specified by its index in src for dimension != dim and by the
             /// corresponding value in index for dimension = dim.
             /// </summary>
-            public Tensor scatter_(long dimension, Tensor index, Tensor src)
+            public Tensor scatter_(long dim, Tensor index, Tensor src)
             {
-                var res = THSTensor_scatter_(Handle, dimension, index.Handle, src.Handle);
+                var res = THSTensor_scatter_(Handle, dim, index.Handle, src.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -6035,9 +6044,9 @@ namespace TorchSharp
             /// For each value in src, it is added to an index in self which is specified by its index in src for dimension != dim and by the
             /// corresponding value in index for dimension = dim.
             /// </summary>
-            public Tensor scatter_add(long dimension, Tensor index, Tensor src)
+            public Tensor scatter_add(long dim, Tensor index, Tensor src)
             {
-                var res = THSTensor_scatter_add(Handle, dimension, index.Handle, src.Handle);
+                var res = THSTensor_scatter_add(Handle, dim, index.Handle, src.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -6047,22 +6056,22 @@ namespace TorchSharp
             ///  value in src, its output index is specified by its index in src for dimension != dim and by the #
             ///  corresponding value in index for dimension = dim.
             /// </summary>
-            public Tensor scatter_add_(long dimension, Tensor index, Tensor src)
+            public Tensor scatter_add_(long dim, Tensor index, Tensor src)
             {
-                var res = THSTensor_scatter_add_(Handle, dimension, index.Handle, src.Handle);
+                var res = THSTensor_scatter_add_(Handle, dim, index.Handle, src.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_gather(IntPtr tensor, long dimension, IntPtr index);
+            extern static IntPtr THSTensor_gather(IntPtr tensor, long dim, IntPtr index);
 
             /// <summary>
             /// Gathers values along an axis specified by dim.
             /// </summary>
-            public Tensor gather(long dimension, Tensor index)
+            public Tensor gather(long dim, Tensor index)
             {
-                var res = THSTensor_gather(Handle, dimension, index.Handle);
+                var res = THSTensor_gather(Handle, dim, index.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -6073,11 +6082,11 @@ namespace TorchSharp
             /// <summary>
             ///  Reverse the order of a n-D tensor along given axis in dims.
             /// </summary>
-            public Tensor flip(params long[] sizes)
+            public Tensor flip(params long[] dims)
             {
                 unsafe {
-                    fixed (long* psizes = sizes) {
-                        var res = THSTensor_flip(Handle, (IntPtr)psizes, sizes.Length);
+                    fixed (long* psizes = dims) {
+                        var res = THSTensor_flip(Handle, (IntPtr)psizes, dims.Length);
                         if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                         return new Tensor(res);
                     }
@@ -6188,16 +6197,16 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_narrow(IntPtr tensor, long dimension, long start, long length);
+            extern static IntPtr THSTensor_narrow(IntPtr tensor, long dim, long start, long length);
 
             /// <summary>
             ///  Returns a new tensor that is a narrowed version of the input along one dimension. The
             /// dimension is input from start to start + length. The
             /// returned tensor and the input tensor share the same underlying storage.
             /// </summary>
-            public Tensor narrow(long dimension, long start, long length)
+            public Tensor narrow(long dim, long start, long length)
             {
-                var res = THSTensor_narrow(Handle, dimension, start, length);
+                var res = THSTensor_narrow(Handle, dim, start, length);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -6296,23 +6305,23 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_slice(IntPtr tensor, long dimension, long start, long length, long step);
+            extern static IntPtr THSTensor_slice(IntPtr tensor, long dim, long start, long length, long step);
 
             /// <summary>
             /// Returns a new tensor that is a sliced version of the input along one dimension. The
             /// dimension is input from start to finish-1. The
             /// returned tensor and the input tensor share the same underlying storage.
             /// </summary>
-            public Tensor slice(long dimension, long start, long finish, long step)
+            public Tensor slice(long dim, long start, long finish, long step)
             {
                 if (step < 1) throw new ArgumentException($"step is {step}, but it should always be positive.");
-                var res = THSTensor_slice(Handle, dimension, start, finish, step);
+                var res = THSTensor_slice(Handle, dim, start, finish, step);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unsqueeze(IntPtr tensor, long dimension);
+            static extern IntPtr THSTensor_unsqueeze(IntPtr tensor, long dim);
 
             /// <summary>
             ///  Returns a new tensor with a dimension of size one inserted at the specified position.
@@ -6326,7 +6335,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unsqueeze_(IntPtr tensor, long dimension);
+            static extern IntPtr THSTensor_unsqueeze_(IntPtr tensor, long dim);
 
             /// <summary>
             ///  Returns a new tensor with a dimension of size one inserted at the specified position.

--- a/src/TorchSharp/Tensor/Tensor.torch.cs
+++ b/src/TorchSharp/Tensor/Tensor.torch.cs
@@ -96,10 +96,10 @@ namespace TorchSharp
         /// Concatenates the given sequence of seq tensors in the given dimension.
         /// </summary>
         /// <param name="tensors"></param>
-        /// <param name="dimension"></param>
+        /// <param name="dim"></param>
         /// <returns></returns>
         /// <remarks> All tensors must either have the same shape (except in the concatenating dimension) or be empty.</remarks>
-        public static Tensor cat(IList<Tensor> tensors, long dimension)
+        public static Tensor cat(IList<Tensor> tensors, long dim)
         {
             if (tensors.Count == 0) {
                 throw new ArgumentException(nameof(tensors));
@@ -111,7 +111,7 @@ namespace TorchSharp
             using (var parray = new PinnedArray<IntPtr>()) {
                 IntPtr tensorsRef = parray.CreateArray(tensors.Select(p => p.Handle).ToArray());
 
-                var res = THSTensor_cat(tensorsRef, parray.Array.Length, dimension);
+                var res = THSTensor_cat(tensorsRef, parray.Array.Length, dim);
                 if (res == IntPtr.Zero)
                     torch.CheckForErrors();
                 return new Tensor(res);
@@ -205,12 +205,12 @@ namespace TorchSharp
         /// </summary>
         /// <returns></returns>
         /// <remarks>All tensors need to be of the same size.</remarks>
-        public static Tensor stack(IEnumerable<Tensor> tensors, long dimension = 0)
+        public static Tensor stack(IEnumerable<Tensor> tensors, long dim = 0)
         {
             using (var parray = new PinnedArray<IntPtr>()) {
                 IntPtr tensorsRef = parray.CreateArray(tensors.Select(p => p.Handle).ToArray());
 
-                var res = THSTensor_stack(tensorsRef, parray.Array.Length, dimension);
+                var res = THSTensor_stack(tensorsRef, parray.Array.Length, dim);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -348,18 +348,18 @@ namespace TorchSharp
         /// </summary>
         /// <param name="tensor">The input tensor</param>
         /// <param name="k">The 'k' in 'top-k'.</param>
-        /// <param name="dimension">The dimension to sort along. If dim is not given, the last dimension of the input is chosen.</param>
+        /// <param name="dim">The dimension to sort along. If dim is not given, the last dimension of the input is chosen.</param>
         /// <param name="largest">Controls whether to return largest or smallest elements</param>
         /// <param name="sorted">Controls whether to return the elements in sorted order</param>
-        public static (Tensor values, Tensor indexes) topk(Tensor tensor, int k, int dimension = -1, bool largest = true, bool sorted = true) => tensor.topk(k, dimension, largest, sorted);
+        public static (Tensor values, Tensor indexes) topk(Tensor tensor, int k, int dim = -1, bool largest = true, bool sorted = true) => tensor.topk(k, dim, largest, sorted);
 
         /// <summary>
         /// Removes a tensor dimension.
         /// </summary>
         /// <param name="tensor">The input tensor</param>
-        /// <param name="dimension">The dimension to remove.</param>
+        /// <param name="dim">The dimension to remove.</param>
         /// <returns>An array of all slices along a given dimension, already without it.</returns>
-        public static Tensor[] unbind(Tensor tensor, int dimension = 0) => tensor.unbind(dimension);
+        public static Tensor[] unbind(Tensor tensor, int dim = 0) => tensor.unbind(dim);
 
         [DllImport("LibTorchSharp")]
         extern static IntPtr THSTorch_lstsq(IntPtr input, IntPtr A, out IntPtr pQR);
@@ -383,28 +383,28 @@ namespace TorchSharp
         ///  value in src, its output index is specified by its index in src for dimension != dim and by the #
         ///  corresponding value in index for dimension = dim.
         /// </summary>
-        public static Tensor scatter(Tensor input, long dimension, Tensor index, Tensor src) => input.scatter(dimension, index, src);
+        public static Tensor scatter(Tensor input, long dim, Tensor index, Tensor src) => input.scatter(dim, index, src);
 
         /// <summary>
         ///  Writes all values from the tensor src into input at the indices specified in the index tensor. For each
         ///  value in src, its output index is specified by its index in src for dimension != dim and by the #
         ///  corresponding value in index for dimension = dim.
         /// </summary>
-        public static Tensor scatter_(Tensor input, long dimension, Tensor index, Tensor src) => input.scatter_(dimension, index, src);
+        public static Tensor scatter_(Tensor input, long dim, Tensor index, Tensor src) => input.scatter_(dim, index, src);
 
         /// <summary>
         /// Adds all values from the tensor other into input at the indices specified in the index tensor in a similar fashion as scatter_().
         /// For each value in src, it is added to an index in self which is specified by its index in src for dimension != dim and by the
         /// corresponding value in index for dimension = dim.
         /// </summary>
-        public static Tensor scatter_add(Tensor input, long dimension, Tensor index, Tensor src) => input.scatter_add(dimension, index, src);
+        public static Tensor scatter_add(Tensor input, long dim, Tensor index, Tensor src) => input.scatter_add(dim, index, src);
 
         /// <summary>
         /// Adds all values from the tensor other into input at the indices specified in the index tensor in a similar fashion as scatter_().
         /// For each value in src, it is added to an index in self which is specified by its index in src for dimension != dim and by the
         /// corresponding value in index for dimension = dim.
         /// </summary>
-        public static Tensor scatter_add_(Tensor input, long dimension, Tensor index, Tensor src) => input.scatter_add_(dimension, index, src);
+        public static Tensor scatter_add_(Tensor input, long dim, Tensor index, Tensor src) => input.scatter_add_(dim, index, src);
 
         /// <summary>
         /// Clamps all elements in input into the range [ min, max ].
@@ -451,18 +451,18 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The input tensor</param>
         /// <param name="dims">The dimension or dimensions to reduce.</param>
-        /// <param name="keepDim">Whether the output tensor has dim retained or not.</param>
+        /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
         /// <param name="out">The output tensor -- optional.</param>
-        static public Tensor amax(Tensor input, long[] dims, bool keepDim = false, Tensor @out = null) => input.amax(dims, keepDim, @out);
+        static public Tensor amax(Tensor input, long[] dims, bool keepdim = false, Tensor @out = null) => input.amax(dims, keepdim, @out);
 
         /// <summary>
         /// Returns the minimum value of each slice of the input tensor in the given dimension(s) dim.
         /// </summary>
         /// <param name="input">The input tensor</param>
         /// <param name="dims">The dimension or dimensions to reduce.</param>
-        /// <param name="keepDim">Whether the output tensor has dim retained or not.</param>
+        /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
         /// <param name="out">The output tensor -- optional.</param>
-        static public Tensor amin(Tensor input, long[] dims, bool keepDim = false, Tensor @out = null) => input.amin(dims, keepDim, @out);
+        static public Tensor amin(Tensor input, long[] dims, bool keepdim = false, Tensor @out = null) => input.amin(dims, keepdim, @out);
 
         /// <summary>
         /// Returns a tensor with the same data and number of elements as the input but with the specified shape.

--- a/src/TorchSharp/TorchAudio/Modules/Tacotron2.cs
+++ b/src/TorchSharp/TorchAudio/Modules/Tacotron2.cs
@@ -336,7 +336,7 @@ namespace TorchSharp.Modules
             public override Tensor forward(Tensor x)
             {
                 foreach (var linear in this.layers) {
-                    x = F.dropout(F.relu(linear.forward(x)), probability: 0.5, training: true);
+                    x = F.dropout(F.relu(linear.forward(x)), p: 0.5, training: true);
                 }
                 return x;
             }
@@ -610,7 +610,7 @@ namespace TorchSharp.Modules
                 (attention_hidden, attention_cell) = this.attention_rnn.forward(cell_input, (attention_hidden, attention_cell));
                 attention_hidden = F.dropout(attention_hidden, this.attention_dropout, training: this.training);
 
-                var attention_weights_cat = torch.cat(new[] { attention_weights.unsqueeze(1), attention_weights_cum.unsqueeze(1) }, dimension: 1);
+                var attention_weights_cat = torch.cat(new[] { attention_weights.unsqueeze(1), attention_weights_cum.unsqueeze(1) }, dim: 1);
                 (attention_context, attention_weights) = this.attention_layer.forward(
                     attention_hidden, memory, processed_memory, attention_weights_cat, mask);
 
@@ -620,7 +620,7 @@ namespace TorchSharp.Modules
                 (decoder_hidden, decoder_cell) = this.decoder_rnn.forward(decoder_input, (decoder_hidden, decoder_cell));
                 decoder_hidden = F.dropout(decoder_hidden, this.decoder_dropout, training: this.training);
 
-                var decoder_hidden_attention_context = torch.cat(new[] { decoder_hidden, attention_context }, dimension: 1);
+                var decoder_hidden_attention_context = torch.cat(new[] { decoder_hidden, attention_context }, dim: 1);
                 var decoder_output = this.linear_projection.forward(decoder_hidden_attention_context);
 
                 var gate_prediction = this.gate_layer.forward(decoder_hidden_attention_context);
@@ -642,7 +642,7 @@ namespace TorchSharp.Modules
             {
                 var decoder_input = this._get_initial_frame(memory).unsqueeze(0);
                 var decoder_inputs = this._parse_decoder_inputs(mel_specgram_truth);
-                decoder_inputs = torch.cat(new[] { decoder_input, decoder_inputs }, dimension: 0);
+                decoder_inputs = torch.cat(new[] { decoder_input, decoder_inputs }, dim: 0);
                 decoder_inputs = this.prenet.forward(decoder_inputs);
 
                 var mask = _get_mask_from_lengths(memory_lengths);
@@ -777,9 +777,9 @@ namespace TorchSharp.Modules
                     Debug.WriteLine("Reached max decoder steps. The generated spectrogram might not cover the whole transcript.");
                 }
 
-                var mel_specgrams = torch.cat(mel_specgram_list, dimension: 0);
-                var gate_outputs = torch.cat(gate_output_list, dimension: 0);
-                var alignments = torch.cat(alignment_list, dimension: 0);
+                var mel_specgrams = torch.cat(mel_specgram_list, dim: 0);
+                var gate_outputs = torch.cat(gate_output_list, dim: 0);
+                var alignments = torch.cat(alignment_list, dim: 0);
 
                 (mel_specgrams, gate_outputs, alignments) = this._parse_decoder_outputs(mel_specgrams, gate_outputs, alignments);
 

--- a/src/TorchSharp/TorchAudio/Modules/Wav2Vec2Components.cs
+++ b/src/TorchSharp/TorchAudio/Modules/Wav2Vec2Components.cs
@@ -1138,7 +1138,7 @@ namespace TorchSharp.Modules
             var negs = label_embeddings.unsqueeze(1).expand(-1, proj_x.size(0), -1);
             var neg_is_pos = (pos == negs).all(-1);
             pos = pos.unsqueeze(0);
-            var targets = torch.cat(new Tensor[] { pos, negs }, dimension: 0);
+            var targets = torch.cat(new Tensor[] { pos, negs }, dim: 0);
 
             var logits = torch.nn.functional.cosine_similarity(proj_x.@float(), targets.@float(), dim: -1).type_as(proj_x);
             logits /= logit_temp;

--- a/src/TorchSharp/TorchAudio/Modules/WaveRNN.cs
+++ b/src/TorchSharp/TorchAudio/Modules/WaveRNN.cs
@@ -80,8 +80,8 @@ namespace TorchSharp.Modules
             this.rnn1 = nn.GRU(n_rnn, n_rnn, batchFirst: true);
             this.rnn2 = nn.GRU(n_rnn + this.n_aux, n_rnn, batchFirst: true);
 
-            this.relu1 = nn.ReLU(inPlace: true);
-            this.relu2 = nn.ReLU(inPlace: true);
+            this.relu1 = nn.ReLU(inplace: true);
+            this.relu2 = nn.ReLU(inplace: true);
 
             this.fc1 = nn.Linear(n_rnn + this.n_aux, n_fc);
             this.fc2 = nn.Linear(n_fc + this.n_aux, n_fc);
@@ -129,22 +129,22 @@ namespace TorchSharp.Modules
             var a3 = aux[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(aux_idx[2], aux_idx[3])];
             var a4 = aux[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(aux_idx[3], aux_idx[4])];
 
-            var x = torch.cat(new Tensor[] { waveform.unsqueeze(-1), specgram, a1 }, dimension: -1);
+            var x = torch.cat(new Tensor[] { waveform.unsqueeze(-1), specgram, a1 }, dim: -1);
             x = this.fc.forward(x);
             var res = x;
             (x, _) = this.rnn1.forward(x, h1);
 
             x = x + res;
             res = x;
-            x = torch.cat(new Tensor[] { x, a2 }, dimension: -1);
+            x = torch.cat(new Tensor[] { x, a2 }, dim: -1);
             (x, _) = this.rnn2.forward(x, h2);
 
             x = x + res;
-            x = torch.cat(new Tensor[] { x, a3 }, dimension: -1);
+            x = torch.cat(new Tensor[] { x, a3 }, dim: -1);
             x = this.fc1.forward(x);
             x = this.relu1.forward(x);
 
-            x = torch.cat(new Tensor[] { x, a4 }, dimension: -1);
+            x = torch.cat(new Tensor[] { x, a4 }, dim: -1);
             x = this.fc2.forward(x);
             x = this.relu2.forward(x);
             x = this.fc3.forward(x);
@@ -193,19 +193,19 @@ namespace TorchSharp.Modules
                 var a3_t = aux_split[2][TensorIndex.Colon, TensorIndex.Colon, i];
                 var a4_t = aux_split[3][TensorIndex.Colon, TensorIndex.Colon, i];
 
-                x = torch.cat(new Tensor[] { x, m_t, a1_t }, dimension: 1);
+                x = torch.cat(new Tensor[] { x, m_t, a1_t }, dim: 1);
                 x = this.fc.forward(x);
                 (_, h1) = this.rnn1.forward(x.unsqueeze(1), h1);
 
                 x = x + h1[0];
-                var inp = torch.cat(new Tensor[] { x, a2_t }, dimension: 1);
+                var inp = torch.cat(new Tensor[] { x, a2_t }, dim: 1);
                 (_, h2) = this.rnn2.forward(inp.unsqueeze(1), h2);
 
                 x = x + h2[0];
-                x = torch.cat(new Tensor[] { x, a3_t }, dimension: 1);
+                x = torch.cat(new Tensor[] { x, a3_t }, dim: 1);
                 x = F.relu(this.fc1.forward(x));
 
-                x = torch.cat(new Tensor[] { x, a4_t }, dimension: 1);
+                x = torch.cat(new Tensor[] { x, a4_t }, dim: 1);
                 x = F.relu(this.fc2.forward(x));
 
                 var logits = this.fc3.forward(x);
@@ -231,7 +231,7 @@ namespace TorchSharp.Modules
                 this.resblock_model = nn.Sequential(
                     nn.Conv1d(inputChannel: n_freq, outputChannel: n_freq, kernelSize: 1, bias: false),
                     nn.BatchNorm1d(n_freq),
-                    nn.ReLU(inPlace: true),
+                    nn.ReLU(inplace: true),
                     nn.Conv1d(inputChannel: n_freq, outputChannel: n_freq, kernelSize: 1, bias: false),
                     nn.BatchNorm1d(n_freq));
                 RegisterComponents();
@@ -258,7 +258,7 @@ namespace TorchSharp.Modules
                 var modules = new List<nn.Module>();
                 modules.Add(nn.Conv1d(inputChannel: n_freq, outputChannel: n_hidden, kernelSize: kernel_size, bias: false));
                 modules.Add(nn.BatchNorm1d(n_hidden));
-                modules.Add(nn.ReLU(inPlace: true));
+                modules.Add(nn.ReLU(inplace: true));
                 for (int i = 0; i < n_res_block; i++) {
                     modules.Add(new ResBlock("resblock", n_hidden));
                 }

--- a/src/TorchSharp/TorchVision/Functional.cs
+++ b/src/TorchSharp/TorchVision/Functional.cs
@@ -62,7 +62,7 @@ namespace TorchSharp
                     var dtype = torch.is_floating_point(img) ? img.dtype : torch.float32;
                     using var t0 = transforms.functional.rgb_to_grayscale(img);
                     using var t1 = t0.to_type(dtype);
-                    using var mean = torch.mean(t1, new long[] { -3, -2, -1 }, keepDimension: true);
+                    using var mean = torch.mean(t1, new long[] { -3, -2, -1 }, keepdim: true);
 
                     return Blend(img, mean, contrast_factor);
                 }
@@ -243,8 +243,8 @@ namespace TorchSharp
                     var bound = input.IsIntegral() ? 255.0f : 1.0f;
                     var dtype = input.IsIntegral() ? ScalarType.Float32 : input.dtype;
 
-                    using var t0 = input.amin(new long[] { -2, -1 }, keepDim: true);
-                    using var t1 = input.amax(new long[] { -2, -1 }, keepDim: true);
+                    using var t0 = input.amin(new long[] { -2, -1 }, keepdim: true);
+                    using var t1 = input.amax(new long[] { -2, -1 }, keepdim: true);
 
                     using var minimum = t0.to(dtype);
                     using var maximum = t1.to(dtype);

--- a/src/TorchSharp/TorchVision/models/AlexNet.cs
+++ b/src/TorchSharp/TorchVision/models/AlexNet.cs
@@ -70,29 +70,29 @@ namespace TorchSharp
             {
                 features = Sequential(
                     Conv2d(3, 64, kernelSize: 11, stride: 4, padding: 2),
-                    ReLU(inPlace: true),
+                    ReLU(inplace: true),
                     MaxPool2d(kernelSize: 3, stride: 2),
                     Conv2d(64, 192, kernelSize: 5, padding: 2),
-                    ReLU(inPlace: true),
+                    ReLU(inplace: true),
                     MaxPool2d(kernelSize: 3, stride: 2),
                     Conv2d(192, 384, kernelSize: 3, padding: 1),
-                    ReLU(inPlace: true),
+                    ReLU(inplace: true),
                     Conv2d(384, 256, kernelSize: 3, padding: 1),
-                    ReLU(inPlace: true),
+                    ReLU(inplace: true),
                     Conv2d(256, 256, kernelSize: 3, padding: 1),
-                    ReLU(inPlace: true),
+                    ReLU(inplace: true),
                     MaxPool2d(kernelSize: 3, stride: 2)
                 );
 
                 avgpool = AdaptiveAvgPool2d(new long[] { 6, 6 });
 
                 classifier = Sequential(
-                    Dropout(probability: dropout),
+                    Dropout(p: dropout),
                     Linear(256 * 6 * 6, 4096),
-                    ReLU(inPlace: true),
-                    Dropout(probability: dropout),
+                    ReLU(inplace: true),
+                    Dropout(p: dropout),
                     Linear(4096, 4096),
-                    ReLU(inPlace: true),
+                    ReLU(inplace: true),
                     Linear(4096, numClasses)
                 );
 

--- a/src/TorchSharp/TorchVision/models/GoogleNet.cs
+++ b/src/TorchSharp/TorchVision/models/GoogleNet.cs
@@ -129,7 +129,7 @@ namespace TorchSharp
                 //aux2 = inception_aux_block(528, numClasses, dropout_aux);
 
                 avgpool = nn.AdaptiveAvgPool2d((1, 1));
-                this.dropout = nn.Dropout(probability: dropout);
+                this.dropout = nn.Dropout(p: dropout);
                 fc = nn.Linear(1024, numClasses);
 
                 RegisterComponents();
@@ -302,7 +302,7 @@ namespace TorchSharp
                     conv = conv_block(in_channels, 128, kernel_size: 1);
                     fc1 = nn.Linear(2048, 1024);
                     fc2 = nn.Linear(1024, num_classes);
-                    this.dropout = nn.Dropout(probability: dropout);
+                    this.dropout = nn.Dropout(p: dropout);
 
                     RegisterComponents();
                 }
@@ -317,7 +317,7 @@ namespace TorchSharp
                     x = torch.flatten(x);
                     // N x 2048
                     // Adaptive average pooling
-                    x = functional.relu(fc1.forward(x), inPlace:true);
+                    x = functional.relu(fc1.forward(x), inplace:true);
                     // N x 1024
                     x = dropout.forward(x);
                     // N x 1024

--- a/src/TorchSharp/TorchVision/models/InceptionV3.cs
+++ b/src/TorchSharp/TorchVision/models/InceptionV3.cs
@@ -124,7 +124,7 @@ namespace TorchSharp
                 Mixed_7b = inception_e(1280);
                 Mixed_7c = inception_e(2048);
                 avgpool = nn.AdaptiveAvgPool2d((1, 1));
-                this.dropout = nn.Dropout(probability: dropout);
+                this.dropout = nn.Dropout(p: dropout);
                 fc = nn.Linear(2048, numClasses);
 
                 RegisterComponents();

--- a/src/TorchSharp/TorchVision/models/ResNet.cs
+++ b/src/TorchSharp/TorchVision/models/ResNet.cs
@@ -322,7 +322,7 @@ namespace TorchSharp
 
                 conv1 = Conv2d(3, 64, kernelSize: 7, stride: 2, padding: 3, bias: false);
                 bn1 = BatchNorm2d(64);
-                relu = ReLU(inPlace: true);
+                relu = ReLU(inplace: true);
                 maxpool = MaxPool2d(kernelSize: 3, stride: 2, padding: 1);
                 MakeLayer(layer1, block, expansion, 64, num_blocks[0], 1);
                 MakeLayer(layer2, block, expansion, 128, num_blocks[1], 2);
@@ -396,7 +396,7 @@ namespace TorchSharp
 
                     conv1 = Conv2d(in_planes, planes, kernelSize: 3, stride: stride, padding: 1, bias: false);
                     bn1 = BatchNorm2d(planes);
-                    relu1 = ReLU(inPlace: true);
+                    relu1 = ReLU(inplace: true);
                     conv2 = Conv2d(planes, planes, kernelSize: 3, stride: 1, padding: 1, bias: false);
                     bn2 = BatchNorm2d(planes);
 
@@ -438,10 +438,10 @@ namespace TorchSharp
 
                     conv1 = Conv2d(in_planes, planes, kernelSize: 1, bias: false);
                     bn1 = BatchNorm2d(planes);
-                    relu1 = ReLU(inPlace: true);
+                    relu1 = ReLU(inplace: true);
                     conv2 = Conv2d(planes, planes, kernelSize: 3, stride: stride, padding: 1, bias: false);
                     bn2 = BatchNorm2d(planes);
-                    relu2 = ReLU(inPlace: true);
+                    relu2 = ReLU(inplace: true);
                     conv3 = Conv2d(planes, expansion * planes, kernelSize: 1, bias: false);
                     bn3 = BatchNorm2d(expansion * planes);
 

--- a/src/TorchSharp/TorchVision/models/VGG.cs
+++ b/src/TorchSharp/TorchVision/models/VGG.cs
@@ -362,7 +362,7 @@ namespace TorchSharp
                         if (batch_norm) {
                             layers.Add(BatchNorm2d(channels[i]));
                         }
-                        layers.Add(ReLU(inPlace: true));
+                        layers.Add(ReLU(inplace: true));
                         in_channels = channels[i];
                     }
                 }
@@ -374,10 +374,10 @@ namespace TorchSharp
                 classifier = Sequential(
                     Linear(512 * 7 * 7, 4096),
                     ReLU(true),
-                    Dropout(probability: dropout),
+                    Dropout(p: dropout),
                     Linear(4096, 4096),
                     ReLU(true),
-                    Dropout(probability: dropout),
+                    Dropout(p: dropout),
                     Linear(4096, numClasses)
                     );
 

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -2839,8 +2839,8 @@ namespace TorchSharp
 
         private Tensor NormalizeTensor(Tensor x, long[] dim, double eps = 1e-5)
         {
-            var x_mean = torch.mean(x, dimensions: dim, keepDimension: true);
-            var x_var = torch.var(x, unbiased: false, dimensions: dim, keepDimension: true);
+            var x_mean = torch.mean(x, dimensions: dim, keepdim: true);
+            var x_var = torch.var(x, unbiased: false, dimensions: dim, keepdim: true);
             return NormalizeTensor(x, x_mean, x_var, eps);
         }
 
@@ -3252,7 +3252,7 @@ namespace TorchSharp
         [Fact]
         public void TestDropoutInPlace()
         {
-            var drop = Dropout(0.75, inPlace: true);
+            var drop = Dropout(0.75, inplace: true);
             var data = torch.rand(new long[] { 12, 23, 24 });
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
@@ -3278,7 +3278,7 @@ namespace TorchSharp
         [Fact]
         public void TestDropout2dInPlace()
         {
-            var drop = Dropout2d(0.75, inPlace: true);
+            var drop = Dropout2d(0.75, inplace: true);
             var data = torch.rand(new long[] { 12, 23, 24, 5 });
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);
@@ -3304,7 +3304,7 @@ namespace TorchSharp
         [Fact]
         public void TestDropout3dInPlace()
         {
-            var drop = Dropout3d(0.75, inPlace: true);
+            var drop = Dropout3d(0.75, inplace: true);
             var data = torch.rand(new long[] { 12, 23, 24, 5, 6 });
             var output = drop.forward(data);
             Assert.Equal(data.shape, output.shape);

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -5030,9 +5030,9 @@ namespace TorchSharp
             var a = torch.randn(new long[] { 15, 5 });
             var b = a.argmax();
             Assert.Equal(1, b.NumberOfElements);
-            var c = a.argmax(0, keepDim: true);
+            var c = a.argmax(0, keepdim: true);
             Assert.Equal(new long[] { 1, 5 }, c.shape);
-            var d = a.argmax(0, keepDim: false);
+            var d = a.argmax(0, keepdim: false);
             Assert.Equal(new long[] { 5 }, d.shape);
         }
 
@@ -5054,9 +5054,9 @@ namespace TorchSharp
             var a = torch.randn(new long[] { 15, 5 });
             var b = a.argmin();
             Assert.Equal(1, b.NumberOfElements);
-            var c = a.argmin(0, keepDim: true);
+            var c = a.argmin(0, keepdim: true);
             Assert.Equal(new long[] { 1, 5 }, c.shape);
-            var d = a.argmin(0, keepDim: false);
+            var d = a.argmin(0, keepdim: false);
             Assert.Equal(new long[] { 5 }, d.shape);
         }
 
@@ -5078,7 +5078,7 @@ namespace TorchSharp
             var a = torch.randn(new long[] { 15, 5, 4, 3 });
             var b = a.amax(0, 1);
             Assert.Equal(new long[] { 4, 3 }, b.shape);
-            var c = a.amax(new long[] { 0, 1 }, keepDim: true);
+            var c = a.amax(new long[] { 0, 1 }, keepdim: true);
             Assert.Equal(new long[] { 1, 1, 4, 3 }, c.shape);
         }
 
@@ -5089,7 +5089,7 @@ namespace TorchSharp
             var a = torch.randn(new long[] { 15, 5, 4, 3 });
             var b = a.amin(0, 1);
             Assert.Equal(new long[] { 4, 3 }, b.shape);
-            var c = a.amin(new long[] { 0, 1 }, keepDim: true);
+            var c = a.amin(new long[] { 0, 1 }, keepdim: true);
             Assert.Equal(new long[] { 1, 1, 4, 3 }, c.shape);
         }
 
@@ -5101,7 +5101,7 @@ namespace TorchSharp
             var b = a.aminmax(0);
             Assert.Equal(new long[] { 5, 4, 3 }, b.min.shape);
             Assert.Equal(new long[] { 5, 4, 3 }, b.max.shape);
-            var c = a.aminmax(0, keepDim: true);
+            var c = a.aminmax(0, keepdim: true);
             Assert.Equal(new long[] { 1, 5, 4, 3 }, c.min.shape);
             Assert.Equal(new long[] { 1, 5, 4, 3 }, c.max.shape);
         }
@@ -5913,7 +5913,7 @@ namespace TorchSharp
                 Assert.Equal(new long[] { 10, 10 }, std.shape);
             }
             {
-                var std = torch.std(data, 1, keepDimension: true);
+                var std = torch.std(data, 1, keepdim: true);
                 Assert.NotNull(std);
                 Assert.Equal(new long[] { 10, 1, 10 }, std.shape);
             }
@@ -5947,7 +5947,7 @@ namespace TorchSharp
                 Assert.Equal(new long[] { 10, 10 }, mean.shape);
             }
             {
-                var (std, mean) = torch.std_mean(data, 1, keepDimension: true);
+                var (std, mean) = torch.std_mean(data, 1, keepdim: true);
                 Assert.NotNull(std);
                 Assert.NotNull(mean);
                 Assert.Equal(new long[] { 10, 1, 10 }, std.shape);
@@ -5993,7 +5993,7 @@ namespace TorchSharp
                 Assert.Equal(new long[] { 10, 10 }, mean.shape);
             }
             {
-                var (@var, mean) = torch.var_mean(data, 1, keepDimension: true);
+                var (@var, mean) = torch.var_mean(data, 1, keepdim: true);
                 Assert.NotNull(@var);
                 Assert.NotNull(mean);
                 Assert.Equal(new long[] { 10, 1, 10 }, @var.shape);
@@ -6242,10 +6242,10 @@ namespace TorchSharp
         {
             var t = torch.tensor(new int[] { 10, 30, 20, 60, 40, 50 }).reshape(2, 3);
             var max_idx = t.argmax();
-            var sort_idx = t.argsort(dimension: 1);
+            var sort_idx = t.argsort(dim: 1);
 
             var x = t.take_along_dim(max_idx);
-            var y = t.take_along_dim(sort_idx, dimension: 1);
+            var y = t.take_along_dim(sort_idx, dim: 1);
 
             Assert.Equal(60, x.item<int>());
             Assert.Equal(new int[] { 10, 20, 30, 40, 50, 60 }, y.data<int>().ToArray());
@@ -7891,7 +7891,7 @@ namespace TorchSharp
         public void AdjustHueTensor()
         {
             {
-                using var input = torch.stack(new Tensor[] { torch.zeros(1, 2, 2), torch.ones(1, 2, 2), torch.zeros(1, 2, 2) }, dimension: -3);
+                using var input = torch.stack(new Tensor[] { torch.zeros(1, 2, 2), torch.ones(1, 2, 2), torch.zeros(1, 2, 2) }, dim: -3);
                 {
                     var poster = torchvision.transforms.functional.adjust_hue(input, 0.0);
 

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -528,7 +528,7 @@ namespace TorchSharp
                 this.stack = Sequential(
                     Conv1d(in_channels, out_channels, 3, stride: stride, padding: padding, bias: false),
                     temp,
-                    ReLU(inPlace: true)
+                    ReLU(inplace: true)
                 );
 
                 temp.weight = Parameter(torch.randn(temp.weight.shape));
@@ -625,7 +625,7 @@ namespace TorchSharp
                 seq = Sequential(
                     conv,
                     batch,
-                    ReLU(inPlace: true)
+                    ReLU(inplace: true)
                 );
 
                 this.RegisterComponents();

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -1746,11 +1746,11 @@ namespace TorchSharp
 
             var seq = Sequential(
                 ("conv1", conv1),
-                ("r1", ReLU(inPlace: true)),
+                ("r1", ReLU(inplace: true)),
                 ("drop1", Dropout(0.1)),
                 ("flat1", Flatten()),
                 ("lin1", lin1),
-                ("r2", ReLU(inPlace: true)),
+                ("r2", ReLU(inplace: true)),
                 ("lin2", lin2));
 
             var x = torch.randn(new long[] { 64, 3, 28, 28 });
@@ -1774,11 +1774,11 @@ namespace TorchSharp
 
                 using (var seq = Sequential(
                         ("conv1", conv1),
-                        ("r1", ReLU(inPlace: true)),
+                        ("r1", ReLU(inplace: true)),
                         ("drop1", Dropout(0.1)),
                         ("flat1", Flatten()),
                         ("lin1", lin1),
-                        ("r2", ReLU(inPlace: true)),
+                        ("r2", ReLU(inplace: true)),
                         ("lin2", lin2))) {
 
                     seq.to((Device)device);


### PR DESCRIPTION
There were several instances of parameter names that were internally inconsistent as well as inconsistent with PyTorch. The fix will break existing code that passes such parameters by name.