### PR TITLE
Add `torch.nn.Hardswish()` and `torch.nn.functional.hardswish()`

### DIFF
--- a/src/TorchSharp/NN/Activation/GLU.cs
+++ b/src/TorchSharp/NN/Activation/GLU.cs
@@ -45,7 +45,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="dim">the dimension on which to split the input. Default: -1</param>
             /// <returns></returns>
-            static public GLU GLU(int dim = -1)
+            static public GLU GLU(long dim = -1)
             {
                 var handle = THSNN_GLU_ctor(dim, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -60,7 +60,7 @@ namespace TorchSharp
                 /// <param name="input">The input tensor</param>
                 /// <param name="dim">the dimension on which to split the input. Default: -1</param>
                 /// <returns></returns>
-                static public Tensor glu(Tensor input, int dim = -1)
+                static public Tensor glu(Tensor input, long dim = -1)
                 {
                     using (var m = nn.GLU(dim)) {
                         return m.forward(input);

--- a/src/TorchSharp/NN/Activation/GLU.cs
+++ b/src/TorchSharp/NN/Activation/GLU.cs
@@ -57,13 +57,13 @@ namespace TorchSharp
                 /// <summary>
                 /// The gated linear unit function.
                 /// </summary>
+                /// <param name="input">The input tensor</param>
                 /// <param name="dim">the dimension on which to split the input. Default: -1</param>
-                /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor glu(Tensor x, int dim = -1)
+                static public Tensor glu(Tensor input, int dim = -1)
                 {
                     using (var m = nn.GLU(dim)) {
-                        return m.forward(x);
+                        return m.forward(input);
                     }
                 }
             }

--- a/src/TorchSharp/NN/Activation/Hardsigmoid.cs
+++ b/src/TorchSharp/NN/Activation/Hardsigmoid.cs
@@ -13,15 +13,16 @@ namespace TorchSharp
         /// </summary>
         public class Hardsigmoid : torch.nn.Module
         {
+            private readonly bool inplace;
+
             internal Hardsigmoid(bool inplace = false) : base(nameof(Hardsigmoid))
             {
                 this.inplace = inplace;
             }
-            private bool inplace;
 
             public override Tensor forward(Tensor tensor)
             {
-                return inplace ? tensor.hardsigmoid_() : tensor.hardsigmoid();
+                return torch.nn.functional.hardsigmoid(tensor, this.inplace);
             }
 
             public override string GetName()
@@ -50,14 +51,12 @@ namespace TorchSharp
                 /// <summary>
                 /// Hardsigmoid
                 /// </summary>
-                /// <param name="x">The input tensor</param>
+                /// <param name="input">The input tensor</param>
                 /// <param name="inplace">Do the operation in-place</param>
                 /// <returns></returns>
-                static public Tensor Hardsigmoid(Tensor x, bool inplace = false)
+                public static Tensor hardsigmoid(Tensor input, bool inplace = false)
                 {
-                    using (var m = nn.Hardsigmoid(inplace)) {
-                        return m.forward(x);
-                    }
+                    return inplace ? input.hardsigmoid_() : input.hardsigmoid();
                 }
             }
         }

--- a/src/TorchSharp/NN/Activation/Hardswish.cs
+++ b/src/TorchSharp/NN/Activation/Hardswish.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+
+using static TorchSharp.torch;
+
+namespace TorchSharp
+{
+    using Modules;
+
+    namespace Modules
+    {
+        /// <summary>
+        /// This class is used to represent a Hardswish module.
+        /// </summary>
+        public class Hardswish : torch.nn.Module
+        {
+            private readonly bool inplace;
+
+            internal Hardswish(bool inplace = false) : base(nameof(Hardswish))
+            {
+                this.inplace = inplace;
+            }
+
+            public override Tensor forward(Tensor tensor)
+            {
+                return this.inplace ? tensor.hardswish_() : tensor.hardswish();
+            }
+
+            public override string GetName()
+            {
+                return typeof(Hardswish).Name;
+            }
+        }
+    }
+
+    public static partial class torch
+    {
+        public static partial class nn
+        {
+            /// <summary>
+            /// Applies the Hardswish function, element-wise, as described in the paper:
+            /// `Searching for MobileNetV3 https://arxiv.org/abs/1905.02244`.
+            /// </summary>
+            /// <param name="inplace">Do the operation in-place</param>
+            /// <returns></returns>
+            static public Hardswish Hardswish(bool inplace = false)
+            {
+                return new Hardswish(inplace);
+            }
+
+            public static partial class functional
+            {
+                /// <summary>
+                /// Applies the Hardswish function, element-wise, as described in the paper:
+                /// `Searching for MobileNetV3 https://arxiv.org/abs/1905.02244`.
+                /// </summary>
+                /// <param name="input">The input tensor</param>
+                /// <param name="inplace">Do the operation in-place</param>
+                /// <returns></returns>
+                static public Tensor hardswish(Tensor input, bool inplace = false)
+                {
+                    using (var m = nn.Hardswish(inplace)) {
+                        return m.forward(input);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/TorchSharp/NN/Activation/Hardswish.cs
+++ b/src/TorchSharp/NN/Activation/Hardswish.cs
@@ -22,7 +22,7 @@ namespace TorchSharp
 
             public override Tensor forward(Tensor tensor)
             {
-                return this.inplace ? tensor.hardswish_() : tensor.hardswish();
+                return torch.nn.functional.hardswish(tensor, this.inplace);
             }
 
             public override string GetName()
@@ -42,7 +42,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="inplace">Do the operation in-place</param>
             /// <returns></returns>
-            static public Hardswish Hardswish(bool inplace = false)
+            public static Hardswish Hardswish(bool inplace = false)
             {
                 return new Hardswish(inplace);
             }
@@ -56,11 +56,9 @@ namespace TorchSharp
                 /// <param name="input">The input tensor</param>
                 /// <param name="inplace">Do the operation in-place</param>
                 /// <returns></returns>
-                static public Tensor hardswish(Tensor input, bool inplace = false)
+                public static Tensor hardswish(Tensor input, bool inplace = false)
                 {
-                    using (var m = nn.Hardswish(inplace)) {
-                        return m.forward(input);
-                    }
+                    return inplace ? input.hardswish_() : input.hardswish();
                 }
             }
         }

--- a/src/TorchSharp/NN/Activation/LeakyReLU.cs
+++ b/src/TorchSharp/NN/Activation/LeakyReLU.cs
@@ -43,12 +43,12 @@ namespace TorchSharp
             /// <summary>
             /// Continuously Differentiable Exponential Linear Unit
             /// </summary>
-            /// <param name="negativeSlope">The α value for the LeakyReLU formulation. Default: 1.0</param>
-            /// <param name="inplace">Do the operation in-place. Default: False</param>
+            /// <param name="negative_slope">The α value for the LeakyReLU formulation.</param>
+            /// <param name="inplace">Do the operation in-place.</param>
             /// <returns></returns>
-            static public LeakyReLU LeakyReLU(double negativeSlope = 1.0, bool inplace = false)
+            static public LeakyReLU LeakyReLU(double negative_slope = 0.01, bool inplace = false)
             {
-                var handle = THSNN_LeakyReLU_ctor(negativeSlope, inplace, out var boxedHandle);
+                var handle = THSNN_LeakyReLU_ctor(negative_slope, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new LeakyReLU(handle, boxedHandle);
             }
@@ -58,14 +58,14 @@ namespace TorchSharp
                 /// <summary>
                 /// Continuously Differentiable Exponential Linear Unit
                 /// </summary>
-                /// <param name="x">The input tensor</param>
-                /// <param name="negativeSlope">The α value for the LeakyReLU formulation. Default: 1.0</param>
+                /// <param name="input">The input tensor</param>
+                /// <param name="negative_slope">The α value for the LeakyReLU formulation. Default: 1.0</param>
                 /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor leaky_relu(Tensor x, double negativeSlope, bool inplace = false)
+                static public Tensor leaky_relu(Tensor input, double negative_slope = 0.01, bool inplace = false)
                 {
-                    using (var m = nn.LeakyReLU(negativeSlope, inplace)) {
-                        return m.forward(x);
+                    using (var m = nn.LeakyReLU(negative_slope, inplace)) {
+                        return m.forward(input);
                     }
                 }
             }

--- a/src/TorchSharp/NN/Shuffle/ChannelShuffle.cs
+++ b/src/TorchSharp/NN/Shuffle/ChannelShuffle.cs
@@ -42,7 +42,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="groups">The number of groups to divide channels in.</param>
             /// <returns></returns>
-            static public ChannelShuffle ChannelShuffle(long groups)
+            public static ChannelShuffle ChannelShuffle(long groups)
             {
                 return new ChannelShuffle(groups);
             }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -422,7 +422,7 @@ namespace TorchSharp
             var input = torch.randn(new long[] { 8, 8, 8 });
             var output = rel.forward(input);
             var values = output.data<float>().ToArray();
-            Assert.Equal(input.shape, new long[] { 8, 8, 8 });
+            Assert.Equal(output.shape, new long[] { 8, 8, 8 });
         }
 
         [Fact]
@@ -432,7 +432,17 @@ namespace TorchSharp
             var input = torch.randn(new long[] { 8, 8, 8 });
             var output = rel.forward(input);
             var values = output.data<float>().ToArray();
-            Assert.Equal(input.shape, new long[] { 8, 8, 8 });
+            Assert.Equal(output.shape, new long[] { 8, 8, 8 });
+        }
+
+        [Fact]
+        public void EvaluateHardswish()
+        {
+            var rel = Hardswish();
+            var input = torch.from_array(new float[] { -3.5f, 0.6f, 3.25f });
+            var output = rel.forward(input);
+            var values = output.data<float>().ToArray();
+            Assert.Equal(new float[] { 0f, 0.36f, 3.25f }, values);
         }
 
         [Fact]
@@ -442,7 +452,7 @@ namespace TorchSharp
             var input = torch.randn(new long[] { 8, 8, 8 });
             var output = rel.forward(input);
             var values = output.data<float>().ToArray();
-            Assert.Equal(input.shape, new long[] { 8, 8, 8 });
+            Assert.Equal(output.shape, new long[] { 8, 8, 8 });
         }
 
         [Fact]


### PR DESCRIPTION
- Add torch.nn.Hardswish() and torch.nn.functional.hardswish()
- `torch.nn.functional.glu(): fix type of `dim`.
- `torch.nn.functional.hardsigmoid(): Call Tensor.hardsigmoid directly.
- `torch.nn.functional.hardsigmoid(): Uncapitalize function name
- `torch.nn.functional.leaky_relu(): Wrong default value of negative_slope. https://pytorch.org/docs/stable/generated/torch.nn.functional.leaky_relu.html#torch.nn.functional.leaky_relu
- `ChannelShuffle.cs` moved as it is not an activation function.