### PR TITLE
Align loss functions with PyTorch's APIs.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,25 +2,32 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
-## NuGet Version 0.97.7
+## NuGet Version 0.98.0
 
 __Breaking Changes:__
 
 Some parameter names were changed to align with PyTorch. This affects names like 'dimension,' 'probability,' and 'keepDims' and will break code that is passing these parameters by name.
 
 Module.to(), cpu(), and cuda() were moved to a static class for extension methods. This means that it is necessary to have a 'using TorchSharp;' (C#) or 'open TorchSharp' (F#) in each file using them.
+
 Doing so (rather than qualifying names with 'TorchSharp.') was already recommended as a best practice, since such a using/open directive will allows qualified names to align with the PyTorch module hierarchy.
+
+__Loss functions are now aligned with the PyTorch APIs.__ This is a major change and the reason for incrementing the minor version number. The most direct consequence is that losses are modules rather than delegates, which means you need to call .forward() to actually compute the loss. Also, the factories are in torch.nn rather than torch.nn.functional and have the same Pascal-case names as the corresponding types. The members of the torch.nn.functional static class are now proper immediate loss functions, whereas the previous ones returned a loss delegate.
 
 __Fixed Bugs:__
 
+#558 Fix deviation from the Pytorch loss function/module APIs<br/>
 #742 Ease of use: Module.to method should be generic T -> T<br/>
 #743 Ease of use: module factories should have dtype and device<br/>
 #744 Some of functions with inconsistent argument names<br/>
 #749 functional.linear is wrong<br/>
+#761 Stateful optimizers should have support for save/load from disk.
 
 __API Changes__:
 
 Module.to(), cpu(), and cuda() were redone as extension methods. The virtual methods to override, if necessary, are now named '_to'. A need to do so should be extremely rare.<br/>
+Support for saving and restoring hyperparameters and state of optimizers<br/>
+
 
 ## NuGet Version 0.97.6
 

--- a/src/Examples/AdversarialExampleGeneration.cs
+++ b/src/Examples/AdversarialExampleGeneration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.IO;
+using TorchSharp.Modules;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn.functional;
 using static TorchSharp.torch.utils.data;
@@ -97,7 +98,7 @@ namespace TorchSharp.Examples
 
             foreach (var ε in epsilons) {
                 using (var test = torchvision.datasets.MNIST(datasetPath, false, true, normImage)) {
-                    var attacked = Test(model, nll_loss(), ε, device, test, test.Count);
+                    var attacked = Test(model, torch.nn.NLLLoss(), ε, device, test, test.Count);
                     Console.WriteLine($"Epsilon: {ε:F2}, accuracy: {attacked:P2}");
                 }
             }
@@ -129,7 +130,7 @@ namespace TorchSharp.Examples
                     data.requires_grad = true;
 
                     using (var output = model.forward(data))
-                    using (var loss = criterion(output, label)) {
+                    using (var loss = criterion.forward(output, label)) {
 
                         model.zero_grad();
                         loss.backward();

--- a/src/Examples/CIFAR10.cs
+++ b/src/Examples/CIFAR10.cs
@@ -116,8 +116,8 @@ namespace TorchSharp.Examples
                         Stopwatch epchSW = new Stopwatch();
                         epchSW.Start();
 
-                        Train(model, optimizer, nll_loss(), train, epoch, _trainBatchSize, train_data.Count);
-                        Test(model, nll_loss(), test, test_data.Count);
+                        Train(model, optimizer, torch.nn.NLLLoss(), train, epoch, _trainBatchSize, train_data.Count);
+                        Test(model, torch.nn.NLLLoss(), test, test_data.Count);
 
                         epchSW.Stop();
                         Console.WriteLine($"Elapsed time for this epoch: {epchSW.Elapsed.TotalSeconds} s.");
@@ -159,7 +159,7 @@ namespace TorchSharp.Examples
                     var target = data["label"];
                     var prediction = model.forward(data["data"]);
                     var lsm = log_softmax(prediction, 1);
-                    var output = loss(lsm, target);
+                    var output = loss.forward(lsm, target);
 
                     output.backward();
 
@@ -200,7 +200,7 @@ namespace TorchSharp.Examples
                     var target = data["label"];
                     var prediction = model.forward(data["data"]);
                     var lsm = log_softmax(prediction, 1);
-                    var output = loss(lsm, target);
+                    var output = loss.forward(lsm, target);
 
                     testLoss += output.ToSingle();
                     batchCount += 1;

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -81,8 +81,8 @@ namespace TorchSharp.Examples
 
                 using (var d = torch.NewDisposeScope()) {
 
-                    Train(model, optimizer, nll_loss(reduction: Reduction.Mean), train, epoch, train_data.Count);
-                    Test(model, nll_loss(reduction: torch.nn.Reduction.Sum), test, test_data.Count);
+                    Train(model, optimizer, torch.nn.NLLLoss(reduction: Reduction.Mean), train, epoch, train_data.Count);
+                    Test(model, torch.nn.NLLLoss(reduction: torch.nn.Reduction.Sum), test, test_data.Count);
 
                     Console.WriteLine($"End-of-epoch memory use: {GC.GetTotalMemory(false)}");
                     scheduler.step();
@@ -170,7 +170,7 @@ namespace TorchSharp.Examples
 
                     var target = data["label"];
                     var prediction = model.forward(data["data"]);
-                    var output = loss(prediction, target);
+                    var output = loss.forward(prediction, target);
 
                     output.backward();
 
@@ -204,7 +204,7 @@ namespace TorchSharp.Examples
 
                 foreach (var data in dataLoader) {
                     var prediction = model.forward(data["data"]);
-                    var output = loss(prediction, data["label"]);
+                    var output = loss.forward(prediction, data["label"]);
                     testLoss += output.ToSingle();
 
                     var pred = prediction.argmax(1);

--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -75,7 +75,7 @@ namespace TorchSharp.Examples
             var ntokens = vocab.Count;
 
             var model = new TransformerModel(ntokens, emsize, nhead, nhid, nlayers, dropout).to((Device)device);
-            var loss = cross_entropy_loss();
+            var loss = CrossEntropyLoss();
             var lr = 2.50;
             var optimizer = torch.optim.SGD(model.parameters(), lr);
             var scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 1, 0.95, last_epoch: 15);
@@ -130,7 +130,7 @@ namespace TorchSharp.Examples
                     }
 
                     using (var output = model.forward(data, src_mask)) {
-                        var loss = criterion(output.view(-1, ntokens), targets);
+                        var loss = criterion.forward(output.view(-1, ntokens), targets);
                         loss.backward();
                         torch.nn.utils.clip_grad_norm_(model.parameters().ToArray(), 0.5);
                         optimizer.step();
@@ -168,7 +168,7 @@ namespace TorchSharp.Examples
                         src_mask = model.GenerateSquareSubsequentMask(data.shape[0]);
                     }
                     using (var output = model.forward(data, src_mask)) {
-                        var loss = criterion(output.view(-1, ntokens), targets);
+                        var loss = criterion.forward(output.view(-1, ntokens), targets);
                         total_loss += data.shape[0] * loss.to(torch.CPU).item<float>();
                     }
 

--- a/src/Examples/SpeechCommands.cs
+++ b/src/Examples/SpeechCommands.cs
@@ -104,8 +104,8 @@ namespace TorchSharp.Examples
                 sw.Start();
 
                 for (var epoch = 1; epoch <= _epochs; epoch++) {
-                    Train(model, transform, optimizer, nll_loss(reduction: torch.nn.Reduction.Mean), train_loader, epoch, train_data.Count);
-                    Test(model, transform, nll_loss(reduction: torch.nn.Reduction.Sum), test_loader, test_data.Count);
+                    Train(model, transform, optimizer, torch.nn.NLLLoss(reduction: torch.nn.Reduction.Mean), train_loader, epoch, train_data.Count);
+                    Test(model, transform, torch.nn.NLLLoss(reduction: torch.nn.Reduction.Sum), test_loader, test_data.Count);
 
                     Console.WriteLine($"End-of-epoch memory use: {GC.GetTotalMemory(false)}");
                     scheduler.step();
@@ -140,7 +140,7 @@ namespace TorchSharp.Examples
                     var audio = transform.forward(batch.audio);
                     var target = batch.label;
                     var output = model.forward(batch.audio).squeeze();
-                    var loss = criteria(output, target);
+                    var loss = criteria.forward(output, target);
                     optimizer.zero_grad();
                     loss.backward();
                     optimizer.step();
@@ -175,7 +175,7 @@ namespace TorchSharp.Examples
                     var audio = transform.forward(batch.audio);
                     var target = batch.label;
                     var output = model.forward(batch.audio).squeeze();
-                    var loss = criteria(output, target);
+                    var loss = criteria.forward(output, target);
                     testLoss += loss.ToSingle();
 
                     var pred = output.argmax(1);

--- a/src/Examples/TextClassification.cs
+++ b/src/Examples/TextClassification.cs
@@ -65,7 +65,7 @@ namespace TorchSharp.Examples
 
                 var model = new TextClassificationModel(vocab.Count, emsize, 4).to((Device)device);
 
-                var loss = cross_entropy_loss();
+                var loss = CrossEntropyLoss();
                 var lr = 5.0;
                 var optimizer = torch.optim.SGD(model.parameters(), lr);
                 var scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 1, 0.2, last_epoch: 5);
@@ -127,7 +127,7 @@ namespace TorchSharp.Examples
 
                 using (var predicted_labels = model.forward(texts, offsets)) {
 
-                    var loss = criterion(predicted_labels, labels);
+                    var loss = criterion.forward(predicted_labels, labels);
                     loss.backward();
                     torch.nn.utils.clip_grad_norm_(model.parameters().ToArray(), 0.5);
                     optimizer.step();
@@ -155,7 +155,7 @@ namespace TorchSharp.Examples
             foreach (var (labels, texts, offsets) in test_data) {
 
                 using (var predicted_labels = model.forward(texts, offsets)) {
-                    var loss = criterion(predicted_labels, labels);
+                    var loss = criterion.forward(predicted_labels, labels);
 
                     total_acc += (predicted_labels.argmax(1) == labels).sum().to(torch.CPU).item<long>();
                     total_count += labels.size(0);

--- a/src/FSharp.Examples/AdversarialExampleGeneration.fs
+++ b/src/FSharp.Examples/AdversarialExampleGeneration.fs
@@ -52,7 +52,8 @@ let hasCUDA = TorchText.Datasets.cuda_is_available() //torch.cuda.is_available()
 
 let device = if hasCUDA then torch.CUDA else torch.CPU
 
-let criterion x y = functional.nll_loss().Invoke(x,y)
+let _loss = torch.nn.NLLLoss()
+let criterion x y = _loss.forward(x,y)
 
 let attack (image:torch.Tensor) (eps:Scalar) (data_grad:torch.Tensor) =
     use sign = data_grad.sign()

--- a/src/FSharp.Examples/AlexNet.fs
+++ b/src/FSharp.Examples/AlexNet.fs
@@ -84,7 +84,8 @@ type Model(name,device:torch.Device) as this =
 
         classifier.forward(x)
 
-let loss x y = functional.nll_loss().Invoke(x,y)
+let _loss = torch.nn.NLLLoss()
+let loss x y = _loss.forward(x,y)
 
 let train (model:Model) (optimizer:Optimizer) (dataLoader:DataLoader) epoch (size:int64) =
 

--- a/src/FSharp.Examples/MNIST.fs
+++ b/src/FSharp.Examples/MNIST.fs
@@ -74,7 +74,8 @@ type Model(name,device:torch.Device) as this =
         --> fc1 --> relu --> dropout2 --> fc2
         --> logsm
 
-let loss x y = functional.nll_loss(reduction=Reduction.Mean).Invoke(x,y)
+let _loss = torch.nn.NLLLoss(reduction=Reduction.Mean)
+let loss x y = _loss.forward(x,y)
 
 let train (model:Model) (optimizer:Optimizer) (data: Dataset) epoch =
     model.train()

--- a/src/FSharp.Examples/SequenceToSequence.fs
+++ b/src/FSharp.Examples/SequenceToSequence.fs
@@ -49,7 +49,8 @@ let hasCUDA = TorchText.Datasets.cuda_is_available() //torch.cuda.is_available()
 
 let device = if hasCUDA then torch.CUDA else torch.CPU
 
-let criterion x y = functional.cross_entropy_loss(reduction=Reduction.Mean).Invoke(x,y)
+let loss = torch.nn.CrossEntropyLoss(reduction=Reduction.Mean)
+let criterion x y = loss.forward(x,y)
 
 type PositionalEncoding(dmodel, maxLen) as this =
     inherit Module("PositionalEncoding")

--- a/src/FSharp.Examples/TextClassification.fs
+++ b/src/FSharp.Examples/TextClassification.fs
@@ -42,7 +42,8 @@ let hasCUDA = TorchText.Datasets.cuda_is_available() //torch.cuda.is_available()
 
 let device = if hasCUDA then torch.CUDA else torch.CPU
 
-let criterion x y = functional.cross_entropy_loss().Invoke(x,y)
+let loss = torch.nn.CrossEntropyLoss()
+let criterion x y = loss.forward(x,y)
 
 type TextClassificationModel(vocabSize, embedDim, nClasses, device:torch.Device) as this =
     inherit Module("Transformer")

--- a/src/Native/LibTorchSharp/THSLoss.cpp
+++ b/src/Native/LibTorchSharp/THSLoss.cpp
@@ -147,7 +147,7 @@ Tensor THSNN_smooth_l1_loss(const Tensor input, const Tensor target, const int64
         auto opts = torch::nn::functional::SmoothL1LossFuncOptions();
         ApplyReduction(opts, reduction);
 
-        res = ResultTensor(torch::nn::functional::smooth_l1_loss(*input, *target, opts));
+        res = ResultTensor(torch::nn::functional::smooth_l1_loss(*input, *target, opts, beta));
     )
 }
 

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -758,7 +758,7 @@ namespace TorchSharp
     {
         using static torch.nn.functional;
 
-        public class CrossEntropyLoss : WeightedLoss
+        public sealed class CrossEntropyLoss : WeightedLoss
         {
             public CrossEntropyLoss(Tensor? weight = null, long? ignore_index = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
             {
@@ -776,7 +776,7 @@ namespace TorchSharp
             public long? ignore_index { get; }
         }
 
-        public class BCELoss : WeightedLoss
+        public sealed class BCELoss : WeightedLoss
         {
             public BCELoss(Tensor? weight = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
             {
@@ -790,7 +790,7 @@ namespace TorchSharp
             }
         }
 
-        public class BCEWithLogitsLoss : WeightedLoss
+        public sealed class BCEWithLogitsLoss : WeightedLoss
         {
             public BCEWithLogitsLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean, Tensor? pos_weights = null) : base(weight, reduction)
             {
@@ -807,7 +807,7 @@ namespace TorchSharp
             public Tensor? pos_weights { get; }
         }
 
-        public class CosineEmbeddingLoss : Loss
+        public sealed class CosineEmbeddingLoss : Loss
         {
             public CosineEmbeddingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -824,7 +824,7 @@ namespace TorchSharp
             public double margin { get; }
         }
 
-        public class CTCLoss : Loss
+        public sealed class CTCLoss : Loss
         {
             public CTCLoss(long blank = 0, bool zero_infinity = false, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -843,7 +843,7 @@ namespace TorchSharp
             public bool zero_infinity { get; }
         }
 
-        public class HingeEmbeddingLoss : Loss
+        public sealed class HingeEmbeddingLoss : Loss
         {
             public HingeEmbeddingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -860,7 +860,7 @@ namespace TorchSharp
             public double margin { get; }
         }
 
-        public class HuberLoss : Loss
+        public sealed class HuberLoss : Loss
         {
             public HuberLoss(double delta = 1.0, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -877,7 +877,7 @@ namespace TorchSharp
             public double delta { get; }
         }
 
-        public class MarginRankingLoss : Loss
+        public sealed class MarginRankingLoss : Loss
         {
             public MarginRankingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -894,7 +894,7 @@ namespace TorchSharp
             public double margin { get; }
         }
 
-        public class MultiLabelMarginLoss : Loss
+        public sealed class MultiLabelMarginLoss : Loss
         {
             public MultiLabelMarginLoss(Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -908,7 +908,7 @@ namespace TorchSharp
             }
         }
 
-        public class MultiLabelSoftMarginLoss : WeightedLoss
+        public sealed class MultiLabelSoftMarginLoss : WeightedLoss
         {
             public MultiLabelSoftMarginLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
             {
@@ -922,7 +922,7 @@ namespace TorchSharp
             }
         }
 
-        public class MultiMarginLoss : WeightedLoss
+        public sealed class MultiMarginLoss : WeightedLoss
         {
             public MultiMarginLoss(int p = 1, double margin = 1.0, Tensor? weight = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
             {
@@ -943,7 +943,7 @@ namespace TorchSharp
             public int p { get; }
         }
 
-        public class MSELoss : Loss
+        public sealed class MSELoss : Loss
         {
             public MSELoss(Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -957,7 +957,7 @@ namespace TorchSharp
             }
         }
 
-        public class L1Loss : Loss
+        public sealed class L1Loss : Loss
         {
             public L1Loss(Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -971,7 +971,7 @@ namespace TorchSharp
             }
         }
 
-        public class NLLLoss : WeightedLoss
+        public sealed class NLLLoss : WeightedLoss
         {
             public NLLLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
             {
@@ -985,7 +985,7 @@ namespace TorchSharp
             }
         }
 
-        public class PoissonNLLLoss : Loss
+        public sealed class PoissonNLLLoss : Loss
         {
             public PoissonNLLLoss(bool log_input = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -1007,7 +1007,7 @@ namespace TorchSharp
 
         }
 
-        public class GaussianNLLLoss : Loss
+        public sealed class GaussianNLLLoss : Loss
         {
             public GaussianNLLLoss(bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -1043,7 +1043,7 @@ namespace TorchSharp
 
         }
 
-        public class KLDivLoss : Loss
+        public sealed class KLDivLoss : Loss
         {
             public KLDivLoss(bool log_target = true, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -1060,7 +1060,7 @@ namespace TorchSharp
             public bool log_target { get; }
         }
 
-        public class SmoothL1Loss : Loss
+        public sealed class SmoothL1Loss : Loss
         {
             public SmoothL1Loss(Reduction reduction = Reduction.Mean, double beta = 1.0) : base(reduction)
             {
@@ -1077,7 +1077,7 @@ namespace TorchSharp
             public double beta { get; }
         }
 
-        public class SoftMarginLoss : Loss
+        public sealed class SoftMarginLoss : Loss
         {
             public SoftMarginLoss(Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -1091,7 +1091,7 @@ namespace TorchSharp
             }
         }
 
-        public class TripletMarginLoss : Loss
+        public sealed class TripletMarginLoss : Loss
         {
             public TripletMarginLoss(double margin = 1.0, long p = 2, double eps = 1e-06, bool swap = false, Reduction reduction = Reduction.Mean) : base(reduction)
             {
@@ -1114,7 +1114,7 @@ namespace TorchSharp
             bool swap { get; }
         }
 
-        public class TripletMarginWithDistanceLoss : Loss
+        public sealed class TripletMarginWithDistanceLoss : Loss
         {
             public TripletMarginWithDistanceLoss(Func<Tensor, Tensor, Tensor>? distance = null, double margin = 1.0, bool swap = false, Reduction reduction = Reduction.Mean) : base(reduction)
             {

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -2,59 +2,256 @@
 using System;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+using static TorchSharp.torch.nn.functional;
 
 #nullable enable
 
 namespace TorchSharp
 {
-    public delegate Tensor Loss(Tensor source, Tensor target);
+    using Modules;
+
+    public class Loss : nn.Module
+    {
+        public Loss(torch.nn.Reduction reduction = nn.Reduction.Mean) : base(nameof(Loss))
+        {
+            this.reduction = reduction;
+        }
+
+        public torch.nn.Reduction reduction { get; }
+    }
+    public class WeightedLoss : Loss
+    {
+        public WeightedLoss(Tensor? weight = null, torch.nn.Reduction reduction = nn.Reduction.Mean) : base(reduction)
+        {
+            this.weight = weight;
+        }
+
+        public Tensor? weight { get; }
+    }
 
     public static partial class torch
     {
         public static partial class nn
         {
             /// <summary>
+            /// This criterion combines log_softmax and nll_loss in a single function.
+            /// </summary>
+            /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+            /// <param name="ignore_index">Specifies a target value that is ignored and does not contribute to the input gradient.</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static Modules.CrossEntropyLoss CrossEntropyLoss(Tensor? weight = null, long? ignore_index = null, Reduction reduction = Reduction.Mean)
+            {
+                return new Modules.CrossEntropyLoss(weight, ignore_index, reduction);
+            }
+
+            /// <summary>
+            /// Measures the Binary Cross Entropy between the target and the output.
+            /// </summary>
+            /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static Modules.BCELoss BCELoss(Tensor? weight = null, Reduction reduction = Reduction.Mean)
+            {
+                return new Modules.BCELoss(weight, reduction);
+            }
+
+            /// <summary>
+            /// Measures Binary Cross Entropy between target and output logits.
+            /// </summary>
+            /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <param name="pos_weights">A weight of positive examples. Must be a vector with length equal to the number of classes.</param>
+            /// <returns></returns>
+            public static Modules.BCEWithLogitsLoss BCEWithLogitsLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean, Tensor? pos_weights = null)
+            {
+                return new Modules.BCEWithLogitsLoss(weight, reduction, pos_weights);
+            }
+
+            /// <summary>
+            /// Measures the loss given two input tensor and a lable tensor with values 1 or -1.
+            ///
+            /// See: https://pytorch.org/docs/stable/generated/torch.nn.CosineEmbeddingLoss.html#torch.nn.CosineEmbeddingLoss
+            /// </summary>
+            /// <param name="margin"> Should be a number from -1 to 1, 0 to 0.5 is suggested</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static Modules.CosineEmbeddingLoss CosineEmbeddingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean)
+            {
+                return new Modules.CosineEmbeddingLoss(margin, reduction);
+            }
+
+
+            /// <summary>
+            /// The Connectionist Temporal Classification loss.
+            ///
+            /// Calculates loss between a continuous (unsegmented) time series and a target sequence.
+            /// CTCLoss sums over the probability of possible alignments of input to target, producing a
+            /// loss value which is differentiable with respect to each input node. The alignment of input to
+            /// target is assumed to be “many-to-one”, which limits the length of the target sequence such that
+            /// it must be less than the input length.
+            /// </summary>
+            /// <returns></returns>
+            public static Modules.CTCLoss CTCLoss(long blank = 0, bool zero_infinity = false, Reduction reduction = Reduction.Mean)
+            {
+                return new Modules.CTCLoss(blank, zero_infinity, reduction);
+            }
+
+            /// <summary>
+            /// Measures the loss given an input tensor x and a labels tensor y (containing 1 or -1).
+            ///
+            /// See: https://pytorch.org/docs/stable/generated/torch.nn.HingeEmbeddingLoss.html#torch.nn.HingeEmbeddingLoss
+            /// </summary>
+            /// <param name="margin"> Should be a number from -1 to 1, 0 to 0.5 is suggested</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static Modules.HingeEmbeddingLoss HingeEmbeddingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean)
+            {
+                return new Modules.HingeEmbeddingLoss(margin, reduction);
+            }
+
+            /// <summary>
+            /// Creates a criterion that uses a squared term if the absolute element-wise error falls below delta and a delta-scaled L1 term otherwise.
+            ///
+            /// See: https://pytorch.org/docs/stable/generated/torch.nn.HuberLoss.html#torch.nn.HuberLoss
+            /// </summary>
+            /// <param name="delta">Specifies the threshold at which to change between delta-scaled L1 and L2 loss. The value must be positive. Default: 1.0</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static Modules.HuberLoss HuberLoss(double delta = 1.0, Reduction reduction = Reduction.Mean)
+            {
+                return new Modules.HuberLoss(delta, reduction);
+            }
+
+            public static Modules.MarginRankingLoss MarginRankingLoss(double margin = 0, Reduction reduction = Reduction.Mean)
+            {
+                return new Modules.MarginRankingLoss(margin, reduction);
+            }
+
+            public static MultiLabelSoftMarginLoss MultiLabelSoftMarginLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean)
+            {
+                return new MultiLabelSoftMarginLoss(weight, reduction);
+            }
+
+            public static MultiMarginLoss MultiMarginLoss(int p = 1, double margin = 1.0, Tensor? weight = null, Reduction reduction = Reduction.Mean)
+            {
+                return new MultiMarginLoss(p, margin, weight, reduction);
+            }
+
+            /// <summary>
+            /// Measures the element-wise mean squared error.
+            /// </summary>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static MSELoss MSELoss(Reduction reduction = Reduction.Mean)
+            {
+                return new MSELoss(reduction);
+            }
+
+            /// <summary>
+            /// Function that takes the mean element-wise absolute value difference.
+            /// </summary>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static L1Loss L1Loss(Reduction reduction = Reduction.Mean)
+            {
+                return new L1Loss(reduction);
+            }
+
+            /// <summary>
+            /// The negative log likelihood loss.
+            /// </summary>
+            /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static NLLLoss NLLLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean)
+            {
+                return new NLLLoss(weight, reduction);
+            }
+
+            /// <summary>
+            /// Poisson negative log likelihood loss.
+            /// </summary>
+            /// <param name="log_input"></param>
+            /// <param name="full">Whether to compute full loss, i. e. to add the Stirling approximation term.</param>
+            /// <param name="eps">Small value to avoid evaluation of log(0)</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static PoissonNLLLoss PoissonNLLLoss(bool log_input = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
+            {
+                return new PoissonNLLLoss(log_input, full, eps, reduction);
+            }
+
+            /// <summary>
+             /// The Kullback-Leibler divergence Loss
+             /// </summary>
+             /// <param name="log_target">A flag indicating whether target is passed in the log space.</param>
+             /// <param name="reduction">Specifies the reduction to apply to the output</param>
+             /// <returns></returns>
+            public static KLDivLoss KLDivLoss(bool log_target = true, Reduction reduction = Reduction.Mean)
+            {
+                return new KLDivLoss(log_target, reduction);
+            }
+
+            /// <summary>
+            /// Optimizes a two-class classification logistic loss between input tensor xx and target tensor yy (containing 1 or -1).
+            /// </summary>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static SoftMarginLoss SoftMarginLoss(Reduction reduction = Reduction.Mean)
+            {
+                return new SoftMarginLoss(reduction);
+            }
+
+            public static TripletMarginLoss TripletMarginLoss(double margin = 1.0, long p = 2, double eps = 1e-06, bool swap = false, Reduction reduction = Reduction.Mean)
+            {
+                return new TripletMarginLoss(margin, p, eps, swap, reduction);
+            }
+
+            public static TripletMarginWithDistanceLoss TripletMarginWithDistanceLoss(Func<Tensor, Tensor, Tensor>? distance = null, double margin = 1.0, bool swap = false, Reduction reduction = Reduction.Mean)
+            {
+                return new TripletMarginWithDistanceLoss(distance, margin, swap, reduction);
+            }
+
+            /// <summary>
+            /// Gaussian negative log likelihood loss.
+            /// </summary>
+            /// <param name="full">Include the constant term in the loss calculation</param>
+            /// <param name="eps">Value used to clamp var (see note below), for stability.</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static GaussianNLLLoss GaussianNLLLoss(bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
+            {
+                return new GaussianNLLLoss(full, eps, reduction);
+            }
+
+
+            public static MultiLabelMarginLoss MultiLabelMarginLoss(Reduction reduction = Reduction.Mean)
+            {
+                return new MultiLabelMarginLoss(reduction);
+            }
+
+            /// <summary>
+            /// Function that uses a squared term if the absolute element-wise error falls below beta and an L1 term otherwise.
+            /// </summary>
+            /// <param name="beta">Specifies the threshold at which to change between L1 and L2 loss. The value must be non-negative. Default: 1.0</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
+            public static SmoothL1Loss SmoothL1Loss(Reduction reduction = Reduction.Mean, double beta = 1.0)
+            {
+                return new SmoothL1Loss(reduction, beta);
+            }
+            /// <summary>
             /// Class maintaing the supported loss functions.
             /// </summary>
             public static partial class functional
             {
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long ignore_index, bool hasII, long reduction);
-
-                /// <summary>
-                /// This criterion combines log_softmax and nll_loss in a single function.
-                /// </summary>
-                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
-                /// <param name="ignore_index">Specifies a target value that is ignored and does not contribute to the input gradient.</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss cross_entropy_loss(Tensor? weight = null, long? ignore_index = null, Reduction reduction = Reduction.Mean)
+                public static Tensor binary_cross_entropy_with_logits(Tensor input, Tensor target, Tensor? weight = null, Reduction reduction = Reduction.Mean, Tensor? posWeights = null)
                 {
-                    return (Tensor src, Tensor target) => {
-                        var ii = ignore_index.HasValue ? ignore_index.Value : -100;
-                        var res = THSNN_cross_entropy(src.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, ii, ignore_index.HasValue, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_binary_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
-
-                /// <summary>
-                /// Measures the Binary Cross Entropy between the target and the output.
-                /// </summary>
-                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss binary_cross_entropy_loss(Tensor? weight = null, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor src, Tensor target) => {
-                        var res = THSNN_binary_cross_entropy(src.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
+                    var res = THSNN_binary_cross_entropy_with_logits(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction, posWeights?.Handle ?? IntPtr.Zero);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
                 }
 
                 public static Tensor binary_cross_entropy(Tensor src, Tensor target, Tensor? weight = null, Reduction reduction = Reduction.Mean)
@@ -64,382 +261,70 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_binary_cross_entropy_with_logits(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction, IntPtr posWeights);
-
-                /// <summary>
-                /// Measures Binary Cross Entropy between target and output logits.
-                /// </summary>
-                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <param name="posWeights">A weight of positive examples. Must be a vector with length equal to the number of classes.</param>
-                /// <returns></returns>
-                public static Loss binary_cross_entropy_with_logits_loss(Tensor? weight = null, Reduction reduction = Reduction.Mean, Tensor? posWeights = null)
-                {
-                    return (Tensor src, Tensor target) => {
-                        var res = THSNN_binary_cross_entropy_with_logits(src.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction, posWeights?.Handle ?? IntPtr.Zero);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                public static Tensor binary_cross_entropy_with_logits(Tensor input, Tensor target, Tensor? weight = null, Reduction reduction = Reduction.Mean, Tensor? posWeights = null)
-                {
-                    var res = THSNN_binary_cross_entropy_with_logits(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction, posWeights?.Handle ?? IntPtr.Zero);
-                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new Tensor(res);
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_cosine_embedding_loss(IntPtr input1, IntPtr input2, IntPtr trgt, double margin, long reduction);
-
-                /// <summary>
-                /// Measures the loss given two input tensor and a lable tensor with values 1 or -1.
-                ///
-                /// See: https://pytorch.org/docs/stable/generated/torch.nn.CosineEmbeddingLoss.html#torch.nn.CosineEmbeddingLoss
-                /// </summary>
-                /// <param name="margin"> Should be a number from -1 to 1, 0 to 0.5 is suggested</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static TwoInputLoss cosine_embedding_loss(double margin = 0.0, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor input1, Tensor input2, Tensor target) => {
-                        var res = THSNN_cosine_embedding_loss(input1.Handle, input2.Handle, target.Handle, margin, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                public delegate Tensor TwoInputLoss(Tensor input1, Tensor input2, Tensor target);
-
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_ctc_loss(IntPtr log_probs, IntPtr targets, IntPtr input_lengths, IntPtr target_lengths, long blank, bool zero_infinity, long reduction);
-
-                /// <summary>
-                /// The Connectionist Temporal Classification loss.
-                ///
-                /// Calculates loss between a continuous (unsegmented) time series and a target sequence.
-                /// CTCLoss sums over the probability of possible alignments of input to target, producing a
-                /// loss value which is differentiable with respect to each input node. The alignment of input to
-                /// target is assumed to be “many-to-one”, which limits the length of the target sequence such that
-                /// it must be less than the input length.
-                /// </summary>
-                /// <returns></returns>
-                public static CTCLoss ctc_loss(long blank = 0, bool zeroInfinity = false, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths) => {
-                        var res = THSNN_ctc_loss(log_probs.Handle, targets.Handle, input_lengths.Handle, target_lengths.Handle, blank, zeroInfinity, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                public delegate Tensor CTCLoss(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths);
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_hinge_embedding_loss(IntPtr input, IntPtr trgt, double margin, long reduction);
-
-                /// <summary>
-                /// Measures the loss given an input tensor x and a labels tensor y (containing 1 or -1).
-                ///
-                /// See: https://pytorch.org/docs/stable/generated/torch.nn.HingeEmbeddingLoss.html#torch.nn.HingeEmbeddingLoss
-                /// </summary>
-                /// <param name="margin"> Should be a number from -1 to 1, 0 to 0.5 is suggested</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss hinge_embedding_loss(double margin = 0.0, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor input, Tensor target) => {
-                        var res = THSNN_hinge_embedding_loss(input.Handle, target.Handle, margin, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_huber_loss(IntPtr input, IntPtr trgt, double delta, long reduction);
-
-                /// <summary>
-                /// Creates a criterion that uses a squared term if the absolute element-wise error falls below delta and a delta-scaled L1 term otherwise.
-                ///
-                /// See: https://pytorch.org/docs/stable/generated/torch.nn.HuberLoss.html#torch.nn.HuberLoss
-                /// </summary>
-                /// <param name="delta">Specifies the threshold at which to change between delta-scaled L1 and L2 loss. The value must be positive. Default: 1.0</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss huber_loss(double delta = 1.0, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor input, Tensor target) => {
-                        var res = THSNN_huber_loss(input.Handle, target.Handle, delta, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_margin_ranking_loss(IntPtr input1, IntPtr input2, IntPtr target, double margin, long reduction);
-
-                public static TwoInputLoss margin_ranking_loss(double margin = 0, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor input1, Tensor input2, Tensor target) => {
-                        var res = THSNN_margin_ranking_loss(input1.Handle, input2.Handle, target.Handle, margin, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_multilabel_margin_loss(IntPtr input, IntPtr target, long reduction);
-
-                public static Loss multilabel_margin_loss(Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor input, Tensor target) => {
-                        var res = THSNN_multilabel_margin_loss(input.Handle, target.Handle, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_multilabel_soft_margin_loss(IntPtr input, IntPtr target, IntPtr weight, long reduction);
-
-                public static Loss multilabel_soft_margin_loss(Tensor? weight = null, Reduction reduction = Reduction.Mean)
-                {
-                    IntPtr h = (weight is null) ? IntPtr.Zero : weight.Handle;
-
-                    return (Tensor input, Tensor target) => {
-                        var res = THSNN_multilabel_soft_margin_loss(input.Handle, target.Handle, h, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_multi_margin_loss(IntPtr input, IntPtr target, long p, double margin, IntPtr weight, long reduction);
-
-                public static Loss multi_margin_loss(int p = 1, double margin = 1.0, Tensor? weight = null, Reduction reduction = Reduction.Mean)
-                {
-                    IntPtr h = (weight is null) ? IntPtr.Zero : weight.Handle;
-
-                    return (Tensor input, Tensor target) => {
-                        var res = THSNN_multi_margin_loss(input.Handle, target.Handle, p, margin, h, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_mse_loss(IntPtr srct, IntPtr trgt, long reduction);
-
-                /// <summary>
-                /// Measures the element-wise mean squared error.
-                /// </summary>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss mse_loss(Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor src, Tensor target) => {
-                        var res = THSNN_mse_loss(src.Handle, target.Handle, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_l1_loss(IntPtr srct, IntPtr trgt, long reduction);
-
-                /// <summary>
-                /// Function that takes the mean element-wise absolute value difference.
-                /// </summary>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss l1_loss(Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor src, Tensor target) => {
-                        var res = THSNN_l1_loss(src.Handle, target.Handle, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_nll_loss(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
-
-                /// <summary>
-                /// The negative log likelihood loss.
-                /// </summary>
-                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss nll_loss(Tensor? weight = null, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor src, Tensor target) => {
-                        var res = THSNN_nll_loss(src.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_poisson_loss(IntPtr srct, IntPtr trgt, bool logInput, bool full, float eps, long reduction);
-
-                /// <summary>
-                /// Poisson negative log likelihood loss.
-                /// </summary>
-                /// <param name="logInput"></param>
-                /// <param name="full">Whether to compute full loss, i. e. to add the Stirling approximation term.</param>
-                /// <param name="eps">Small value to avoid evaluation of log(0)</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss poisson_loss(bool logInput = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor src, Tensor target) => {
-                        var res = THSNN_poisson_loss(src.Handle, target.Handle, logInput, full, eps, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_kl_div_loss(IntPtr input, IntPtr target, long reduction, bool logTarget);
-
-                /// <summary>
-                /// The Kullback-Leibler divergence Loss
-                /// </summary>
-                /// <param name="logTarget">A flag indicating whether target is passed in the log space.</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss kl_div_loss(bool logTarget = true, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor src, Tensor target) => {
-                        var res = THSNN_kl_div_loss(src.Handle, target.Handle, (long)reduction, logTarget);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_smooth_l1_loss(IntPtr srct, IntPtr trgt, long reduction, double beta);
-
-                /// <summary>
-                /// Function that uses a squared term if the absolute element-wise error falls below beta and an L1 term otherwise.
-                /// </summary>
-                /// <param name="logInput"></param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss smooth_l1_loss(bool logInput = true, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor src, Tensor target) => {
-                        // Currently, the 'beta' parameter is being ignored by the native layer, so we just pass the default.
-                        var res = THSNN_smooth_l1_loss(src.Handle, target.Handle, (long)reduction, 1.0);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_soft_margin_loss(IntPtr srct, IntPtr trgt, long reduction);
-
-                /// <summary>
-                /// Optimizes a two-class classification logistic loss between input tensor xx and target tensor yy (containing 1 or -1).
-                /// </summary>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static Loss soft_margin_loss(Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor src, Tensor target) => {
-                        var res = THSNN_soft_margin_loss(src.Handle, target.Handle, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_triplet_margin_loss(IntPtr anchor, IntPtr positive, IntPtr negative, double margin, long p, double eps, bool swap, long reduction);
-
-                public static TripletMarginLoss triplet_margin_loss(double margin = 1.0, long p = 2, double eps = 1e-06, bool swap = false, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor anchor, Tensor positive, Tensor negative) => {
-                        var res = THSNN_triplet_margin_loss(anchor.Handle, positive.Handle, negative.Handle, margin, p, eps, swap, (long)reduction);
-                        if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                        return new Tensor(res);
-                    };
-                }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_triplet_margin_with_distance_loss(IntPtr anchor, IntPtr positive, IntPtr negative, DistanceFunctionNative? distance_function, double margin, bool swap, long reduction);
-
-                public static TripletMarginLoss triplet_margin_with_distance_loss(Func<Tensor, Tensor, Tensor>? distance = null, double margin = 1.0, bool swap = false, Reduction reduction = Reduction.Mean)
-                {
-                    if (distance != null) {
-                        return (Tensor anchor, Tensor positive, Tensor negative) => {
-                            DistanceFunctionNative func = (IntPtr x, IntPtr y) => {
-                                var x1 = new Tensor(x);
-                                var y1 = new Tensor(y);
-                                var res = distance(x1, y1);
-
-                                GC.SuppressFinalize(x1);
-                                GC.SuppressFinalize(y1);
-                                GC.SuppressFinalize(res);
-
-                                return res.Handle;
-                            };
-                            var res = THSNN_triplet_margin_with_distance_loss(anchor.Handle, positive.Handle, negative.Handle, func, margin, swap, (long)reduction);
-                            if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                            return new Tensor(res);
-                        };
-                    } else {
-                        return (Tensor anchor, Tensor positive, Tensor negative) => {
-                            var res = THSNN_triplet_margin_with_distance_loss(anchor.Handle, positive.Handle, negative.Handle, null, margin, swap, (long)reduction);
-                            if (res == IntPtr.Zero) { torch.CheckForErrors(); }
-                            return new Tensor(res);
-                        };
-                    }
-
-                }
-
-                public delegate Tensor TripletMarginLoss(Tensor anchor, Tensor positive, Tensor negative);
-
-                /// <summary>
-                /// Gaussian negative log likelihood loss.
-                /// </summary>
-                /// <param name="full">Include the constant term in the loss calculation</param>
-                /// <param name="eps">Value used to clamp var (see note below), for stability.</param>
-                /// <param name="reduction">Specifies the reduction to apply to the output</param>
-                /// <returns></returns>
-                public static GaussianNLLLoss gaussian_nll_loss(bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
-                {
-                    return (Tensor input, Tensor target, Tensor variance) => {
-                        input = input.view(input.shape[0], -1);
-                        target = target.view(target.shape[0], -1);
-                        if (target.shape == input.shape) throw new ArgumentException("input and target must have the same shape");
-
-                        variance = variance.view(target.shape[0], -1);
-                        if (variance.shape[1] != input.shape[1] && variance.shape[1] != 1) throw new ArgumentException("variance has the wrong shape");
-
-                        if ((variance < 0).any().cpu().item<bool>()) throw new ArgumentException("variance has negative entry/entries");
-
-                        using (var _ = torch.no_grad())
-                            variance = variance.clamp_min(eps);
-
-                        var loss = 0.5 * (variance.log() + (input - target).square() / variance).view(input.shape[0], -1).sum(dim: stackalloc long[] { 1 });
-
-                        if (full) {
-                            loss = loss + 0.5 * input.shape[1] * MathF.Log(2 * MathF.PI);
-                        }
-
-                        return (reduction == Reduction.Mean) ? loss.mean() : (reduction == Reduction.Sum) ? loss.sum() : loss;
-                    };
-                }
-
-                public delegate Tensor GaussianNLLLoss(Tensor source, Tensor target, Tensor variance);
-
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                 public delegate IntPtr DistanceFunctionNative(IntPtr x, IntPtr y);
 
+                #region External functions
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long ignore_index, bool hasII, long reduction);
 
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_binary_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_binary_cross_entropy_with_logits(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction, IntPtr posWeights);
+                
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_cosine_embedding_loss(IntPtr input1, IntPtr input2, IntPtr trgt, double margin, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_ctc_loss(IntPtr log_probs, IntPtr targets, IntPtr input_lengths, IntPtr target_lengths, long blank, bool zero_infinity, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_hinge_embedding_loss(IntPtr input, IntPtr trgt, double margin, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_huber_loss(IntPtr input, IntPtr trgt, double delta, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_margin_ranking_loss(IntPtr input1, IntPtr input2, IntPtr target, double margin, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_multilabel_margin_loss(IntPtr input, IntPtr target, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_multilabel_soft_margin_loss(IntPtr input, IntPtr target, IntPtr weight, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_multi_margin_loss(IntPtr input, IntPtr target, long p, double margin, IntPtr weight, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_mse_loss(IntPtr srct, IntPtr trgt, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_l1_loss(IntPtr srct, IntPtr trgt, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_nll_loss(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_poisson_loss(IntPtr srct, IntPtr trgt, bool logInput, bool full, float eps, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_kl_div_loss(IntPtr input, IntPtr target, long reduction, bool logTarget);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_smooth_l1_loss(IntPtr srct, IntPtr trgt, long reduction, double beta);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_soft_margin_loss(IntPtr srct, IntPtr trgt, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_triplet_margin_loss(IntPtr anchor, IntPtr positive, IntPtr negative, double margin, long p, double eps, bool swap, long reduction);
+
+                [DllImport("LibTorchSharp")]
+                internal static extern IntPtr THSNN_triplet_margin_with_distance_loss(IntPtr anchor, IntPtr positive, IntPtr negative, DistanceFunctionNative? distance_function, double margin, bool swap, long reduction);
+                #endregion
             }
 
             public enum Reduction : long
@@ -448,6 +333,402 @@ namespace TorchSharp
                 Mean = 1,
                 Sum = 2
             }
+        }
+    }
+
+    namespace Modules
+    {
+        using static torch.nn.functional;
+
+        public class CrossEntropyLoss : WeightedLoss
+        {
+            public CrossEntropyLoss(Tensor? weight = null, long? ignore_index = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
+            {
+                this.ignore_index = ignore_index;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var ii = ignore_index.HasValue ? ignore_index.Value : -100;
+                var res = THSNN_cross_entropy(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, ii, ignore_index.HasValue, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public long? ignore_index { get; }
+        }
+
+        public class BCELoss : WeightedLoss
+        {
+            public BCELoss(Tensor? weight = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
+            {
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_binary_cross_entropy(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+        }
+
+        public class BCEWithLogitsLoss : WeightedLoss
+        {
+            public BCEWithLogitsLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean, Tensor? pos_weights = null) : base(weight, reduction)
+            {
+                this.pos_weights = pos_weights;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_binary_cross_entropy_with_logits(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction, pos_weights?.Handle ?? IntPtr.Zero);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public Tensor? pos_weights { get; }
+        }
+
+        public class CosineEmbeddingLoss : Loss
+        {
+            public CosineEmbeddingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.margin = margin;
+            }
+
+            public override Tensor forward(Tensor input1, Tensor input2, Tensor target)
+            {
+                var res = THSNN_cosine_embedding_loss(input1.Handle, input2.Handle, target.Handle, margin, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public double margin { get; }
+        }
+
+        public class CTCLoss : Loss
+        {
+            public CTCLoss(long blank = 0, bool zero_infinity = false, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.blank = blank;
+                this.zero_infinity = zero_infinity;
+            }
+
+            public Tensor forward(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths)
+            {
+                var res = THSNN_ctc_loss(log_probs.Handle, targets.Handle, input_lengths.Handle, target_lengths.Handle, blank, zero_infinity, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public long blank { get; }
+            public bool zero_infinity { get; }
+        }
+
+        public class HingeEmbeddingLoss : Loss
+        {
+            public HingeEmbeddingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.margin = margin;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_hinge_embedding_loss(input.Handle, target.Handle, margin, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public double margin { get; }
+        }
+
+        public class HuberLoss : Loss
+        {
+            public HuberLoss(double delta = 1.0, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.delta = delta;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_huber_loss(input.Handle, target.Handle, delta, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public double delta { get; }
+        }
+
+        public class MarginRankingLoss : Loss
+        {
+            public MarginRankingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.margin = margin;
+            }
+
+            public override Tensor forward(Tensor input1, Tensor input2, Tensor target)
+            {
+                var res = THSNN_margin_ranking_loss(input1.Handle, input2.Handle, target.Handle, margin, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public double margin { get; }
+        }
+
+        public class MultiLabelMarginLoss : Loss
+        {
+            public MultiLabelMarginLoss(Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_multilabel_margin_loss(input.Handle, target.Handle, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+        }
+
+        public class MultiLabelSoftMarginLoss : WeightedLoss
+        {
+            public MultiLabelSoftMarginLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
+            {
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_multilabel_soft_margin_loss(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+        }
+
+        public class MultiMarginLoss : WeightedLoss
+        {
+            public MultiMarginLoss(int p = 1, double margin = 1.0, Tensor? weight = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
+            {
+                this.margin = margin;
+                this.p = p;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                IntPtr h = (weight is null) ? IntPtr.Zero : weight.Handle;
+
+                var res = THSNN_multi_margin_loss(input.Handle, target.Handle, p, margin, h, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public double margin { get; }
+            public int p { get; }
+        }
+
+        public class MSELoss : Loss
+        {
+            public MSELoss(Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_mse_loss(input.Handle, target.Handle, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+        }
+
+        public class L1Loss : Loss
+        {
+            public L1Loss(Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_l1_loss(input.Handle, target.Handle, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+        }
+
+        public class NLLLoss : WeightedLoss
+        {
+            public NLLLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean) : base(weight, reduction)
+            {
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_nll_loss(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+        }
+
+        public class PoissonNLLLoss : Loss
+        {
+            public PoissonNLLLoss(bool log_input = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.full = full;
+                this.log_input = log_input;
+                this.eps = eps;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_poisson_loss(input.Handle, target.Handle, log_input, full, eps, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public bool log_input { get; }
+            public bool full { get; }
+            public float eps { get; }
+
+        }
+
+        public class GaussianNLLLoss : Loss
+        {
+            public GaussianNLLLoss(bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.full = full;
+                this.eps = eps;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target, Tensor variance)
+            {
+                input = input.view(input.shape[0], -1);
+                target = target.view(target.shape[0], -1);
+                if (target.shape == input.shape) throw new ArgumentException("input and target must have the same shape");
+
+                variance = variance.view(target.shape[0], -1);
+                if (variance.shape[1] != input.shape[1] && variance.shape[1] != 1) throw new ArgumentException("variance has the wrong shape");
+
+                if ((variance < 0).any().cpu().item<bool>()) throw new ArgumentException("variance has negative entry/entries");
+
+                using (var _ = torch.no_grad())
+                    variance = variance.clamp_min(eps);
+
+                var loss = 0.5 * (variance.log() + (input - target).square() / variance).view(input.shape[0], -1).sum(dim: stackalloc long[] { 1 });
+
+                if (full) {
+                    loss = loss + 0.5 * input.shape[1] * MathF.Log(2 * MathF.PI);
+                }
+
+                return (reduction == Reduction.Mean) ? loss.mean() : (reduction == Reduction.Sum) ? loss.sum() : loss;
+            }
+
+            public bool full { get; }
+            public float eps { get; }
+
+        }
+
+        public class KLDivLoss : Loss
+        {
+            public KLDivLoss(bool log_target = true, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.log_target = log_target;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_kl_div_loss(input.Handle, target.Handle, (long)reduction, log_target);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public bool log_target { get; }
+        }
+
+        public class SmoothL1Loss : Loss
+        {
+            public SmoothL1Loss(Reduction reduction = Reduction.Mean, double beta = 1.0) : base(reduction)
+            {
+                this.beta = beta;
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                // Currently, the 'beta' parameter is being ignored by the native layer, so we just pass the default.
+                var res = THSNN_smooth_l1_loss(input.Handle, target.Handle, (long)reduction, 1.0);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public double beta { get; }
+        }
+
+        public class SoftMarginLoss : Loss
+        {
+            public SoftMarginLoss(Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+            }
+
+            public override Tensor forward(Tensor input, Tensor target)
+            {
+                var res = THSNN_soft_margin_loss(input.Handle, target.Handle, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+        }
+
+        public class TripletMarginLoss : Loss
+        {
+            public TripletMarginLoss(double margin = 1.0, long p = 2, double eps = 1e-06, bool swap = false, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                this.margin = margin;
+                this.p = p;
+                this.eps = eps;
+                this.swap = swap;
+            }
+
+            public override Tensor forward(Tensor anchor, Tensor positive, Tensor negative)
+            {
+                var res = THSNN_triplet_margin_loss(anchor.Handle, positive.Handle, negative.Handle, margin, p, eps, swap, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+
+            public double margin { get; }
+            public long p { get; }
+            double eps { get; }
+            bool swap { get; }
+        }
+
+        public class TripletMarginWithDistanceLoss : Loss
+        {
+            public TripletMarginWithDistanceLoss(Func<Tensor, Tensor, Tensor>? distance = null, double margin = 1.0, bool swap = false, Reduction reduction = Reduction.Mean) : base(reduction)
+            {
+                if (distance != null) {
+                    this.distance = (IntPtr x, IntPtr y) => {
+                        var x1 = new Tensor(x);
+                        var y1 = new Tensor(y);
+                        var res = distance(x1, y1);
+
+                        GC.SuppressFinalize(x1);
+                        GC.SuppressFinalize(y1);
+                        GC.SuppressFinalize(res);
+
+                        return res.Handle;
+                    };
+                }
+
+                this.margin = margin;
+                this.swap = swap;
+            }
+
+            public override Tensor forward(Tensor anchor, Tensor positive, Tensor negative)
+            {
+                var res = THSNN_triplet_margin_with_distance_loss(anchor.Handle, positive.Handle, negative.Handle, distance, margin, swap, (long)reduction);
+                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                return new Tensor(res);
+            }
+            
+            DistanceFunctionNative? distance { get; }
+            public double margin { get; }
+            bool swap { get; }
         }
     }
 }

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.torch.distributions.constraints;
 using static TorchSharp.torch.nn;
 using static TorchSharp.torch.nn.functional;
 
@@ -106,7 +107,7 @@ namespace TorchSharp
             /// <param name="margin"> Should be a number from -1 to 1, 0 to 0.5 is suggested</param>
             /// <param name="reduction">Specifies the reduction to apply to the output</param>
             /// <returns></returns>
-            public static Modules.HingeEmbeddingLoss HingeEmbeddingLoss(double margin = 0.0, Reduction reduction = Reduction.Mean)
+            public static Modules.HingeEmbeddingLoss HingeEmbeddingLoss(double margin = 1.0, Reduction reduction = Reduction.Mean)
             {
                 return new Modules.HingeEmbeddingLoss(margin, reduction);
             }
@@ -124,16 +125,41 @@ namespace TorchSharp
                 return new Modules.HuberLoss(delta, reduction);
             }
 
+            /// <summary>
+            /// Creates a criterion that measures the loss given inputs x1, x2, two 1D mini-batch or 0D Tensors, and a label 1D mini-batch or 0D Tensor y (containing 1 or -1).
+            ///
+            /// See: https://pytorch.org/docs/stable/generated/torch.nn.MarginRankingLoss.html#torch.nn.MarginRankingLoss
+            /// </summary>
+            /// <param name="margin">Has a default value of 0.</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
             public static Modules.MarginRankingLoss MarginRankingLoss(double margin = 0, Reduction reduction = Reduction.Mean)
             {
                 return new Modules.MarginRankingLoss(margin, reduction);
             }
 
+            /// <summary>
+            /// Creates a criterion that optimizes a multi-label one-versus-all loss based on max-entropy, between input x and target y of size NxC.
+            ///
+            /// See: https://pytorch.org/docs/stable/generated/torch.nn.MultiLabelSoftMarginLoss.html#torch.nn.MultiLabelSoftMarginLoss
+            /// </summary>
+            /// <param name="weight">A manual rescaling weight given to each class. If given, it has to be a Tensor of size C. Otherwise, it is treated as if having all ones.</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
             public static MultiLabelSoftMarginLoss MultiLabelSoftMarginLoss(Tensor? weight = null, Reduction reduction = Reduction.Mean)
             {
                 return new MultiLabelSoftMarginLoss(weight, reduction);
             }
 
+            /// <summary>
+            /// Creates a criterion that optimizes a multi-class classification hinge loss.
+            ///
+            /// See: https://pytorch.org/docs/stable/generated/torch.nn.MultiMarginLoss.html#torch.nn.MultiMarginLoss
+            /// </summary>
+            /// <param name="p">Has a default value of 1. 1 and 2 are the only supported values.</param>
+            /// <param name="margin">Has a default value of 1</param>
+            /// <param name="weight">A manual rescaling weight given to each class. If given, it has to be a Tensor of size C. Otherwise, it is treated as if having all ones.</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
             public static MultiMarginLoss MultiMarginLoss(int p = 1, double margin = 1.0, Tensor? weight = null, Reduction reduction = Reduction.Mean)
             {
                 return new MultiMarginLoss(p, margin, weight, reduction);
@@ -184,11 +210,11 @@ namespace TorchSharp
             }
 
             /// <summary>
-             /// The Kullback-Leibler divergence Loss
-             /// </summary>
-             /// <param name="log_target">A flag indicating whether target is passed in the log space.</param>
-             /// <param name="reduction">Specifies the reduction to apply to the output</param>
-             /// <returns></returns>
+            /// The Kullback-Leibler divergence Loss
+            /// </summary>
+            /// <param name="log_target">A flag indicating whether target is passed in the log space.</param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
             public static KLDivLoss KLDivLoss(bool log_target = true, Reduction reduction = Reduction.Mean)
             {
                 return new KLDivLoss(log_target, reduction);
@@ -204,11 +230,45 @@ namespace TorchSharp
                 return new SoftMarginLoss(reduction);
             }
 
+            /// <summary>
+            /// Creates a criterion that measures the triplet loss given an input tensors x1, x2, x3 and a margin with a value greater than 0.
+            /// This is used for measuring a relative similarity between samples.
+            ///
+            /// See: https://pytorch.org/docs/stable/generated/torch.nn.TripletMarginLoss.html#torch.nn.TripletMarginLoss
+            /// </summary>
+            /// <param name="margin">
+            /// A nonnegative margin representing the minimum difference between the positive and negative distances required for the loss to be 0.
+            /// Larger margins penalize cases where the negative examples are not distant enough from the anchors, relative to the positives.
+            /// </param>
+            /// <param name="p">The norm degree for pairwise distance. </param>
+            /// <param name="eps"></param>
+            /// <param name="swap">
+            /// If true, and if the positive example is closer to the negative example than the anchor is, swaps the positive example and the anchor in the loss computation.
+            /// The distance swap is described in detail in the paper Learning shallow convolutional feature descriptors with triplet losses by V. Balntas, E. Riba et al.
+            /// </param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
             public static TripletMarginLoss TripletMarginLoss(double margin = 1.0, long p = 2, double eps = 1e-06, bool swap = false, Reduction reduction = Reduction.Mean)
             {
                 return new TripletMarginLoss(margin, p, eps, swap, reduction);
             }
 
+            /// <summary>
+            /// Creates a criterion that measures the triplet loss given input tensors a, p, and n (representing anchor, positive, and negative examples, respectively),
+            /// and a nonnegative, real-valued function ("distance function") used to compute the relationship between the anchor and positive example ("positive distance")
+            /// and the anchor and negative example ("negative distance").
+            /// </summary>
+            /// <param name="distance"> A nonnegative, real-valued function that quantifies the closeness of two tensors. If not specified, nn.PairwiseDistance will be used.</param>
+            /// <param name="margin">
+            /// A nonnegative margin representing the minimum difference between the positive and negative distances required for the loss to be 0.
+            /// Larger margins penalize cases where the negative examples are not distant enough from the anchors, relative to the positives.
+            /// </param>
+            /// <param name="swap">
+            /// If true, and if the positive example is closer to the negative example than the anchor is, swaps the positive example and the anchor in the loss computation.
+            /// The distance swap is described in detail in the paper Learning shallow convolutional feature descriptors with triplet losses by V. Balntas, E. Riba et al.
+            /// </param>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
             public static TripletMarginWithDistanceLoss TripletMarginWithDistanceLoss(Func<Tensor, Tensor, Tensor>? distance = null, double margin = 1.0, bool swap = false, Reduction reduction = Reduction.Mean)
             {
                 return new TripletMarginWithDistanceLoss(distance, margin, swap, reduction);
@@ -226,7 +286,12 @@ namespace TorchSharp
                 return new GaussianNLLLoss(full, eps, reduction);
             }
 
-
+            /// <summary>
+            /// Creates a criterion that optimizes a multi-class multi-classification hinge loss (margin-based loss) between input x (a 2D mini-batch Tensor)
+            /// and output y (which is a 2D Tensor of target class indices).
+            /// </summary>
+            /// <param name="reduction">Specifies the reduction to apply to the output</param>
+            /// <returns></returns>
             public static MultiLabelMarginLoss MultiLabelMarginLoss(Reduction reduction = Reduction.Mean)
             {
                 return new MultiLabelMarginLoss(reduction);
@@ -242,23 +307,376 @@ namespace TorchSharp
             {
                 return new SmoothL1Loss(reduction, beta);
             }
+
+
             /// <summary>
             /// Class maintaing the supported loss functions.
             /// </summary>
             public static partial class functional
             {
-                public static Tensor binary_cross_entropy_with_logits(Tensor input, Tensor target, Tensor? weight = null, Reduction reduction = Reduction.Mean, Tensor? posWeights = null)
+                /// <summary>
+                /// Function that measures Binary Cross Entropy between target and input logits.
+                /// </summary>
+                /// <param name="input">Tensor of arbitrary shape as unnormalized scores (often referred to as logits).</param>
+                /// <param name="target">Tensor of the same shape as input with values between 0 and 1</param>
+                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <param name="pos_weights">A weight of positive examples. Must be a vector with length equal to the number of classes.</param>
+                /// <returns></returns>
+                public static Tensor binary_cross_entropy_with_logits(Tensor input, Tensor target, Tensor? weight = null, Reduction reduction = Reduction.Mean, Tensor? pos_weights = null)
                 {
-                    var res = THSNN_binary_cross_entropy_with_logits(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction, posWeights?.Handle ?? IntPtr.Zero);
+                    var res = THSNN_binary_cross_entropy_with_logits(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction, pos_weights?.Handle ?? IntPtr.Zero);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
                 }
 
-                public static Tensor binary_cross_entropy(Tensor src, Tensor target, Tensor? weight = null, Reduction reduction = Reduction.Mean)
+                /// <summary>
+                /// Function that measures the Binary Cross Entropy between the target and input probabilities.
+                /// </summary>
+                /// <param name="input">Tensor of arbitrary shape as probabilities.</param>
+                /// <param name="target">Tensor of the same shape as input with values between 0 and 1</param>
+                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor binary_cross_entropy(Tensor input, Tensor target, Tensor? weight = null, Reduction reduction = Reduction.Mean)
                 {
-                    var res = THSNN_binary_cross_entropy(src.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
+                    var res = THSNN_binary_cross_entropy(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Computes the cross entropy loss between input and target.
+                /// </summary>
+                /// <param name="input">Tensor of arbitrary shape as unnormalized scores (often referred to as logits).</param>
+                /// <param name="target">Ground truth class indices or class probabilities; see Shape section below for supported shapes.</param>
+                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+                /// <param name="ignore_index">
+                /// Specifies a target value that is ignored and does not contribute to the input gradient.
+                /// Note that ignore_index is only applicable when the target contains class indices.
+                /// </param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor cross_entropy(Tensor input, Tensor target, Tensor? weight = null, long ignore_index = -100, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_cross_entropy(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, ignore_index, true, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Poisson negative log likelihood loss.
+                /// </summary>
+                /// <param name="input">Expectation of underlying Poisson distribution.</param>
+                /// <param name="target">Random sample target.</param>
+                /// <param name="log_input"></param>
+                /// <param name="full">Whether to compute full loss, i.e. to add the Stirling approximation term.</param>
+                /// <param name="eps">Small value to avoid evaluation of log(0)</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor poisson_nll_loss(Tensor input, Tensor target, bool log_input = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_poisson_loss(input.Handle, target.Handle, log_input, full, eps, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// 
+                /// </summary>
+                /// <param name="input1">(N,D) or (D), where N is the batch size and D is the embedding dimension.</param>
+                /// <param name="input2">Same shape as input1</param>
+                /// <param name="target">N or ()</param>
+                /// <param name="margin">Should be a number from -1−1 to 11, 00 to 0.50.5 is suggested</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor cosine_embedding_loss(Tensor input1, Tensor input2, Tensor target, double margin = 0.0, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_cosine_embedding_loss(input1.Handle, input2.Handle, target.Handle, margin, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Computes the Connectionist Temporal Classification loss.
+                /// </summary>
+                /// <param name="log_probs">The logarithmized probabilities of the outputs.</param>
+                /// <param name="targets"></param>
+                /// <param name="input_lengths">Lengths of the inputs.</param>
+                /// <param name="target_lengths">Lengths of the targets.</param>
+                /// <param name="blank">Blank label.</param>
+                /// <param name="zero_infinity">Whether to zero infinite losses and the associated gradients.</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor ctc_loss(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, long blank = 0, bool zero_infinity = false, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_ctc_loss(log_probs.Handle, targets.Handle, input_lengths.Handle, target_lengths.Handle, blank, zero_infinity, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Measures the loss given an input tensor x and a labels tensor y (containing 1 or -1).
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="margin"> Should be a number from -1 to 1, 0 to 0.5 is suggested</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor hinge_embedding_loss(Tensor input, Tensor target, double margin = 0.0, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_hinge_embedding_loss(input.Handle, target.Handle, margin, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Function that uses a squared term if the absolute element-wise error falls below delta and a delta-scaled L1 term otherwise.
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="delta">Specifies the threshold at which to change between delta-scaled L1 and L2 loss. The value must be positive. Default: 1.0</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor huber_loss(Tensor input, Tensor target, double delta = 1.0, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_huber_loss(input.Handle, target.Handle, delta, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Creates a criterion that measures the loss given inputs x1, x2, two 1D mini-batch or 0D Tensors, and a label 1D mini-batch or 0D Tensor y (containing 1 or -1).
+                /// </summary>
+                /// <param name="input1"></param>
+                /// <param name="input2"></param>
+                /// <param name="target"></param>
+                /// <param name="margin">Has a default value of 0.</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor margin_ranking_loss(Tensor input1, Tensor input2, Tensor target, double margin = 0.0, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_margin_ranking_loss(input1.Handle, input2.Handle, target.Handle, margin, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Creates a criterion that optimizes a multi-class multi-classification hinge loss (margin-based loss) between input x (a 2D mini-batch Tensor)
+                /// and output y (which is a 2D Tensor of target class indices).
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor multi_label_margin_loss(Tensor input, Tensor target, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_multilabel_margin_loss(input.Handle, target.Handle, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Creates a criterion that optimizes a multi-label one-versus-all loss based on max-entropy, between input x and target y of size NxC.
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor multilabel_soft_margin_loss(Tensor input, Tensor target, Tensor? weight = null,Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_multilabel_soft_margin_loss(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Creates a criterion that optimizes a multi-class classification hinge loss.
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="p">Has a default value of 1. 1 and 2 are the only supported values.</param>
+                /// <param name="margin">Has a default value of 1</param>
+                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor multi_margin_loss(Tensor input, Tensor target, int p = 1, double margin = 1.0, Tensor? weight = null, Reduction reduction = Reduction.Mean)
+                {
+                    IntPtr h = (weight is null) ? IntPtr.Zero : weight.Handle;
+                    var res = THSNN_multi_margin_loss(input.Handle, target.Handle, p, margin, h, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                ///	Measures the element-wise mean squared error.
+                /// </summary>
+                /// <param name="input">Tensor of any shape.</param>
+                /// <param name="target">Tensor of the same shape as 'input'</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor mse_loss(Tensor input, Tensor target, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_mse_loss(input.Handle, target.Handle, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Function that takes the mean element-wise absolute value difference.
+                /// </summary>
+                /// <param name="input">Tensor of any shape.</param>
+                /// <param name="target">Tensor of the same shape as 'input'</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor l1_loss(Tensor input, Tensor target, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_l1_loss(input.Handle, target.Handle, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Computes the negative log likelihood loss.
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="weight">A manual rescaling weight if provided it’s repeated to match input tensor shape</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor nll_loss(Tensor input, Tensor target, Tensor? weight = null, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_nll_loss(input.Handle, target.Handle, weight?.Handle ?? IntPtr.Zero, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Gaussian negative log likelihood loss.
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="variance">Tensor of positive variance(s), one for each of the expectations in the input (heteroscedastic), or a single one (homoscedastic).</param>
+                /// <param name="full">Include the constant term in the loss calculation. </param>
+                /// <param name="eps">Value added to var, for stability</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor gaussian_nll_loss(Tensor input, Tensor target, Tensor variance, bool full = false, float eps = 1e-6f, Reduction reduction = Reduction.Mean)
+                {
+                    return new Modules.GaussianNLLLoss(full, eps, reduction).forward(input, target, variance);
+                }
+
+                /// <summary>
+                /// Computes the Kullback-Leibler divergence Loss
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="log_target">A flag indicating whether target is passed in the log space.</param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor kl_div(Tensor input, Tensor target, bool log_target = true, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_kl_div_loss(input.Handle, target.Handle, (long)reduction, log_target);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Function that uses a squared term if the absolute element-wise error falls below beta and an L1 term otherwise.
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <param name="beta">Specifies the threshold at which to change between L1 and L2 loss. The value must be non-negative.</param>
+                /// <returns></returns>
+                public static Tensor smooth_l1_loss(Tensor input, Tensor target, Reduction reduction = Reduction.Mean, double beta = 1.0)
+                {
+                    var res = THSNN_smooth_l1_loss(input.Handle, target.Handle, (long)reduction, beta);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                ///  Optimizes a two-class classification logistic loss between input tensor x and target tensor y (containing 1 or -1).
+                /// </summary>
+                /// <param name="input"></param>
+                /// <param name="target"></param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor soft_margin_loss(Tensor input, Tensor target, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_soft_margin_loss(input.Handle, target.Handle, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Creates a criterion that measures the triplet loss given an input tensors x1, x2, x3 and a margin with a value greater than 0.
+                /// This is used for measuring a relative similarity between samples.
+                /// </summary>
+                /// <param name="anchor"></param>
+                /// <param name="positive"></param>
+                /// <param name="negative"></param>
+                /// <param name="margin">
+                /// A nonnegative margin representing the minimum difference between the positive and negative distances required for the loss to be 0.
+                /// Larger margins penalize cases where the negative examples are not distant enough from the anchors, relative to the positives.
+                /// </param>
+                /// <param name="p">The norm degree for pairwise distance. </param>
+                /// <param name="eps"></param>
+                /// <param name="swap">
+                /// If true, and if the positive example is closer to the negative example than the anchor is, swaps the positive example and the anchor in the loss computation.
+                /// The distance swap is described in detail in the paper Learning shallow convolutional feature descriptors with triplet losses by V. Balntas, E. Riba et al.
+                /// </param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor triplet_margin_loss(Tensor anchor, Tensor positive, Tensor negative, double margin = 1.0, long p = 2, double eps = 1e-06, bool swap = false, Reduction reduction = Reduction.Mean)
+                {
+                    var res = THSNN_triplet_margin_loss(anchor.Handle, positive.Handle, negative.Handle, margin, p, eps, swap, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+                }
+
+                /// <summary>
+                /// Creates a criterion that measures the triplet loss given input tensors a, p, and n (representing anchor, positive, and negative examples, respectively),
+                /// and a nonnegative, real-valued function ("distance function") used to compute the relationship between the anchor and positive example ("positive distance")
+                /// and the anchor and negative example ("negative distance").
+                /// </summary>
+                /// <param name="anchor"></param>
+                /// <param name="positive"></param>
+                /// <param name="negative"></param>
+                /// <param name="distance"> A nonnegative, real-valued function that quantifies the closeness of two tensors. If not specified, nn.PairwiseDistance will be used.</param>
+                /// <param name="margin">
+                /// A nonnegative margin representing the minimum difference between the positive and negative distances required for the loss to be 0.
+                /// Larger margins penalize cases where the negative examples are not distant enough from the anchors, relative to the positives.
+                /// </param>
+                /// <param name="swap">
+                /// If true, and if the positive example is closer to the negative example than the anchor is, swaps the positive example and the anchor in the loss computation.
+                /// The distance swap is described in detail in the paper Learning shallow convolutional feature descriptors with triplet losses by V. Balntas, E. Riba et al.
+                /// </param>
+                /// <param name="reduction">Specifies the reduction to apply to the output</param>
+                /// <returns></returns>
+                public static Tensor triplet_margin_with_distance_loss(Tensor anchor, Tensor positive, Tensor negative, Func<Tensor, Tensor, Tensor>? distance = null, double margin = 1.0, bool swap = false, Reduction reduction = Reduction.Mean)
+                {
+                    DistanceFunctionNative? func = null;
+
+                    if (distance != null) {
+                        func = (IntPtr x, IntPtr y) => {
+                            var x1 = new Tensor(x);
+                            var y1 = new Tensor(y);
+                            var res = distance(x1, y1);
+
+                            GC.SuppressFinalize(x1);
+                            GC.SuppressFinalize(y1);
+                            GC.SuppressFinalize(res);
+
+                            return res.Handle;
+                        };
+                    }
+                    var res = THSNN_triplet_margin_with_distance_loss(anchor.Handle, positive.Handle, negative.Handle, func, margin, swap, (long)reduction);
+                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    return new Tensor(res);
+
                 }
 
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -273,7 +691,7 @@ namespace TorchSharp
 
                 [DllImport("LibTorchSharp")]
                 internal static extern IntPtr THSNN_binary_cross_entropy_with_logits(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction, IntPtr posWeights);
-                
+
                 [DllImport("LibTorchSharp")]
                 internal static extern IntPtr THSNN_cosine_embedding_loss(IntPtr input1, IntPtr input2, IntPtr trgt, double margin, long reduction);
 
@@ -651,8 +1069,7 @@ namespace TorchSharp
 
             public override Tensor forward(Tensor input, Tensor target)
             {
-                // Currently, the 'beta' parameter is being ignored by the native layer, so we just pass the default.
-                var res = THSNN_smooth_l1_loss(input.Handle, target.Handle, (long)reduction, 1.0);
+                var res = THSNN_smooth_l1_loss(input.Handle, target.Handle, (long)reduction, beta);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
@@ -725,7 +1142,7 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-            
+
             DistanceFunctionNative? distance { get; }
             public double margin { get; }
             bool swap { get; }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -677,8 +677,8 @@ namespace TorchSharp
             var y = torch.randn(new long[] { 64, 10 });
 
             var eval = seq.forward(x);
-            var loss = mse_loss(Reduction.Sum);
-            var output = loss(eval, y);
+            var loss = MSELoss(Reduction.Sum);
+            var output = loss.forward(eval, y);
 
             var result = output.ToSingle();
         }
@@ -734,8 +734,8 @@ namespace TorchSharp
             var y = torch.randn(new long[] { 64, 10 });
 
             var eval = seq.forward(x);
-            var loss = mse_loss(Reduction.Sum);
-            var output = loss(eval, y);
+            var loss = MSELoss(Reduction.Sum);
+            var output = loss.forward(eval, y);
 
             var result = output.ToSingle();
         }
@@ -748,9 +748,9 @@ namespace TorchSharp
             using (Tensor input = torch.tensor(new float[] { 0.5f, 1.5f, 2.5f }))
             using (Tensor target = torch.tensor(new float[] { 1f, 2f, 3f })) {
                 var componentWiseLoss = ((Tensor)input.exp()) - target * input;
-                Assert.True(componentWiseLoss.Equals(poisson_loss(reduction: Reduction.None)(input, target)));
-                Assert.True(componentWiseLoss.sum().Equals(poisson_loss(reduction: Reduction.Sum)(input, target)));
-                Assert.True(componentWiseLoss.mean().Equals(poisson_loss(reduction: Reduction.Mean)(input, target)));
+                Assert.True(componentWiseLoss.Equals(torch.nn.PoissonNLLLoss(reduction: Reduction.None).forward(input, target)));
+                Assert.True(componentWiseLoss.sum().Equals(torch.nn.PoissonNLLLoss(reduction: Reduction.Sum).forward(input, target)));
+                Assert.True(componentWiseLoss.mean().Equals(torch.nn.PoissonNLLLoss(reduction: Reduction.Mean).forward(input, target)));
             }
         }
 
@@ -759,7 +759,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.rand(new long[] { 5, 2 }))
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
-                var outTensor = poisson_loss(true, true)(input, target);
+                var outTensor = torch.nn.PoissonNLLLoss(true, true).forward(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -771,7 +771,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.rand(new long[] { 5, 12 }))
             using (Tensor target = torch.randint(12, new long[] { 5 }, torch.int64)) {
-                var outTensor = cross_entropy_loss()(input, target);
+                var outTensor = CrossEntropyLoss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -783,7 +783,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.rand(new long[] { 5, 2 }))
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
-                var outTensor = l1_loss()(input, target);
+                var outTensor = L1Loss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -796,7 +796,7 @@ namespace TorchSharp
             var m = Sigmoid();
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
-                var outTensor = binary_cross_entropy_loss()(m.forward(input), target);
+                var outTensor = BCELoss().forward(m.forward(input), target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -808,7 +808,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
-                var outTensor = binary_cross_entropy_with_logits_loss()(input, target);
+                var outTensor = BCEWithLogitsLoss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -820,7 +820,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
-                var outTensor = kl_div_loss()(input, target);
+                var outTensor = KLDivLoss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -832,7 +832,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
-                var outTensor = smooth_l1_loss()(input, target);
+                var outTensor = SmoothL1Loss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -844,7 +844,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
-                var outTensor = soft_margin_loss()(input, target);
+                var outTensor = SoftMarginLoss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -865,7 +865,7 @@ namespace TorchSharp
                     variance = variance.cuda();
                 }
 
-                var outTensor = gaussian_nll_loss()(input, target, variance);
+                var outTensor = GaussianNLLLoss().forward(input, target, variance);
                 outTensor.backward();
 
                 var values = outTensor.cpu().data<float>().ToArray();
@@ -882,7 +882,7 @@ namespace TorchSharp
                     target = target.cuda();
                     variance = variance.cuda();
                 }
-                var outTensor = gaussian_nll_loss()(input, target, variance);
+                var outTensor = GaussianNLLLoss().forward(input, target, variance);
                 outTensor.backward();
 
                 var values = outTensor.cpu().data<float>().ToArray();
@@ -897,7 +897,7 @@ namespace TorchSharp
             using (Tensor variance = torch.rand(new long[] { 15, 1 }, torch.float64, requiresGrad: true))
             using (Tensor input = torch.randn(new long[] { 15, 5, 5 }, torch.float64, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15, 5, 5 }, torch.float64)) {
-                var outTensor = gaussian_nll_loss()(input, target, variance);
+                var outTensor = GaussianNLLLoss().forward(input, target, variance);
                 outTensor.backward();
 
                 var values = outTensor.data<double>().ToArray();
@@ -907,7 +907,7 @@ namespace TorchSharp
             using (Tensor variance = torch.rand(new long[] { 15, 5, 5 }, torch.float64, requiresGrad: true))
             using (Tensor input = torch.randn(new long[] { 15, 5, 5 }, torch.float64, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15, 5, 5 }, torch.float64)) {
-                var outTensor = gaussian_nll_loss()(input, target, variance);
+                var outTensor = GaussianNLLLoss().forward(input, target, variance);
                 outTensor.backward();
 
                 var values = outTensor.data<double>().ToArray();
@@ -924,7 +924,7 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 15, 5 })) {
 
                 Assert.Throws<ArgumentException>(() => {
-                    var outTensor = gaussian_nll_loss()(input, target, variance);
+                    var outTensor = GaussianNLLLoss().forward(input, target, variance);
                     outTensor.backward();
                 });
 
@@ -938,7 +938,7 @@ namespace TorchSharp
             using (Tensor input2 = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15 }).sign()) {
 
-                var outTensor = cosine_embedding_loss()(input1, input2, target);
+                var outTensor = CosineEmbeddingLoss().forward(input1, input2, target);
                 outTensor.backward();
 
             }
@@ -949,7 +949,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
-                var outTensor = hinge_embedding_loss()(input, target);
+                var outTensor = HingeEmbeddingLoss().forward(input, target);
                 outTensor.backward();
             }
         }
@@ -959,7 +959,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
-                var outTensor = hinge_embedding_loss()(input, target);
+                var outTensor = HingeEmbeddingLoss().forward(input, target);
                 outTensor.backward();
             }
         }
@@ -969,9 +969,9 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
-                var outTensor = huber_loss()(input, target);
+                var outTensor = HuberLoss().forward(input, target);
                 outTensor.backward();
-                outTensor = huber_loss(1.5)(input, target);
+                outTensor = HuberLoss(1.5).forward(input, target);
                 outTensor.backward();
             }
         }
@@ -982,7 +982,7 @@ namespace TorchSharp
             using (Tensor input1 = torch.randn(new long[] { 15 }, requiresGrad: true))
             using (Tensor input2 = torch.randn(new long[] { 15 }, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15 }).sign()) {
-                var outTensor = margin_ranking_loss()(input1, input2, target);
+                var outTensor = MarginRankingLoss().forward(input1, input2, target);
                 outTensor.backward();
             }
         }
@@ -992,7 +992,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.ones(new long[] { 15, 5 }, torch.int64)) {
-                var outTensor = multilabel_margin_loss()(input, target);
+                var outTensor = MultiLabelMarginLoss().forward(input, target);
                 outTensor.backward();
             }
         }
@@ -1002,7 +1002,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.ones(new long[] { 15, 5 })) {
-                var outTensor = multilabel_soft_margin_loss()(input, target);
+                var outTensor = MultiLabelSoftMarginLoss().forward(input, target);
                 outTensor.backward();
             }
         }
@@ -1012,7 +1012,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.ones(new long[] { 15 }, torch.int64)) {
-                var outTensor = multi_margin_loss()(input, target);
+                var outTensor = MultiMarginLoss().forward(input, target);
                 outTensor.backward();
             }
         }
@@ -1024,8 +1024,8 @@ namespace TorchSharp
             using (Tensor positive = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
 
-                var output = triplet_margin_loss();
-                var result = output(anchor, positive, negative);
+                var output = TripletMarginLoss();
+                var result = output.forward(anchor, positive, negative);
                 Assert.True(true);
             }
         }
@@ -1042,8 +1042,8 @@ namespace TorchSharp
             using (Tensor positive = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
 
-                var output = triplet_margin_with_distance_loss(distance);
-                var result = output(anchor, positive, negative);
+                var output = TripletMarginWithDistanceLoss(distance);
+                var result = output.forward(anchor, positive, negative);
                 Assert.True(true);
             }
         }
@@ -1055,8 +1055,8 @@ namespace TorchSharp
             using (Tensor positive = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
 
-                var output = triplet_margin_with_distance_loss();
-                var result = output(anchor, positive, negative);
+                var output = TripletMarginWithDistanceLoss();
+                var result = output.forward(anchor, positive, negative);
                 Assert.True(true);
             }
         }
@@ -1078,8 +1078,8 @@ namespace TorchSharp
             var y = torch.randn(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.forward(x);
-            var loss = mse_loss(Reduction.Sum);
-            var output = loss(eval, y);
+            var loss = MSELoss(Reduction.Sum);
+            var output = loss.forward(eval, y);
 
             seq.zero_grad();
 
@@ -1100,8 +1100,8 @@ namespace TorchSharp
             var y = torch.randn(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.forward(x);
-            var loss = mse_loss(Reduction.Sum);
-            var output = loss(eval, y);
+            var loss = MSELoss(Reduction.Sum);
+            var output = loss.forward(eval, y);
 
             seq.zero_grad();
 
@@ -1125,8 +1125,8 @@ namespace TorchSharp
             var y = torch.randn(new long[] { 64, 10 }, requiresGrad: true);
 
             var eval = seq.forward(x);
-            var loss = mse_loss(Reduction.Sum);
-            var output = loss(eval, y);
+            var loss = MSELoss(Reduction.Sum);
+            var output = loss.forward(eval, y);
 
             seq.zero_grad();
 
@@ -1152,8 +1152,8 @@ namespace TorchSharp
             var afterScaler = afterCat * scaler;
             var prediction = linear.forward(afterScaler);
 
-            var loss = mse_loss();
-            var output = loss(prediction, y);
+            var loss = MSELoss();
+            var output = loss.forward(prediction, y);
 
             linear.zero_grad();
 
@@ -1224,8 +1224,8 @@ namespace TorchSharp
             Assert.True(modT.training);
 
             var eval = modT.forward(x);
-            var loss = mse_loss(Reduction.Sum);
-            var output = loss(eval, y);
+            var loss = MSELoss(Reduction.Sum);
+            var output = loss.forward(eval, y);
 
             modT.zero_grad();
 
@@ -1243,7 +1243,7 @@ namespace TorchSharp
             modF.train();
 
             eval = modF.forward(x);
-            output = loss(eval, y);
+            output = loss.forward(eval, y);
 
             modF.zero_grad();
 
@@ -3585,7 +3585,7 @@ namespace TorchSharp
         {
             using (Tensor input = torch.tensor(new float[] { 0.5f, 1.5f }))
             using (Tensor target = torch.tensor(new float[] { 1f, 2f, 3f })) {
-                Assert.Throws<ExternalException>(() => poisson_loss()(input, target));
+                Assert.Throws<ExternalException>(() => torch.nn.PoissonNLLLoss().forward(input, target));
             }
         }
 #endif

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -772,8 +772,11 @@ namespace TorchSharp
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
                 var outTensor = torch.nn.PoissonNLLLoss(true, true).forward(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -784,8 +787,11 @@ namespace TorchSharp
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
                 var outTensor = torch.nn.functional.poisson_nll_loss(input, target, true, true);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -796,8 +802,11 @@ namespace TorchSharp
             using (Tensor target = torch.randint(12, new long[] { 5 }, torch.int64)) {
                 var outTensor = CrossEntropyLoss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -808,8 +817,11 @@ namespace TorchSharp
             using (Tensor target = torch.randint(12, new long[] { 5 }, torch.int64)) {
                 var outTensor = cross_entropy(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -820,8 +832,11 @@ namespace TorchSharp
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
                 var outTensor = L1Loss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -832,8 +847,11 @@ namespace TorchSharp
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
                 var outTensor = l1_loss(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -845,8 +863,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = BCELoss().forward(m.forward(input), target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -858,8 +879,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = binary_cross_entropy(m.forward(input), target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -870,8 +894,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = BCEWithLogitsLoss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -882,8 +909,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = binary_cross_entropy_with_logits(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -894,8 +924,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = KLDivLoss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -906,8 +939,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = kl_div(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -918,8 +954,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = SmoothL1Loss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -930,8 +969,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = smooth_l1_loss(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -942,8 +984,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = SoftMarginLoss().forward(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -954,8 +999,11 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = soft_margin_loss(input, target);
                 var values = outTensor.data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -977,8 +1025,11 @@ namespace TorchSharp
                 outTensor.backward();
 
                 var values = outTensor.cpu().data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
             {
                 Tensor variance = torch.rand(new long[] { 15, 1 }, requiresGrad: true);
@@ -994,8 +1045,11 @@ namespace TorchSharp
                 outTensor.backward();
 
                 var values = outTensor.cpu().data<float>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1009,8 +1063,11 @@ namespace TorchSharp
                 outTensor.backward();
 
                 var values = outTensor.data<double>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(double.IsNaN(outTensor.item<double>()))
+                );
             }
             using (Tensor variance = torch.rand(new long[] { 15, 5, 5 }, torch.float64, requiresGrad: true))
             using (Tensor input = torch.randn(new long[] { 15, 5, 5 }, torch.float64, requiresGrad: true))
@@ -1019,8 +1076,11 @@ namespace TorchSharp
                 outTensor.backward();
 
                 var values = outTensor.data<double>().ToArray();
-                Assert.Empty(outTensor.shape);
-                Assert.Single(values);
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.Single(values),
+                () => Assert.False(double.IsNaN(outTensor.item<double>()))
+                );
             }
         }
 
@@ -1048,7 +1108,10 @@ namespace TorchSharp
 
                 var outTensor = CosineEmbeddingLoss().forward(input1, input2, target);
                 outTensor.backward();
-
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1061,7 +1124,10 @@ namespace TorchSharp
 
                 var outTensor = cosine_embedding_loss(input1, input2, target);
                 outTensor.backward();
-
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1072,6 +1138,10 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
                 var outTensor = HingeEmbeddingLoss().forward(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1082,6 +1152,10 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
                 var outTensor = hinge_embedding_loss(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1092,8 +1166,16 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
                 var outTensor = HuberLoss().forward(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
                 outTensor = HuberLoss(1.5).forward(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1104,8 +1186,16 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
                 var outTensor = huber_loss(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
                 outTensor = huber_loss(input, target, 1.5);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1117,6 +1207,10 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 15 }).sign()) {
                 var outTensor = MarginRankingLoss().forward(input1, input2, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1128,6 +1222,10 @@ namespace TorchSharp
             using (Tensor target = torch.randn(new long[] { 15 }).sign()) {
                 var outTensor = margin_ranking_loss(input1, input2, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1138,6 +1236,10 @@ namespace TorchSharp
             using (Tensor target = torch.ones(new long[] { 15, 5 }, torch.int64)) {
                 var outTensor = MultiLabelMarginLoss().forward(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1148,6 +1250,10 @@ namespace TorchSharp
             using (Tensor target = torch.ones(new long[] { 15, 5 }, torch.int64)) {
                 var outTensor = multi_label_margin_loss(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1158,6 +1264,10 @@ namespace TorchSharp
             using (Tensor target = torch.ones(new long[] { 15, 5 })) {
                 var outTensor = MultiLabelSoftMarginLoss().forward(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1168,6 +1278,10 @@ namespace TorchSharp
             using (Tensor target = torch.ones(new long[] { 15, 5 })) {
                 var outTensor = multilabel_soft_margin_loss(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1178,6 +1292,10 @@ namespace TorchSharp
             using (Tensor target = torch.ones(new long[] { 15 }, torch.int64)) {
                 var outTensor = MultiMarginLoss().forward(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1188,6 +1306,10 @@ namespace TorchSharp
             using (Tensor target = torch.ones(new long[] { 15 }, torch.int64)) {
                 var outTensor = multi_margin_loss(input, target);
                 outTensor.backward();
+                Assert.Multiple(
+                () => Assert.Empty(outTensor.shape),
+                () => Assert.False(float.IsNaN(outTensor.item<float>()))
+                );
             }
         }
 
@@ -1200,7 +1322,10 @@ namespace TorchSharp
 
                 var output = TripletMarginLoss();
                 var result = output.forward(anchor, positive, negative);
-                Assert.True(true);
+                Assert.Multiple(
+                () => Assert.Empty(result.shape),
+                () => Assert.False(float.IsNaN(result.item<float>()))
+                );
             }
         }
 
@@ -1212,7 +1337,10 @@ namespace TorchSharp
             using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
 
                 var result = triplet_margin_loss(anchor, positive, negative);
-                Assert.True(true);
+                Assert.Multiple(
+                () => Assert.Empty(result.shape),
+                () => Assert.False(float.IsNaN(result.item<float>()))
+                );
             }
         }
 
@@ -1230,7 +1358,10 @@ namespace TorchSharp
 
                 var output = TripletMarginWithDistanceLoss(distance);
                 var result = output.forward(anchor, positive, negative);
-                Assert.True(true);
+                Assert.Multiple(
+                () => Assert.Empty(result.shape),
+                () => Assert.False(float.IsNaN(result.item<float>()))
+                );
             }
         }
 
@@ -1247,7 +1378,10 @@ namespace TorchSharp
             using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
 
                 var result = triplet_margin_with_distance_loss(anchor, positive, negative, distance);
-                Assert.True(true);
+                Assert.Multiple(
+                () => Assert.Empty(result.shape),
+                () => Assert.False(float.IsNaN(result.item<float>()))
+                );
             }
         }
 
@@ -1260,7 +1394,10 @@ namespace TorchSharp
 
                 var output = TripletMarginWithDistanceLoss();
                 var result = output.forward(anchor, positive, negative);
-                Assert.True(true);
+                Assert.Multiple(
+                () => Assert.Empty(result.shape),
+                () => Assert.False(float.IsNaN(result.item<float>()))
+                );
             }
         }
 
@@ -1272,7 +1409,10 @@ namespace TorchSharp
             using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
 
                 var result = triplet_margin_with_distance_loss(anchor, positive, negative);
-                Assert.True(true);
+                Assert.Multiple(
+                () => Assert.Empty(result.shape),
+                () => Assert.False(float.IsNaN(result.item<float>()))
+                );
             }
         }
 

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -753,6 +753,17 @@ namespace TorchSharp
                 Assert.True(componentWiseLoss.mean().Equals(torch.nn.PoissonNLLLoss(reduction: Reduction.Mean).forward(input, target)));
             }
         }
+        [Fact]
+        public void TestPoissonNLLLossF()
+        {
+            using (Tensor input = torch.tensor(new float[] { 0.5f, 1.5f, 2.5f }))
+            using (Tensor target = torch.tensor(new float[] { 1f, 2f, 3f })) {
+                var componentWiseLoss = ((Tensor)input.exp()) - target * input;
+                Assert.True(componentWiseLoss.Equals(torch.nn.functional.poisson_nll_loss(input, target, reduction: Reduction.None)));
+                Assert.True(componentWiseLoss.sum().Equals(torch.nn.functional.poisson_nll_loss(input, target, reduction: Reduction.Sum)));
+                Assert.True(componentWiseLoss.mean().Equals(torch.nn.functional.poisson_nll_loss(input, target, reduction: Reduction.Mean)));
+            }
+        }
 
         [Fact]
         public void TestPoissonNLLLoss2()
@@ -760,6 +771,18 @@ namespace TorchSharp
             using (Tensor input = torch.rand(new long[] { 5, 2 }))
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
                 var outTensor = torch.nn.PoissonNLLLoss(true, true).forward(input, target);
+                var values = outTensor.data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestPoissonNLLLossF2()
+        {
+            using (Tensor input = torch.rand(new long[] { 5, 2 }))
+            using (Tensor target = torch.rand(new long[] { 5, 2 })) {
+                var outTensor = torch.nn.functional.poisson_nll_loss(input, target, true, true);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -779,11 +802,35 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestCrossEntropyLossF()
+        {
+            using (Tensor input = torch.rand(new long[] { 5, 12 }))
+            using (Tensor target = torch.randint(12, new long[] { 5 }, torch.int64)) {
+                var outTensor = cross_entropy(input, target);
+                var values = outTensor.data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
         public void TestL1Loss()
         {
             using (Tensor input = torch.rand(new long[] { 5, 2 }))
             using (Tensor target = torch.rand(new long[] { 5, 2 })) {
                 var outTensor = L1Loss().forward(input, target);
+                var values = outTensor.data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestL1LossF()
+        {
+            using (Tensor input = torch.rand(new long[] { 5, 2 }))
+            using (Tensor target = torch.rand(new long[] { 5, 2 })) {
+                var outTensor = l1_loss(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -804,11 +851,36 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestBinaryCrossEntropyLossF()
+        {
+            var m = Sigmoid();
+            using (Tensor input = torch.randn(new long[] { 3 }))
+            using (Tensor target = torch.randn(new long[] { 3 })) {
+                var outTensor = binary_cross_entropy(m.forward(input), target);
+                var values = outTensor.data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
         public void TestBinaryCrossEntropyLossWithLogits()
         {
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = BCEWithLogitsLoss().forward(input, target);
+                var values = outTensor.data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestBinaryCrossEntropyLossWithLogitsF()
+        {
+            using (Tensor input = torch.randn(new long[] { 3 }))
+            using (Tensor target = torch.randn(new long[] { 3 })) {
+                var outTensor = binary_cross_entropy_with_logits(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -828,6 +900,18 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestKLDivLossF()
+        {
+            using (Tensor input = torch.randn(new long[] { 3 }))
+            using (Tensor target = torch.randn(new long[] { 3 })) {
+                var outTensor = kl_div(input, target);
+                var values = outTensor.data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
         public void TestSmoothL1Loss()
         {
             using (Tensor input = torch.randn(new long[] { 3 }))
@@ -840,11 +924,35 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestSmoothL1LossF()
+        {
+            using (Tensor input = torch.randn(new long[] { 3 }))
+            using (Tensor target = torch.randn(new long[] { 3 })) {
+                var outTensor = smooth_l1_loss(input, target);
+                var values = outTensor.data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
         public void TestSoftMarginLoss()
         {
             using (Tensor input = torch.randn(new long[] { 3 }))
             using (Tensor target = torch.randn(new long[] { 3 })) {
                 var outTensor = SoftMarginLoss().forward(input, target);
+                var values = outTensor.data<float>().ToArray();
+                Assert.Empty(outTensor.shape);
+                Assert.Single(values);
+            }
+        }
+
+        [Fact]
+        public void TestSoftMarginLossF()
+        {
+            using (Tensor input = torch.randn(new long[] { 3 }))
+            using (Tensor target = torch.randn(new long[] { 3 })) {
+                var outTensor = soft_margin_loss(input, target);
                 var values = outTensor.data<float>().ToArray();
                 Assert.Empty(outTensor.shape);
                 Assert.Single(values);
@@ -945,12 +1053,15 @@ namespace TorchSharp
         }
 
         [Fact]
-        public void TestCTCLoss()
+        public void TestCosineEmbeddingLossF()
         {
-            using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
-            using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
-                var outTensor = HingeEmbeddingLoss().forward(input, target);
+            using (Tensor input1 = torch.rand(new long[] { 15, 5 }, requiresGrad: true).neg())
+            using (Tensor input2 = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor target = torch.randn(new long[] { 15 }).sign()) {
+
+                var outTensor = cosine_embedding_loss(input1, input2, target);
                 outTensor.backward();
+
             }
         }
 
@@ -960,6 +1071,16 @@ namespace TorchSharp
             using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
                 var outTensor = HingeEmbeddingLoss().forward(input, target);
+                outTensor.backward();
+            }
+        }
+
+        [Fact]
+        public void TestHingeEmbeddingLossF()
+        {
+            using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
+                var outTensor = hinge_embedding_loss(input, target);
                 outTensor.backward();
             }
         }
@@ -977,12 +1098,35 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestHuberLossF()
+        {
+            using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor target = torch.randn(new long[] { 15, 5 }).sign()) {
+                var outTensor = huber_loss(input, target);
+                outTensor.backward();
+                outTensor = huber_loss(input, target, 1.5);
+                outTensor.backward();
+            }
+        }
+
+        [Fact]
         public void TestMarginRankingLoss()
         {
             using (Tensor input1 = torch.randn(new long[] { 15 }, requiresGrad: true))
             using (Tensor input2 = torch.randn(new long[] { 15 }, requiresGrad: true))
             using (Tensor target = torch.randn(new long[] { 15 }).sign()) {
                 var outTensor = MarginRankingLoss().forward(input1, input2, target);
+                outTensor.backward();
+            }
+        }
+
+        [Fact]
+        public void TestMarginRankingLossF()
+        {
+            using (Tensor input1 = torch.randn(new long[] { 15 }, requiresGrad: true))
+            using (Tensor input2 = torch.randn(new long[] { 15 }, requiresGrad: true))
+            using (Tensor target = torch.randn(new long[] { 15 }).sign()) {
+                var outTensor = margin_ranking_loss(input1, input2, target);
                 outTensor.backward();
             }
         }
@@ -998,11 +1142,31 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestMultilabelMarginLossF()
+        {
+            using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor target = torch.ones(new long[] { 15, 5 }, torch.int64)) {
+                var outTensor = multi_label_margin_loss(input, target);
+                outTensor.backward();
+            }
+        }
+
+        [Fact]
         public void TestMultilabelSoftMarginLoss()
         {
             using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor target = torch.ones(new long[] { 15, 5 })) {
                 var outTensor = MultiLabelSoftMarginLoss().forward(input, target);
+                outTensor.backward();
+            }
+        }
+
+        [Fact]
+        public void TestMultilabelSoftMarginLossF()
+        {
+            using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor target = torch.ones(new long[] { 15, 5 })) {
+                var outTensor = multilabel_soft_margin_loss(input, target);
                 outTensor.backward();
             }
         }
@@ -1018,6 +1182,16 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestMultiMarginLossF()
+        {
+            using (Tensor input = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor target = torch.ones(new long[] { 15 }, torch.int64)) {
+                var outTensor = multi_margin_loss(input, target);
+                outTensor.backward();
+            }
+        }
+
+        [Fact]
         public void TestTripleMarginLoss()
         {
             using (Tensor anchor = torch.rand(new long[] { 15, 5 }, requiresGrad: true).neg())
@@ -1026,6 +1200,18 @@ namespace TorchSharp
 
                 var output = TripletMarginLoss();
                 var result = output.forward(anchor, positive, negative);
+                Assert.True(true);
+            }
+        }
+
+        [Fact]
+        public void TestTripleMarginLossF()
+        {
+            using (Tensor anchor = torch.rand(new long[] { 15, 5 }, requiresGrad: true).neg())
+            using (Tensor positive = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
+
+                var result = triplet_margin_loss(anchor, positive, negative);
                 Assert.True(true);
             }
         }
@@ -1049,6 +1235,23 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestTripleMarginWithDistanceLossF()
+        {
+            Func<Tensor, Tensor, Tensor> distance =
+                (x, y) => {
+                    return (x - y).abs();
+                };
+
+            using (Tensor anchor = torch.rand(new long[] { 15, 5 }, requiresGrad: true).neg())
+            using (Tensor positive = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
+
+                var result = triplet_margin_with_distance_loss(anchor, positive, negative, distance);
+                Assert.True(true);
+            }
+        }
+
+        [Fact]
         public void TestTripleMarginWithDistanceLossNoDistance()
         {
             using (Tensor anchor = torch.rand(new long[] { 15, 5 }, requiresGrad: true).neg())
@@ -1057,6 +1260,18 @@ namespace TorchSharp
 
                 var output = TripletMarginWithDistanceLoss();
                 var result = output.forward(anchor, positive, negative);
+                Assert.True(true);
+            }
+        }
+
+        [Fact]
+        public void TestTripleMarginWithDistanceLossNoDistanceF()
+        {
+            using (Tensor anchor = torch.rand(new long[] { 15, 5 }, requiresGrad: true).neg())
+            using (Tensor positive = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
+            using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
+
+                var result = triplet_margin_with_distance_loss(anchor, positive, negative);
                 Assert.True(true);
             }
         }

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -806,10 +806,10 @@ namespace TorchSharp
             using var x = torch.randn(new long[] { 64, 10 });
             using var y = torch.randn(new long[] { 64, 10 });
 
-            var loss = torch.nn.functional.mse_loss(Reduction.Sum);
+            var loss = torch.nn.MSELoss(Reduction.Sum);
 
             using var eval = seq.forward(x);
-            var output = loss(eval, y);
+            var output = loss.forward(eval, y);
 
             var l = output.ToSingle();
 
@@ -876,10 +876,10 @@ namespace TorchSharp
             using var x = torch.randn(new long[] { 64, 10 });
             using var y = torch.randn(new long[] { 64, 10 });
 
-            var loss = torch.nn.functional.mse_loss(Reduction.Sum);
+            var loss = torch.nn.MSELoss(Reduction.Sum);
 
             using var eval = seq.forward(x);
-            var output = loss(eval, y);
+            var output = loss.forward(eval, y);
 
             var l = output.ToSingle();
 

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -97,8 +97,8 @@ namespace TorchSharp
             using (Tensor positive = torch.randn(new long[] { 15, 5 }, requiresGrad: true))
             using (Tensor negative = torch.randn(new long[] { 15, 5 })) {
 
-                var output = nn.functional.triplet_margin_with_distance_loss(distance);
-                using (var result = output(anchor, positive, negative)) { }
+                var output = nn.TripletMarginWithDistanceLoss(distance);
+                using (var result = output.forward(anchor, positive, negative)) { }
             }
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -120,11 +120,11 @@ namespace TorchSharp
 
             double learning_rate = 0.00004f;
             var optimizer = torch.optim.LBFGS(seq.parameters(), learning_rate);
-            var loss = nn.functional.mse_loss(Reduction.Sum);
+            var loss = nn.MSELoss(Reduction.Sum);
 
             Func<Tensor> closure = () => {
                 using var eval = seq.forward(x);
-                var output = loss(eval, y);
+                var output = loss.forward(eval, y);
 
                 var l = output.ToSingle();
 
@@ -561,8 +561,8 @@ namespace TorchSharp
                 var y = torch.ones(5, 4).cuda();
 
                 var z = model.forward(x);
-                var lossFunc = torch.nn.functional.cross_entropy_loss();
-                var loss = lossFunc(y, z);
+                var lossFunc = torch.nn.CrossEntropyLoss();
+                var loss = lossFunc.forward(y, z);
                 loss.backward();
                 optimizer.step();
 

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -40,14 +40,14 @@ namespace TorchSharp
             var y = torch.randn(new long[] { 64, 10 });
 
             float learning_rate = 0.00004f;
-            var loss = mse_loss(Reduction.Sum);
+            var loss = MSELoss(Reduction.Sum);
 
-            float initialLoss = loss(seq.forward(x), y).ToSingle();
+            float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
                 var eval = seq.forward(x);
-                var output = loss(eval, y);
+                var output = loss.forward(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -84,14 +84,14 @@ namespace TorchSharp
             var y = torch.randn(new long[] { 64, 10 });
 
             float learning_rate = 0.00004f;
-            var loss = mse_loss(Reduction.Sum);
+            var loss = MSELoss(Reduction.Sum);
 
-            float initialLoss = loss(seq.forward(x), y).ToSingle();
+            float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
                 var eval = seq.forward(x);
-                var output = loss(eval, y);
+                var output = loss.forward(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -188,14 +188,14 @@ namespace TorchSharp
 
         private static float TrainLoop(Module seq, Tensor x, Tensor y, optim.Optimizer optimizer)
         {
-            var loss = mse_loss(Reduction.Sum);
+            var loss = MSELoss(Reduction.Sum);
 
-            float initialLoss = loss(seq.forward(x), y).ToSingle();
+            float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
                 using var eval = seq.forward(x);
-                using var output = loss(eval, y);
+                using var output = loss.forward(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -215,9 +215,9 @@ namespace TorchSharp
 
         private static float TrainLoop(Module seq, Tensor x, Tensor y, optim.Optimizer optimizer, optim.lr_scheduler.LRScheduler scheduler, bool check_lr = true, int iters = 10)
         {
-            var loss = mse_loss(Reduction.Sum);
+            var loss = MSELoss(Reduction.Sum);
 
-            float initialLoss = loss(seq.forward(x), y).ToSingle();
+            float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
             var pgFirst = optimizer.ParamGroups.First();
@@ -225,7 +225,7 @@ namespace TorchSharp
 
             for (int i = 0; i < iters; i++) {
                 using var eval = seq.forward(x);
-                using var output = loss(eval, y);
+                using var output = loss.forward(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -1514,16 +1514,16 @@ namespace TorchSharp
             var optimizer = torch.optim.SGD(seq.parameters(), learning_rate);
             var scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer, new int[] { 3, 5, 7 }, 0.97);
 
-            var loss = mse_loss(Reduction.Sum);
+            var loss = MSELoss(Reduction.Sum);
 
-            float initialLoss = loss(seq.forward(x), y).ToSingle();
+            float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
             double lastLR = learning_rate;
 
             for (int i = 0; i < 10; i++) {
                 using var eval = seq.forward(x);
-                using var output = loss(eval, y);
+                using var output = loss.forward(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -1560,16 +1560,16 @@ namespace TorchSharp
             var optimizer = torch.optim.SGD(seq.parameters(), learning_rate);
             var scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, 10);
 
-            var loss = mse_loss(Reduction.Sum);
+            var loss = MSELoss(Reduction.Sum);
 
-            float initialLoss = loss(seq.forward(x), y).ToSingle();
+            float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
             double lastLR = learning_rate;
 
             for (int i = 0; i < 10; i++) {
                 using var eval = seq.forward(x);
-                using var output = loss(eval, y);
+                using var output = loss.forward(eval, y);
                 var lossVal = output.ToSingle();
 
                 finalLoss = lossVal;
@@ -1640,16 +1640,16 @@ namespace TorchSharp
 
             double learning_rate = 0.00004f;
             var optimizer = torch.optim.LBFGS(seq.parameters(), learning_rate);
-            var loss = mse_loss(Reduction.Sum);
+            var loss = MSELoss(Reduction.Sum);
 
-            float initialLoss = loss(seq.forward(x), y).ToSingle();
+            float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
             for (int i = 0; i < 10; i++) {
 
                 Func<Tensor> closure = () => {
                     using var eval = seq.forward(x);
-                    var output = loss(eval, y);
+                    var output = loss.forward(eval, y);
 
                     finalLoss = output.ToSingle();
 
@@ -1692,9 +1692,9 @@ namespace TorchSharp
 
             double learning_rate = 0.00004f;
             var optimizer = torch.optim.LBFGS(seq.parameters(), learning_rate, max_iter: 15, max_eval: 15);
-            var loss = mse_loss(Reduction.Sum);
+            var loss = MSELoss(Reduction.Sum);
 
-            float initialLoss = loss(seq.forward(x), y).ToSingle();
+            float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
             float finalLoss = float.MaxValue;
 
             Assert.Throws<ArgumentNullException>(() => optimizer.step(null));
@@ -1703,7 +1703,7 @@ namespace TorchSharp
 
                 Func<Tensor> closure = () => {
                     using var eval = seq.forward(x);
-                    var output = loss(eval, y);
+                    var output = loss.forward(eval, y);
 
                     finalLoss = output.ToSingle();
 
@@ -1786,17 +1786,17 @@ namespace TorchSharp
                     seq.to((Device)device);
 
                     var optimizer = torch.optim.Adam(seq.parameters());
-                    var loss = mse_loss(Reduction.Sum);
+                    var loss = MSELoss(Reduction.Sum);
 
                     using (Tensor x = torch.randn(new long[] { 64, 3, 28, 28 }, device: (Device)device),
                            y = torch.randn(new long[] { 64, 10 }, device: (Device)device)) {
 
-                        float initialLoss = loss(seq.forward(x), y).ToSingle();
+                        float initialLoss = loss.forward(seq.forward(x), y).ToSingle();
                         float finalLoss = float.MaxValue;
 
                         for (int i = 0; i < 10; i++) {
                             var eval = seq.forward(x);
-                            var output = loss(eval, y);
+                            var output = loss.forward(eval, y);
                             var lossVal = output.ToSingle();
 
                             finalLoss = lossVal;


### PR DESCRIPTION
The most immediate consequence is that losses are modules rather than delegates, which means you need to call `.forward()` to actually compute the loss. Also, the factories are in `torch.nn` rather than `torch.nn.functional` and have the same Pascal-casing as the corresponding types.

The members of the `torch.nn.functional` static class are now proper immediate loss functions, whereas the previous ones returned a loss delegate.