### PR TITLE
WIP: Yet another draft solution for the forward() problem.

### DIFF
--- a/src/Examples/AlexNet.cs
+++ b/src/Examples/AlexNet.cs
@@ -8,11 +8,11 @@ namespace TorchSharp.Examples
     /// <summary>
     /// Modified version of original AlexNet to fix CIFAR10 32x32 images.
     /// </summary>
-    class AlexNet : Module
+    class AlexNet : Module<Tensor, Tensor>
     {
-        private readonly Module features;
-        private readonly Module avgPool;
-        private readonly Module classifier;
+        private readonly Module<Tensor, Tensor> features;
+        private readonly Module<Tensor, Tensor> avgPool;
+        private readonly Module<Tensor, Tensor> classifier;
 
         public AlexNet(string name, int numClasses, torch.Device device = null) : base(name)
         {

--- a/src/Examples/CIFAR10.cs
+++ b/src/Examples/CIFAR10.cs
@@ -56,7 +56,7 @@ namespace TorchSharp.Examples
 
             Console.WriteLine($"\tCreating the model...");
 
-            Module model = null;
+            Module<torch.Tensor, torch.Tensor> model = null;
 
             switch (modelName.ToLower()) {
             case "alexnet":
@@ -134,7 +134,7 @@ namespace TorchSharp.Examples
         }
 
         private static void Train(
-            Module model,
+            Module<torch.Tensor, torch.Tensor> model,
             torch.optim.Optimizer optimizer,
             Loss loss,
             DataLoader dataLoader,
@@ -182,7 +182,7 @@ namespace TorchSharp.Examples
         }
 
         private static void Test(
-            Module model,
+            Module<torch.Tensor, torch.Tensor> model,
             Loss loss,
             DataLoader dataLoader,
             long size)

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -96,26 +96,26 @@ namespace TorchSharp.Examples
             model.save(dataset + ".model.bin");
         }
 
-        internal class Model : Module
+        internal class Model : Module<Tensor, Tensor>
         {
-            private Module conv1 = Conv2d(1, 32, 3);
-            private Module conv2 = Conv2d(32, 64, 3);
-            private Module fc1 = Linear(9216, 128);
-            private Module fc2 = Linear(128, 10);
+            private Module<Tensor, Tensor> conv1 = Conv2d(1, 32, 3);
+            private Module<Tensor, Tensor> conv2 = Conv2d(32, 64, 3);
+            private Module<Tensor, Tensor> fc1 = Linear(9216, 128);
+            private Module<Tensor, Tensor> fc2 = Linear(128, 10);
 
             // These don't have any parameters, so the only reason to instantiate
             // them is performance, since they will be used over and over.
-            private Module pool1 = MaxPool2d(kernelSize: new long[] { 2, 2 });
+            private Module<Tensor, Tensor> pool1 = MaxPool2d(kernelSize: new long[] { 2, 2 });
 
-            private Module relu1 = ReLU();
-            private Module relu2 = ReLU();
-            private Module relu3 = ReLU();
+            private Module<Tensor, Tensor> relu1 = ReLU();
+            private Module<Tensor, Tensor> relu2 = ReLU();
+            private Module<Tensor, Tensor> relu3 = ReLU();
 
-            private Module dropout1 = Dropout(0.25);
-            private Module dropout2 = Dropout(0.5);
+            private Module<Tensor, Tensor> dropout1 = Dropout(0.25);
+            private Module<Tensor, Tensor> dropout2 = Dropout(0.5);
 
-            private Module flatten = Flatten();
-            private Module logsm = LogSoftmax(1);
+            private Module<Tensor, Tensor> flatten = Flatten();
+            private Module<Tensor, Tensor> logsm = LogSoftmax(1);
 
             public Model(string name, torch.Device device = null) : base(name)
             {

--- a/src/Examples/MobileNet.cs
+++ b/src/Examples/MobileNet.cs
@@ -14,7 +14,7 @@ namespace TorchSharp.Examples
     /// With an unaugmented CIFAR-10 data set, the author of this saw training converge
     /// at roughly 75% accuracy on the test set, over the course of 1500 epochs.
     /// </remarks>
-    class MobileNet : Module
+    class MobileNet : Module<Tensor, Tensor>
     {
         // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/mobilenet.py
         // Licence and copypright notice at: https://github.com/kuangliu/pytorch-cifar/blob/master/LICENSE
@@ -22,13 +22,13 @@ namespace TorchSharp.Examples
         private readonly long[] planes = new long[] { 64, 128, 128, 256, 256, 512, 512, 512, 512, 512, 512, 1024, 1024 };
         private readonly long[] strides = new long[] { 1, 2, 1, 2, 1, 2, 1, 1, 1, 1, 1, 2, 1 };
 
-        private readonly Module layers;
+        private readonly Module<Tensor, Tensor> layers;
 
         public MobileNet(string name, int numClasses, Device device = null) : base(name)
         {
             if (planes.Length != strides.Length) throw new ArgumentException("'planes' and 'strides' must have the same length.");
 
-            var modules = new List<(string, Module)>();
+            var modules = new List<(string, Module<Tensor, Tensor>)>();
 
             modules.Add(($"conv2d-first", Conv2d(3, 32, kernelSize: 3, stride: 1, padding: 1, bias: false)));
             modules.Add(($"bnrm2d-first", BatchNorm2d(32)));
@@ -46,7 +46,7 @@ namespace TorchSharp.Examples
                 this.to(device);
         }
 
-        private void MakeLayers(List<(string, Module)> modules, long in_planes)
+        private void MakeLayers(List<(string, Module<Tensor, Tensor>)> modules, long in_planes)
         {
 
             for (var i = 0; i < strides.Length; i++) {

--- a/src/Examples/ResNet.cs
+++ b/src/Examples/ResNet.cs
@@ -10,12 +10,12 @@ namespace TorchSharp.Examples
     /// <summary>
     /// Modified version of ResNet to classify CIFAR10 32x32 images.
     /// </summary>
-    class ResNet : Module
+    class ResNet : Module<Tensor, Tensor>
     {
         // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/resnet.py
         // Licence and copypright notice at: https://github.com/kuangliu/pytorch-cifar/blob/master/LICENSE
 
-        private readonly Module layers;
+        private readonly Module<Tensor, Tensor> layers;
         private int in_planes = 64;
 
         public static ResNet ResNet18(int numClasses, Device device = null)
@@ -68,9 +68,9 @@ namespace TorchSharp.Examples
                 device);
         }
 
-        public ResNet(string name, Func<string, int,int,int,Module> block, int expansion, IList<int> num_blocks, int numClasses, Device device = null) : base(name)
+        public ResNet(string name, Func<string, int,int,int,Module<Tensor, Tensor>> block, int expansion, IList<int> num_blocks, int numClasses, Device device = null) : base(name)
         {
-            var modules = new List<(string, Module)>();
+            var modules = new List<(string, Module<Tensor, Tensor>)>();
 
             modules.Add(($"conv2d-first", Conv2d(3, 64, kernelSize: 3, stride: 1, padding: 1, bias: false)));
             modules.Add(($"bnrm2d-first", BatchNorm2d(64)));
@@ -91,7 +91,7 @@ namespace TorchSharp.Examples
                 this.to(device);
         }
 
-        private void MakeLayer(List<(string, Module)> modules, Func<string, int, int, int, Module> block, int expansion, int planes, int num_blocks, int stride)
+        private void MakeLayer(List<(string, Module<Tensor, Tensor>)> modules, Func<string, int, int, int, Module<Tensor, Tensor>> block, int expansion, int planes, int num_blocks, int stride)
         {
             var strides = new List<int>();
             strides.Add(stride);
@@ -109,11 +109,11 @@ namespace TorchSharp.Examples
             return layers.forward(input);
         }
 
-        class BasicBlock : Module
+        class BasicBlock : Module<Tensor, Tensor>
         {
             public BasicBlock (string name, int in_planes, int planes, int stride) : base(name)
             {
-                var modules = new List<(string, Module)>();
+                var modules = new List<(string, Module<Tensor, Tensor>)>();
 
                 modules.Add(($"{name}-conv2d-1", Conv2d(in_planes, planes, kernelSize: 3, stride: stride, padding: 1, bias: false)));
                 modules.Add(($"{name}-bnrm2d-1", BatchNorm2d(planes)));
@@ -146,15 +146,15 @@ namespace TorchSharp.Examples
 
             public static int expansion = 1;
 
-            private readonly Module layers;
-            private readonly Module shortcut;
+            private readonly Module<Tensor, Tensor> layers;
+            private readonly Module<Tensor, Tensor> shortcut;
         }
 
-        class Bottleneck : Module
+        class Bottleneck : Module<Tensor, Tensor>
         {
             public Bottleneck(string name, int in_planes, int planes, int stride) : base(name)
             {
-                var modules = new List<(string, Module)>();
+                var modules = new List<(string, Module<Tensor, Tensor>)>();
 
                 modules.Add(($"{name}-conv2d-1", Conv2d(in_planes, planes, kernelSize: 1, bias: false)));
                 modules.Add(($"{name}-bnrm2d-1", BatchNorm2d(planes)));
@@ -187,8 +187,8 @@ namespace TorchSharp.Examples
 
             public static int expansion = 4;
 
-            private readonly Module layers;
-            private readonly Module shortcut;
+            private readonly Module<Tensor, Tensor> layers;
+            private readonly Module<Tensor, Tensor> shortcut;
         }
     }
 }

--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -211,9 +211,9 @@ namespace TorchSharp.Examples
             return (data, target);
         }
 
-        class TransformerModel : Module
+        class TransformerModel : Module<Tensor, Tensor, Tensor>
         {
-            private Module transformer_encoder;
+            private Modules.TransformerEncoder transformer_encoder;
             private PositionalEncoding pos_encoder;
             private Modules.Embedding encoder;
             private Modules.Linear decoder;
@@ -252,11 +252,6 @@ namespace TorchSharp.Examples
                 init.uniform_(decoder.weight, -initrange, initrange);
             }
 
-            public override Tensor forward(Tensor t)
-            {
-                throw new NotImplementedException("single-argument forward()");
-            }
-
             public override Tensor forward(Tensor t, Tensor mask)
             {
                 var src = pos_encoder.forward(encoder.forward(t) * MathF.Sqrt(ninputs));
@@ -271,9 +266,9 @@ namespace TorchSharp.Examples
             }
         }
 
-        class PositionalEncoding : Module
+        class PositionalEncoding : Module<Tensor, Tensor>
         {
-            private Module dropout;
+            private Module<Tensor, Tensor> dropout;
             private Tensor pe;
 
             public PositionalEncoding(long dmodel, double dropout, int maxLen = 5000) : base("PositionalEncoding")

--- a/src/Examples/SpeechCommands.cs
+++ b/src/Examples/SpeechCommands.cs
@@ -217,21 +217,21 @@ namespace TorchSharp.Examples
             public torch.Tensor label;
         }
 
-        internal class M5 : Module
+        internal class M5 : Module<Tensor, Tensor>
         {
-            private readonly Module conv1;
-            private readonly Module bn1;
-            private readonly Module pool1;
-            private readonly Module conv2;
-            private readonly Module bn2;
-            private readonly Module pool2;
-            private readonly Module conv3;
-            private readonly Module bn3;
-            private readonly Module pool3;
-            private readonly Module conv4;
-            private readonly Module bn4;
-            private readonly Module pool4;
-            private readonly Module fc1;
+            private readonly Module<Tensor, Tensor> conv1;
+            private readonly Module<Tensor, Tensor> bn1;
+            private readonly Module<Tensor, Tensor> pool1;
+            private readonly Module<Tensor, Tensor> conv2;
+            private readonly Module<Tensor, Tensor> bn2;
+            private readonly Module<Tensor, Tensor> pool2;
+            private readonly Module<Tensor, Tensor> conv3;
+            private readonly Module<Tensor, Tensor> bn3;
+            private readonly Module<Tensor, Tensor> pool3;
+            private readonly Module<Tensor, Tensor> conv4;
+            private readonly Module<Tensor, Tensor> bn4;
+            private readonly Module<Tensor, Tensor> pool4;
+            private readonly Module<Tensor, Tensor> fc1;
 
             public M5(string name, int n_input = 1, int n_output = 35, int stride = 16, int n_channel = 32) : base(name)
             {

--- a/src/Examples/TextClassification.cs
+++ b/src/Examples/TextClassification.cs
@@ -166,7 +166,7 @@ namespace TorchSharp.Examples
         }
     }
 
-    class TextClassificationModel : Module
+    class TextClassificationModel : Module<Tensor, Tensor>
     {
         private Modules.EmbeddingBag embedding;
         private Modules.Linear fc;
@@ -194,7 +194,7 @@ namespace TorchSharp.Examples
             throw new NotImplementedException();
         }
 
-        public override Tensor forward(Tensor input, Tensor offsets)
+        public Tensor forward(Tensor input, Tensor offsets)
         {
             return fc.forward(embedding.forward(input, offsets));
         }

--- a/src/Examples/VGG.cs
+++ b/src/Examples/VGG.cs
@@ -13,7 +13,7 @@ namespace TorchSharp.Examples
     /// With an unaugmented CIFAR-10 data set, the author of this saw training converge
     /// at roughly 85% accuracy on the test set, after 50 epochs using VGG-16.
     /// </remarks>
-    class VGG : Module
+    class VGG : Module<Tensor, Tensor>
     {
         // The code here is is loosely based on https://github.com/kuangliu/pytorch-cifar/blob/master/models/vgg.py
         // Licence and copypright notice at: https://github.com/kuangliu/pytorch-cifar/blob/master/LICENSE
@@ -25,11 +25,11 @@ namespace TorchSharp.Examples
             { "VGG19", new long[] { 64, 64, 0, 128, 128, 0, 256, 256, 256, 256, 0, 512, 512, 512, 512, 0, 512, 512, 512, 512, 0 } }
         };
 
-        private readonly Module layers;
+        private readonly Module<Tensor, Tensor> layers;
 
         public VGG(string name, int numClasses, Device device = null) : base(name)
         {
-            var modules = new List<(string, Module)>();
+            var modules = new List<(string, Module<Tensor, Tensor>)>();
 
             var channels = _channels[name];
 

--- a/src/TorchSharp/JIT/ScriptModule.cs
+++ b/src/TorchSharp/JIT/ScriptModule.cs
@@ -13,7 +13,7 @@ namespace TorchSharp
     {
         public static partial class jit
         {
-            public class ScriptModule : torch.nn.Module
+            public class ScriptModule : torch.nn.Module<Tensor, Tensor>
             {
                 internal ScriptModule(IntPtr handle) : base(new HType(handle, true, THSJIT_Module_dispose), null)
                 {
@@ -290,7 +290,7 @@ namespace TorchSharp
                 /// <param name="x">The first input tensor</param>
                 /// <param name="y">The second input tensor</param>
                 /// <returns></returns>
-                public unsafe override Tensor forward(Tensor x, Tensor y)
+                public unsafe Tensor forward(Tensor x, Tensor y)
                 {
                     var tensorRefs = stackalloc[] { x.Handle, y.Handle };
                     var res = THSJIT_Module_forward(handle, (IntPtr)tensorRefs, 2);
@@ -306,7 +306,7 @@ namespace TorchSharp
                 /// <param name="y">The second input tensor</param>
                 /// <param name="z">The third input tensor</param>
                 /// <returns></returns>
-                public unsafe override Tensor forward(Tensor x, Tensor y, Tensor z)
+                public unsafe Tensor forward(Tensor x, Tensor y, Tensor z)
                 {
                     var tensorRefs = stackalloc[] { x.Handle, y.Handle, z.Handle };
                     var res = THSJIT_Module_forward(handle, (IntPtr)tensorRefs, 3);
@@ -380,7 +380,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern void THSJIT_save(nn.Module.HType handle, string filename);
+            private static extern void THSJIT_save(nn.Module<Tensor, Tensor>.HType handle, string filename);
 
             /// <summary>
             /// Save an offline version of a previously loaded script module.

--- a/src/TorchSharp/NN/Activation/CELU.cs
+++ b/src/TorchSharp/NN/Activation/CELU.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a CELU module.
         /// </summary>
-        public class CELU : torch.nn.Module
+        public class CELU : torch.nn.Module<Tensor, Tensor>
         {
             internal CELU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_CELU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_CELU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/ELU.cs
+++ b/src/TorchSharp/NN/Activation/ELU.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ELU module.
         /// </summary>
-        public class ELU : torch.nn.Module
+        public class ELU : torch.nn.Module<Tensor, Tensor>
         {
             internal ELU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ELU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ELU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/GELU.cs
+++ b/src/TorchSharp/NN/Activation/GELU.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a GELU module.
         /// </summary>
-        public class GELU : torch.nn.Module
+        public class GELU : torch.nn.Module<Tensor, Tensor>
         {
             internal GELU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GELU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_GELU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/GLU.cs
+++ b/src/TorchSharp/NN/Activation/GLU.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a GLU (gated linear unit) module.
         /// </summary>
-        public class GLU : torch.nn.Module
+        public class GLU : torch.nn.Module<Tensor, Tensor>
         {
             internal GLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_GLU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Hardshrink.cs
+++ b/src/TorchSharp/NN/Activation/Hardshrink.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Hardshrink module.
         /// </summary>
-        public class Hardshrink : torch.nn.Module
+        public class Hardshrink : torch.nn.Module<Tensor, Tensor>
         {
             internal Hardshrink(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Hardshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Hardshrink_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Hardsigmoid.cs
+++ b/src/TorchSharp/NN/Activation/Hardsigmoid.cs
@@ -11,7 +11,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Hardsigmoid module.
         /// </summary>
-        public class Hardsigmoid : torch.nn.Module
+        public class Hardsigmoid : torch.nn.Module<Tensor, Tensor>
         {
             private readonly bool inplace;
 

--- a/src/TorchSharp/NN/Activation/Hardswish.cs
+++ b/src/TorchSharp/NN/Activation/Hardswish.cs
@@ -11,7 +11,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Hardswish module.
         /// </summary>
-        public class Hardswish : torch.nn.Module
+        public class Hardswish : torch.nn.Module<Tensor, Tensor>
         {
             private readonly bool inplace;
 

--- a/src/TorchSharp/NN/Activation/Hardtanh.cs
+++ b/src/TorchSharp/NN/Activation/Hardtanh.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Hardtanh module.
         /// </summary>
-        public class Hardtanh : torch.nn.Module
+        public class Hardtanh : torch.nn.Module<Tensor, Tensor>
         {
             internal Hardtanh(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Hardtanh_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Hardtanh_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/LeakyReLU.cs
+++ b/src/TorchSharp/NN/Activation/LeakyReLU.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a LeakyReLU module.
         /// </summary>
-        public class LeakyReLU : torch.nn.Module
+        public class LeakyReLU : torch.nn.Module<Tensor, Tensor>
         {
             internal LeakyReLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LeakyReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_LeakyReLU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/LogSoftMax.cs
+++ b/src/TorchSharp/NN/Activation/LogSoftMax.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a log softmax module.
         /// </summary>
-        public class LogSoftmax : torch.nn.Module
+        public class LogSoftmax : torch.nn.Module<Tensor, Tensor>
         {
             internal LogSoftmax(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LogSoftmax_forward(torch.nn.Module.HType handle, IntPtr tensor);
+            private static extern IntPtr THSNN_LogSoftmax_forward(torch.nn.Module<Tensor, Tensor>.HType handle, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Mish.cs
+++ b/src/TorchSharp/NN/Activation/Mish.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Mish module.
         /// </summary>
-        public class Mish : torch.nn.Module
+        public class Mish : torch.nn.Module<Tensor, Tensor>
         {
             internal Mish(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Mish_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Mish_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/RReLU.cs
+++ b/src/TorchSharp/NN/Activation/RReLU.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a RReLU module.
         /// </summary>
-        public class RReLU : torch.nn.Module
+        public class RReLU : torch.nn.Module<Tensor, Tensor>
         {
             internal RReLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_RReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_RReLU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/ReLU6.cs
+++ b/src/TorchSharp/NN/Activation/ReLU6.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ReLU6 module.
         /// </summary>
-        public class ReLU6 : torch.nn.Module
+        public class ReLU6 : torch.nn.Module<Tensor, Tensor>
         {
             internal ReLU6(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReLU6_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ReLU6_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/ReLu.cs
+++ b/src/TorchSharp/NN/Activation/ReLu.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ReLU module.
         /// </summary>
-        public class ReLU : torch.nn.Module
+        public class ReLU : torch.nn.Module<Tensor, Tensor>
         {
             internal ReLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ReLU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/SELU.cs
+++ b/src/TorchSharp/NN/Activation/SELU.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a SELU module.
         /// </summary>
-        public class SELU : torch.nn.Module
+        public class SELU : torch.nn.Module<Tensor, Tensor>
         {
             internal SELU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_SELU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_SELU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/SiLU.cs
+++ b/src/TorchSharp/NN/Activation/SiLU.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a SiLU module.
         /// </summary>
-        public class SiLU : torch.nn.Module
+        public class SiLU : torch.nn.Module<Tensor, Tensor>
         {
             internal SiLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_SiLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_SiLU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Sigmoid.cs
+++ b/src/TorchSharp/NN/Activation/Sigmoid.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Sigmoid module.
         /// </summary>
-        public class Sigmoid : torch.nn.Module
+        public class Sigmoid : torch.nn.Module<Tensor, Tensor>
         {
             internal Sigmoid(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Sigmoid_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Sigmoid_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Softmax.cs
+++ b/src/TorchSharp/NN/Activation/Softmax.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Softmax module.
         /// </summary>
-        public class Softmax : torch.nn.Module
+        public class Softmax : torch.nn.Module<Tensor, Tensor>
         {
             internal Softmax(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softmax_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Softmax_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Softmax2d.cs
+++ b/src/TorchSharp/NN/Activation/Softmax2d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Softmax2d module.
         /// </summary>
-        public class Softmax2d : torch.nn.Module
+        public class Softmax2d : torch.nn.Module<Tensor, Tensor>
         {
             internal Softmax2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softmax2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Softmax2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Softmin.cs
+++ b/src/TorchSharp/NN/Activation/Softmin.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Softmin module.
         /// </summary>
-        public class Softmin : torch.nn.Module
+        public class Softmin : torch.nn.Module<Tensor, Tensor>
         {
             internal Softmin(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softmin_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Softmin_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Softplus.cs
+++ b/src/TorchSharp/NN/Activation/Softplus.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Softplus module.
         /// </summary>
-        public class Softplus : torch.nn.Module
+        public class Softplus : torch.nn.Module<Tensor, Tensor>
         {
             internal Softplus(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softplus_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Softplus_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Softshrink.cs
+++ b/src/TorchSharp/NN/Activation/Softshrink.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Softshrink module.
         /// </summary>
-        public class Softshrink : torch.nn.Module
+        public class Softshrink : torch.nn.Module<Tensor, Tensor>
         {
             internal Softshrink(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Softshrink_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Softsign.cs
+++ b/src/TorchSharp/NN/Activation/Softsign.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Softsign module.
         /// </summary>
-        public class Softsign : torch.nn.Module
+        public class Softsign : torch.nn.Module<Tensor, Tensor>
         {
             internal Softsign(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softsign_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Softsign_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Tanh.cs
+++ b/src/TorchSharp/NN/Activation/Tanh.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Tanh module.
         /// </summary>
-        public class Tanh : torch.nn.Module
+        public class Tanh : torch.nn.Module<Tensor, Tensor>
         {
             internal Tanh(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Tanh_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Tanh_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Tanhshrink.cs
+++ b/src/TorchSharp/NN/Activation/Tanhshrink.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Tanhshrink module.
         /// </summary>
-        public class Tanhshrink : torch.nn.Module
+        public class Tanhshrink : torch.nn.Module<Tensor, Tensor>
         {
             internal Tanhshrink(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Tanhshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Tanhshrink_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Activation/Threshold.cs
+++ b/src/TorchSharp/NN/Activation/Threshold.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Threshold module.
         /// </summary>
-        public class Threshold : torch.nn.Module
+        public class Threshold : torch.nn.Module<Tensor, Tensor>
         {
             internal Threshold(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Threshold_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Threshold_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/AlphaDropout.cs
+++ b/src/TorchSharp/NN/AlphaDropout.cs
@@ -17,12 +17,12 @@ namespace TorchSharp
         /// The elements to masked are randomized on every forward call, and scaled and shifted to maintain zero mean and unit standard deviation.
         /// During evaluation the module simply computes an identity function.
         /// </summary>
-        public class AlphaDropout : torch.nn.Module
+        public class AlphaDropout : torch.nn.Module<Tensor, Tensor>
         {
             internal AlphaDropout(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AlphaDropout_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_AlphaDropout_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Bilinear.cs
+++ b/src/TorchSharp/NN/Bilinear.cs
@@ -11,18 +11,18 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class Bilinear : torch.nn.Module
+        public class Bilinear : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal Bilinear(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             public new static Bilinear Load(String modelPath)
             {
-                var res = Module.Load(modelPath);
+                var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new Bilinear(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Bilinear_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
+            extern static IntPtr THSNN_Bilinear_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr input1, IntPtr input2);
 
             public override Tensor forward(Tensor input1, Tensor input2)
             {
@@ -31,9 +31,9 @@ namespace TorchSharp
                 return new Tensor(res);
             }
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Bilinear_bias(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Bilinear_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Bilinear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Bilinear_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -48,9 +48,9 @@ namespace TorchSharp
                 }
             }
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Bilinear_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Bilinear_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Bilinear_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Bilinear_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/Convolution/Conv1D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv1D.cs
@@ -25,12 +25,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class Conv1d : torch.nn.Module
+        public class Conv1d : torch.nn.Module<Tensor, Tensor>
         {
             internal Conv1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Conv1d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -40,9 +40,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv1d_bias(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Conv1d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv1d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Conv1d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -57,9 +57,9 @@ namespace TorchSharp
                 }
             }
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv1d_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Conv1d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv1d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Conv1d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/Convolution/Conv2D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv2D.cs
@@ -10,12 +10,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class Conv2d : torch.nn.Module
+        public class Conv2d : torch.nn.Module<Tensor, Tensor>
         {
             internal Conv2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Conv2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -25,9 +25,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv2d_bias(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Conv2d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv2d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Conv2d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -42,9 +42,9 @@ namespace TorchSharp
                 }
             }
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv2d_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Conv2d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv2d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Conv2d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/Convolution/Conv3D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv3D.cs
@@ -10,12 +10,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class Conv3d : torch.nn.Module
+        public class Conv3d : torch.nn.Module<Tensor, Tensor>
         {
             internal Conv3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Conv3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -25,9 +25,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv3d_bias(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Conv3d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv3d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Conv3d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -42,9 +42,9 @@ namespace TorchSharp
                 }
             }
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv3d_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Conv3d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv3d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Conv3d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
@@ -10,12 +10,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class ConvTranspose1d : torch.nn.Module
+        public class ConvTranspose1d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConvTranspose1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ConvTranspose1d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -25,9 +25,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose1d_bias(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_ConvTranspose1d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose1d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_ConvTranspose1d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -42,9 +42,9 @@ namespace TorchSharp
                 }
             }
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose1d_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_ConvTranspose1d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose1d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_ConvTranspose1d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
@@ -10,12 +10,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class ConvTranspose2d : torch.nn.Module
+        public class ConvTranspose2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConvTranspose2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ConvTranspose2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -25,9 +25,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose2d_bias(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_ConvTranspose2d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose2d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_ConvTranspose2d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -42,9 +42,9 @@ namespace TorchSharp
                 }
             }
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose2d_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_ConvTranspose2d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose2d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_ConvTranspose2d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight
                 {

--- a/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
@@ -10,12 +10,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class ConvTranspose3d : torch.nn.Module
+        public class ConvTranspose3d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConvTranspose3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ConvTranspose3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -25,9 +25,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose3d_bias(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_ConvTranspose3d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose3d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_ConvTranspose3d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -42,9 +42,9 @@ namespace TorchSharp
                 }
             }
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose3d_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_ConvTranspose3d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose3d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_ConvTranspose3d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/CosineSimilarity.cs
+++ b/src/TorchSharp/NN/CosineSimilarity.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a dropout module for 2d/3d convolutational layers.
         /// </summary>
-        public class CosineSimilarity : torch.nn.Module
+        public class CosineSimilarity : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal CosineSimilarity(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Dropout.cs
+++ b/src/TorchSharp/NN/Dropout.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a dropout module.
         /// </summary>
-        public class Dropout : torch.nn.Module
+        public class Dropout : torch.nn.Module<Tensor, Tensor>
         {
             internal Dropout(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Dropout_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Dropout_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Dropout2d.cs
+++ b/src/TorchSharp/NN/Dropout2d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Dropout2d module.
         /// </summary>
-        public class Dropout2d : torch.nn.Module
+        public class Dropout2d : torch.nn.Module<Tensor, Tensor>
         {
             internal Dropout2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Dropout2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Dropout2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Dropout3d.cs
+++ b/src/TorchSharp/NN/Dropout3d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Dropout3d module.
         /// </summary>
-        public class Dropout3d : torch.nn.Module
+        public class Dropout3d : torch.nn.Module<Tensor, Tensor>
         {
             internal Dropout3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Dropout3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Dropout3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Embedding.cs
+++ b/src/TorchSharp/NN/Embedding.cs
@@ -10,12 +10,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class Embedding : torch.nn.Module
+        public class Embedding : torch.nn.Module<Tensor, Tensor>
         {
             internal Embedding(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Embedding_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Embedding_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor input)
             {
@@ -25,10 +25,10 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Embedding_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Embedding_weight(torch.nn.Module<Tensor, Tensor>.HType module);
 
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Embedding_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Embedding_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -17,12 +17,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class EmbeddingBag : torch.nn.Module
+        public class EmbeddingBag : torch.nn.Module<Tensor, Tensor>
         {
             internal EmbeddingBag(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_EmbeddingBag_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr offsets, IntPtr per_sample_weights);
+            private static extern IntPtr THSNN_EmbeddingBag_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, IntPtr offsets, IntPtr per_sample_weights);
 
             /// <summary>
             /// Forward pass of EmbeddingBag.
@@ -33,7 +33,7 @@ namespace TorchSharp
             /// If specified, per_sample_weights must have exactly the same shape as input and is treated as having the same offsets, if those are not None.
             /// Only supported for mode='sum'.</param>
             /// <returns></returns>
-            public override Tensor forward(Tensor input, Tensor offsets, Tensor perSampleWeights)
+            public Tensor forward(Tensor input, Tensor offsets, Tensor perSampleWeights)
             {
                 if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
                 if (!(offsets is null) && input.dtype != offsets.dtype) throw new ArgumentException("input and offsets must have the same element type.");
@@ -53,7 +53,7 @@ namespace TorchSharp
             /// <param name="input">Tensor containing bags of indices into the embedding matrix.</param>
             /// <param name="offsets">Only used when input is 1D. offsets determines the starting index position of each bag (sequence) in input.</param>
             /// <returns></returns>
-            public override Tensor forward(Tensor input, Tensor offsets)
+            public Tensor forward(Tensor input, Tensor offsets)
             {
                 if (!input.IsIntegral()) throw new ArgumentException("Embedding input must be an integral tensor.");
                 if (!(offsets is null) && input.dtype != offsets.dtype) throw new ArgumentException("input and offsets must have the same element type.");
@@ -85,10 +85,10 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_EmbeddingBag_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_EmbeddingBag_weight(torch.nn.Module<Tensor, Tensor>.HType module);
 
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_EmbeddingBag_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_EmbeddingBag_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/FeatureDropout.cs
+++ b/src/TorchSharp/NN/FeatureDropout.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a dropout module for 2d/3d convolutational layers.
         /// </summary>
-        public class FeatureAlphaDropout : torch.nn.Module
+        public class FeatureAlphaDropout : torch.nn.Module<Tensor, Tensor>
         {
             internal FeatureAlphaDropout(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FeatureAlphaDropout_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_FeatureAlphaDropout_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Flatten.cs
+++ b/src/TorchSharp/NN/Flatten.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a dropout module for 2d/3d convolutational layers.
         /// </summary>
-        public class Flatten : torch.nn.Module
+        public class Flatten : torch.nn.Module<Tensor, Tensor>
         {
             internal Flatten(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Flatten_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Flatten_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Identity.cs
+++ b/src/TorchSharp/NN/Identity.cs
@@ -10,12 +10,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class Identity : torch.nn.Module
+        public class Identity : torch.nn.Module<Tensor, Tensor>
         {
             internal Identity(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Identity_forward(torch.nn.Module.HType module, IntPtr tensor);
+            extern static IntPtr THSNN_Identity_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class Linear : torch.nn.Module
+        public class Linear : torch.nn.Module<Tensor, Tensor>
         {
             internal Linear(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -20,12 +20,12 @@ namespace TorchSharp
 
             public new static Linear Load(String modelPath)
             {
-                var res = Module.Load(modelPath);
+                var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new Linear(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Linear_forward(torch.nn.Module.HType module, IntPtr tensor);
+            extern static IntPtr THSNN_Linear_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -35,9 +35,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Linear_bias(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Linear_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Linear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Linear_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
             public Parameter? bias {
                 get {
                     var res = THSNN_Linear_bias(handle);
@@ -52,9 +52,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Linear_weight(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_Linear_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_Linear_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_Linear_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -803,15 +803,6 @@ namespace TorchSharp
                     return res;
                 }
 
-                public virtual Tensor forward(Tensor t)
-                    => throw new NotImplementedException("forward(t)");
-
-                public virtual Tensor forward(Tensor x, Tensor y)
-                    => throw new NotImplementedException("forward(x,y)");
-
-                public virtual Tensor forward(Tensor x, Tensor y, Tensor z)
-                    => throw new NotImplementedException("forward(x,y,z)");
-
                 /// <summary>
                 /// Save the parameters and buffers of the module to a disk location.
                 /// </summary>
@@ -979,7 +970,7 @@ namespace TorchSharp
                     IntPtr ForwardNative(IntPtr t)
                     {
                         var input = new Tensor(t);
-                        var output = forward(input);
+                        var output = ((nn.Module<Tensor, Tensor>)this).forward(input);
 
                         // handles must live on - we don't own them, but
                         // the managed objects should go away.
@@ -1119,6 +1110,22 @@ namespace TorchSharp
                         handle.SetHandleAsInvalid();
                     }
                 }
+            }
+
+            public abstract class Module<T1, TResult> : Module
+            {
+                protected Module(string name) : base(name) { }
+                protected Module(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+                internal Module(HType handle, IntPtr? boxedHandle) : base(handle, boxedHandle) { }
+                public abstract TResult forward(T1 input1);
+            }
+
+            public abstract class Module<T1, T2, TResult> : Module
+            {
+                protected Module(string name) : base(name) { }
+                protected Module(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
+                internal Module(HType handle, IntPtr? boxedHandle) : base(handle, boxedHandle) { }
+                public abstract TResult forward(T1 input1, T2 input2);
             }
         }
     }

--- a/src/TorchSharp/NN/MultiheadAttention.cs
+++ b/src/TorchSharp/NN/MultiheadAttention.cs
@@ -15,7 +15,7 @@ namespace TorchSharp
             internal MultiheadAttention(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_MultiheadAttention_forward(torch.nn.Module.HType module, IntPtr query, IntPtr key, IntPtr value, IntPtr key_padding_mask, bool need_weights, IntPtr attn_mask, out IntPtr res1, out IntPtr res2);
+            private static extern void THSNN_MultiheadAttention_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr query, IntPtr key, IntPtr value, IntPtr key_padding_mask, bool need_weights, IntPtr attn_mask, out IntPtr res1, out IntPtr res2);
             /// <summary>
             /// Applies the MultiheadAttention function element-wise.
             /// </summary>

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -13,7 +13,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a BatchNorm1D module.
         /// </summary>
-        public class BatchNorm1d : torch.nn.Module
+        public class BatchNorm1d : torch.nn.Module<Tensor, Tensor>
         {
             internal BatchNorm1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -31,25 +31,25 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_bias(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm1d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            private static extern void THSNN_BatchNorm1d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr bias);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_weight(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm1d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm1d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_reset_stats(torch.nn.Module.HType module);
+            private static extern void THSNN_BatchNorm1d_reset_stats(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_get_mean(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm1d_get_mean(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_get_var(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm1d_get_var(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_get_batches(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm1d_get_batches(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm1d_set_mean(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_set_var(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm1d_set_var(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -13,7 +13,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a BatchNorm2D module.
         /// </summary>
-        public class BatchNorm2d : torch.nn.Module
+        public class BatchNorm2d : torch.nn.Module<Tensor, Tensor>
         {
             internal BatchNorm2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -31,25 +31,25 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_bias(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm2d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            private static extern void THSNN_BatchNorm2d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr bias);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_weight(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm2d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm2d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_reset_stats(torch.nn.Module.HType module);
+            private static extern void THSNN_BatchNorm2d_reset_stats(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_get_mean(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm2d_get_mean(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_get_var(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm2d_get_var(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_get_batches(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm2d_get_batches(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm2d_set_mean(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_set_var(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm2d_set_var(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -13,7 +13,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a BatchNorm3D module.
         /// </summary>
-        public class BatchNorm3d : torch.nn.Module
+        public class BatchNorm3d : torch.nn.Module<Tensor, Tensor>
         {
             internal BatchNorm3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -31,25 +31,25 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_bias(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm3d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            private static extern void THSNN_BatchNorm3d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr bias);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_weight(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm3d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm3d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_reset_stats(torch.nn.Module.HType module);
+            private static extern void THSNN_BatchNorm3d_reset_stats(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_get_mean(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm3d_get_mean(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_get_var(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm3d_get_var(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_get_batches(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_BatchNorm3d_get_batches(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm3d_set_mean(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_set_var(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_BatchNorm3d_set_var(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {

--- a/src/TorchSharp/NN/Normalization/GroupNorm.cs
+++ b/src/TorchSharp/NN/Normalization/GroupNorm.cs
@@ -14,7 +14,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a GroupNorm module.
         /// </summary>
-        public class GroupNorm : torch.nn.Module
+        public class GroupNorm : torch.nn.Module<Tensor, Tensor>
         {
             internal GroupNorm(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -32,13 +32,13 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GroupNorm_bias(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_GroupNorm_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_GroupNorm_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            private static extern void THSNN_GroupNorm_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr bias);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GroupNorm_weight(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_GroupNorm_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_GroupNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_GroupNorm_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {

--- a/src/TorchSharp/NN/Normalization/InstanceNorm1d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm1d.cs
@@ -14,7 +14,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a InstanceNorm1D module.
         /// </summary>
-        public class InstanceNorm1d : torch.nn.Module
+        public class InstanceNorm1d : torch.nn.Module<Tensor, Tensor>
         {
             internal InstanceNorm1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -32,25 +32,25 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_bias(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm1d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            private static extern void THSNN_InstanceNorm1d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr bias);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_weight(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm1d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm1d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_reset_stats(torch.nn.Module.HType module);
+            private static extern void THSNN_InstanceNorm1d_reset_stats(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_get_mean(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm1d_get_mean(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_get_var(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm1d_get_var(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_get_batches(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm1d_get_batches(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm1d_set_mean(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_set_var(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm1d_set_var(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {

--- a/src/TorchSharp/NN/Normalization/InstanceNorm2d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm2d.cs
@@ -14,7 +14,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a InstanceNorm2D module.
         /// </summary>
-        public class InstanceNorm2d : torch.nn.Module
+        public class InstanceNorm2d : torch.nn.Module<Tensor, Tensor>
         {
             internal InstanceNorm2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -32,25 +32,25 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_bias(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm2d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            private static extern void THSNN_InstanceNorm2d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr bias);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_weight(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm2d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm2d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_reset_stats(torch.nn.Module.HType module);
+            private static extern void THSNN_InstanceNorm2d_reset_stats(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_get_mean(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm2d_get_mean(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_get_var(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm2d_get_var(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_get_batches(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm2d_get_batches(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm2d_set_mean(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_set_var(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm2d_set_var(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {

--- a/src/TorchSharp/NN/Normalization/InstanceNorm3d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm3d.cs
@@ -14,7 +14,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a InstanceNorm3D module.
         /// </summary>
-        public class InstanceNorm3d : torch.nn.Module
+        public class InstanceNorm3d : torch.nn.Module<Tensor, Tensor>
         {
             internal InstanceNorm3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -32,25 +32,25 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_bias(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm3d_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            private static extern void THSNN_InstanceNorm3d_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr bias);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_weight(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm3d_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm3d_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_reset_stats(torch.nn.Module.HType module);
+            private static extern void THSNN_InstanceNorm3d_reset_stats(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_get_mean(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm3d_get_mean(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_get_var(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm3d_get_var(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_get_batches(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_InstanceNorm3d_get_batches(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm3d_set_mean(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_set_var(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_InstanceNorm3d_set_var(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {

--- a/src/TorchSharp/NN/Normalization/LayerNorm.cs
+++ b/src/TorchSharp/NN/Normalization/LayerNorm.cs
@@ -14,7 +14,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a LayerNorm module.
         /// </summary>
-        public class LayerNorm : torch.nn.Module
+        public class LayerNorm : torch.nn.Module<Tensor, Tensor>
         {
             internal LayerNorm(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -31,13 +31,13 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LayerNorm_bias(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_LayerNorm_bias(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_LayerNorm_set_bias(torch.nn.Module.HType module, IntPtr bias);
+            private static extern void THSNN_LayerNorm_set_bias(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr bias);
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LayerNorm_weight(torch.nn.Module.HType module);
+            private static extern IntPtr THSNN_LayerNorm_weight(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            private static extern void THSNN_LayerNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
+            private static extern void THSNN_LayerNorm_set_weight(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {

--- a/src/TorchSharp/NN/Normalization/LocalResponseNorm.cs
+++ b/src/TorchSharp/NN/Normalization/LocalResponseNorm.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a LocalResponseNorm module.
         /// </summary>
-        public class LocalResponseNorm : torch.nn.Module
+        public class LocalResponseNorm : torch.nn.Module<Tensor, Tensor>
         {
             internal LocalResponseNorm(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Padding/ConstantPad1d.cs
+++ b/src/TorchSharp/NN/Padding/ConstantPad1d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ConstantPad1d module.
         /// </summary>
-        public class ConstantPad1d : torch.nn.Module
+        public class ConstantPad1d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConstantPad1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConstantPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ConstantPad1d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ConstantPad2d.cs
+++ b/src/TorchSharp/NN/Padding/ConstantPad2d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ConstantPad2d module.
         /// </summary>
-        public class ConstantPad2d : torch.nn.Module
+        public class ConstantPad2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConstantPad2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConstantPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ConstantPad2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ConstantPad3d.cs
+++ b/src/TorchSharp/NN/Padding/ConstantPad3d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ConstantPad3d module.
         /// </summary>
-        public class ConstantPad3d : torch.nn.Module
+        public class ConstantPad3d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConstantPad3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConstantPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ConstantPad3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ReflectionPad1d.cs
+++ b/src/TorchSharp/NN/Padding/ReflectionPad1d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ReflectionPad1d module.
         /// </summary>
-        public class ReflectionPad1d : torch.nn.Module
+        public class ReflectionPad1d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReflectionPad1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReflectionPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ReflectionPad1d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ReflectionPad2d.cs
+++ b/src/TorchSharp/NN/Padding/ReflectionPad2d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ReflectionPad2d module.
         /// </summary>
-        public class ReflectionPad2d : torch.nn.Module
+        public class ReflectionPad2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReflectionPad2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReflectionPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ReflectionPad2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ReflectionPad3d.cs
+++ b/src/TorchSharp/NN/Padding/ReflectionPad3d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ReflectionPad3d module.
         /// </summary>
-        public class ReflectionPad3d : torch.nn.Module
+        public class ReflectionPad3d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReflectionPad3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReflectionPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ReflectionPad3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ReplicationPad1d.cs
+++ b/src/TorchSharp/NN/Padding/ReplicationPad1d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ReplicationPad1d module.
         /// </summary>
-        public class ReplicationPad1d : torch.nn.Module
+        public class ReplicationPad1d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReplicationPad1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReplicationPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ReplicationPad1d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ReplicationPad2d.cs
+++ b/src/TorchSharp/NN/Padding/ReplicationPad2d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ReplicationPad2d module.
         /// </summary>
-        public class ReplicationPad2d : torch.nn.Module
+        public class ReplicationPad2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReplicationPad2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReplicationPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ReplicationPad2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ReplicationPad3d.cs
+++ b/src/TorchSharp/NN/Padding/ReplicationPad3d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ReplicationPad3d module.
         /// </summary>
-        public class ReplicationPad3d : torch.nn.Module
+        public class ReplicationPad3d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReplicationPad3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReplicationPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ReplicationPad3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Padding/ZeroPad2d.cs
+++ b/src/TorchSharp/NN/Padding/ZeroPad2d.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ZeroPad2d module.
         /// </summary>
-        public class ZeroPad2d : torch.nn.Module
+        public class ZeroPad2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ZeroPad2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ZeroPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_ZeroPad2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/PairwiseDistance.cs
+++ b/src/TorchSharp/NN/PairwiseDistance.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// Computes the pairwise distance between vectors using the p-norm.
         /// </summary>
-        public class PairwiseDistance : torch.nn.Module
+        public class PairwiseDistance : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal PairwiseDistance(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_PairwiseDistance_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
+            private static extern IntPtr THSNN_PairwiseDistance_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr input1, IntPtr input2);
 
             public override Tensor forward(Tensor input1, Tensor input2)
             {

--- a/src/TorchSharp/NN/PixelShuffle.cs
+++ b/src/TorchSharp/NN/PixelShuffle.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a dropout module.
         /// </summary>
-        public class PixelShuffle : torch.nn.Module
+        public class PixelShuffle : torch.nn.Module<Tensor, Tensor>
         {
             internal PixelShuffle(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_PixelShuffle_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_PixelShuffle_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/PixelUnshuffle.cs
+++ b/src/TorchSharp/NN/PixelUnshuffle.cs
@@ -12,12 +12,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a dropout module.
         /// </summary>
-        public class PixelUnshuffle : torch.nn.Module
+        public class PixelUnshuffle : torch.nn.Module<Tensor, Tensor>
         {
             internal PixelUnshuffle(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_PixelUnshuffle_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_PixelUnshuffle_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool1D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AdaptiveAvgPool1D module.
         /// </summary>
-        public class AdaptiveAvgPool1d : torch.nn.Module
+        public class AdaptiveAvgPool1d : torch.nn.Module<Tensor, Tensor>
         {
             internal AdaptiveAvgPool1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool2D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AdaptiveAvgPool2D module.
         /// </summary>
-        public class AdaptiveAvgPool2d : torch.nn.Module
+        public class AdaptiveAvgPool2d : torch.nn.Module<Tensor, Tensor>
         {
             internal AdaptiveAvgPool2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool3D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AdaptiveAvgPool3D module.
         /// </summary>
-        public class AdaptiveAvgPool3d : torch.nn.Module
+        public class AdaptiveAvgPool3d : torch.nn.Module<Tensor, Tensor>
         {
             internal AdaptiveAvgPool3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool1D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AdaptiveMaxPool1D module.
         /// </summary>
-        public class AdaptiveMaxPool1d : torch.nn.Module
+        public class AdaptiveMaxPool1d : torch.nn.Module<Tensor, Tensor>
         {
             internal AdaptiveMaxPool1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool2D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AdaptiveMaxPool2D module.
         /// </summary>
-        public class AdaptiveMaxPool2d : torch.nn.Module
+        public class AdaptiveMaxPool2d : torch.nn.Module<Tensor, Tensor>
         {
             internal AdaptiveMaxPool2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool3D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AdaptiveMaxPool3D module.
         /// </summary>
-        public class AdaptiveMaxPool3d : torch.nn.Module
+        public class AdaptiveMaxPool3d : torch.nn.Module<Tensor, Tensor>
         {
             internal AdaptiveMaxPool3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/AvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool1D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AvgPool1D module.
         /// </summary>
-        public class AvgPool1d : torch.nn.Module
+        public class AvgPool1d : torch.nn.Module<Tensor, Tensor>
         {
             internal AvgPool1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/AvgPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool2D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AvgPool2D module.
         /// </summary>
-        public class AvgPool2d : torch.nn.Module
+        public class AvgPool2d : torch.nn.Module<Tensor, Tensor>
         {
             internal AvgPool2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/AvgPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool3D.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a AvgPool3D module.
         /// </summary>
-        public class AvgPool3d : torch.nn.Module
+        public class AvgPool3d : torch.nn.Module<Tensor, Tensor>
         {
             internal AvgPool3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/FractionalMaxPool2d.cs
+++ b/src/TorchSharp/NN/Pooling/FractionalMaxPool2d.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a FractionalMaxPool2D module.
         /// </summary>
-        public class FractionalMaxPool2d : torch.nn.Module
+        public class FractionalMaxPool2d : torch.nn.Module<Tensor, Tensor>
         {
             internal FractionalMaxPool2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FractionalMaxPool2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_FractionalMaxPool2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -29,7 +29,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FractionalMaxPool2d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+            private static extern IntPtr THSNN_FractionalMaxPool2d_forward_with_indices(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Pooling/FractionalMaxPool3d.cs
+++ b/src/TorchSharp/NN/Pooling/FractionalMaxPool3d.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a FractionalMaxPool3d module.
         /// </summary>
-        public class FractionalMaxPool3d : torch.nn.Module
+        public class FractionalMaxPool3d : torch.nn.Module<Tensor, Tensor>
         {
             internal FractionalMaxPool3d(IntPtr handle, IntPtr boxedHandle, bool ratio) : base(handle, boxedHandle)
             {
@@ -20,7 +20,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FractionalMaxPool3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_FractionalMaxPool3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -34,7 +34,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FractionalMaxPool3d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+            private static extern IntPtr THSNN_FractionalMaxPool3d_forward_with_indices(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Pooling/LPPool1d.cs
+++ b/src/TorchSharp/NN/Pooling/LPPool1d.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a LPPool1D module.
         /// </summary>
-        public class LPPool1d : torch.nn.Module
+        public class LPPool1d : torch.nn.Module<Tensor, Tensor>
         {
             internal LPPool1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/LPPool2d.cs
+++ b/src/TorchSharp/NN/Pooling/LPPool2d.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a LPPool2D module.
         /// </summary>
-        public class LPPool2d : torch.nn.Module
+        public class LPPool2d : torch.nn.Module<Tensor, Tensor>
         {
             internal LPPool2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {

--- a/src/TorchSharp/NN/Pooling/MaxPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool1D.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a MaxPool1D module.
         /// </summary>
-        public class MaxPool1d : torch.nn.Module
+        public class MaxPool1d : torch.nn.Module<Tensor, Tensor>
         {
             internal MaxPool1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_MaxPool1d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -29,7 +29,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool1d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+            private static extern IntPtr THSNN_MaxPool1d_forward_with_indices(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Pooling/MaxPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool2D.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a MaxPool2D module.
         /// </summary>
-        public class MaxPool2d : torch.nn.Module
+        public class MaxPool2d : torch.nn.Module<Tensor, Tensor>
         {
             internal MaxPool2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_MaxPool2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -29,7 +29,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool2d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+            private static extern IntPtr THSNN_MaxPool2d_forward_with_indices(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Pooling/MaxPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool3D.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a MaxPool3D module.
         /// </summary>
-        public class MaxPool3d : torch.nn.Module
+        public class MaxPool3d : torch.nn.Module<Tensor, Tensor>
         {
             internal MaxPool3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_MaxPool3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -29,7 +29,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool3d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+            private static extern IntPtr THSNN_MaxPool3d_forward_with_indices(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Pooling/MaxUnpool1d.cs
+++ b/src/TorchSharp/NN/Pooling/MaxUnpool1d.cs
@@ -19,7 +19,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxUnpool1d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize);
+            private static extern IntPtr THSNN_MaxUnpool1d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize);
 
             public Tensor forward(Tensor tensor, Tensor indices, long[] output_size = null)
             {

--- a/src/TorchSharp/NN/Pooling/MaxUnpool2d.cs
+++ b/src/TorchSharp/NN/Pooling/MaxUnpool2d.cs
@@ -19,7 +19,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxUnpool2d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize, int outputSizeLength);
+            private static extern IntPtr THSNN_MaxUnpool2d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize, int outputSizeLength);
 
             public Tensor forward(Tensor tensor, Tensor indices, long[] output_size = null)
             {

--- a/src/TorchSharp/NN/Pooling/MaxUnpool3d.cs
+++ b/src/TorchSharp/NN/Pooling/MaxUnpool3d.cs
@@ -19,7 +19,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxUnpool3d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize, int outputSizeLength);
+            private static extern IntPtr THSNN_MaxUnpool3d_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize, int outputSizeLength);
 
             public Tensor forward(Tensor tensor, Tensor indices, long[] output_size = null)
             {

--- a/src/TorchSharp/NN/Recurrent/GRU.cs
+++ b/src/TorchSharp/NN/Recurrent/GRU.cs
@@ -25,7 +25,7 @@ namespace TorchSharp
             private bool _batch_first;
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRU_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
+            extern static IntPtr THSNN_GRU_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
 
             /// <summary>
             /// Applies a multi-layer gated recurrent unit (GRU) RNN to an input sequence.
@@ -35,7 +35,7 @@ namespace TorchSharp
             /// Defaults to 0 if not provided. If the GRU is bidirectional, num_directions should be 2, else it should be 1.</param>
             /// <returns></returns>
             /// <returns></returns>
-            public new (Tensor, Tensor) forward(Tensor input, Tensor h0 = null)
+            public (Tensor, Tensor) forward(Tensor input, Tensor h0 = null)
             {
                 if (h0 is null) {
                     var N = _batch_first ? input.shape[0] : input.shape[1];
@@ -50,7 +50,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_GRU_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
+            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_GRU_forward_with_packed_input(torch.nn.Module<Tensor, Tensor>.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
 
             /// <summary>
             /// Applies a multi-layer gated recurrent unit (GRU) RNN to an input sequence.
@@ -77,7 +77,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRU_flatten_parameters(torch.nn.Module.HType module);
+            extern static void THSNN_GRU_flatten_parameters(torch.nn.Module<Tensor, Tensor>.HType module);
 
             public void flatten_parameters()
             {

--- a/src/TorchSharp/NN/Recurrent/GRUCell.cs
+++ b/src/TorchSharp/NN/Recurrent/GRUCell.cs
@@ -11,18 +11,18 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class GRUCell : torch.nn.Module
+        public class GRUCell : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal GRUCell(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             public new static GRUCell Load(String modelPath)
             {
-                var res = Module.Load(modelPath);
+                var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new GRUCell(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0);
+            extern static IntPtr THSNN_GRUCell_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr input, IntPtr h_0);
 
             /// <summary>
             /// Apply the GRU cell to an input tensor.
@@ -38,13 +38,13 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_bias_ih(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_GRUCell_bias_ih(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRUCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_GRUCell_set_bias_ih(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_bias_hh(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_GRUCell_bias_hh(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRUCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_GRUCell_set_bias_hh(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias_ih {
                 get {
@@ -73,13 +73,13 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_weight_ih(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_GRUCell_weight_ih(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRUCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_GRUCell_set_weight_ih(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_weight_hh(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_GRUCell_weight_hh(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRUCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_GRUCell_set_weight_hh(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight_ih {
                 get {

--- a/src/TorchSharp/NN/Recurrent/LSTM.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTM.cs
@@ -26,7 +26,7 @@ namespace TorchSharp
             private bool _batch_first;
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTM_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, IntPtr c_0, out IntPtr h_n, out IntPtr c_n);
+            extern static IntPtr THSNN_LSTM_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr input, IntPtr h_0, IntPtr c_0, out IntPtr h_n, out IntPtr c_n);
 
             /// <summary>
             /// Applies a multi-layer long short-term memory (LSTM) RNN to an input sequence.
@@ -55,7 +55,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_LSTM_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, IntPtr c_0, out IntPtr h_n, out IntPtr c_n);
+            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_LSTM_forward_with_packed_input(torch.nn.Module<Tensor, Tensor>.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, IntPtr c_0, out IntPtr h_n, out IntPtr c_n);
 
             /// <summary>
             /// Applies a multi-layer long short-term memory (LSTM) RNN to an input sequence.
@@ -86,7 +86,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTM_flatten_parameters(torch.nn.Module.HType module);
+            extern static void THSNN_LSTM_flatten_parameters(torch.nn.Module<Tensor, Tensor>.HType module);
 
             public void flatten_parameters()
             {

--- a/src/TorchSharp/NN/Recurrent/LSTMCell.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTMCell.cs
@@ -18,12 +18,12 @@ namespace TorchSharp
 
             public new static LSTMCell Load(String modelPath)
             {
-                var res = Module.Load(modelPath);
+                var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new LSTMCell(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, IntPtr c_0, out IntPtr c_n);
+            extern static IntPtr THSNN_LSTMCell_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr input, IntPtr h_0, IntPtr c_0, out IntPtr c_n);
 
             /// <summary>
             /// Apply the RNN cell to an input tensor.
@@ -39,13 +39,13 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_bias_ih(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_LSTMCell_bias_ih(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTMCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_LSTMCell_set_bias_ih(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_bias_hh(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_LSTMCell_bias_hh(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTMCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_LSTMCell_set_bias_hh(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias_ih {
                 get {
@@ -74,13 +74,13 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_weight_ih(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_LSTMCell_weight_ih(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTMCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_LSTMCell_set_weight_ih(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_weight_hh(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_LSTMCell_weight_hh(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTMCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_LSTMCell_set_weight_hh(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight_ih {
                 get {

--- a/src/TorchSharp/NN/Recurrent/RNN.cs
+++ b/src/TorchSharp/NN/Recurrent/RNN.cs
@@ -26,7 +26,7 @@ namespace TorchSharp
             private bool _batch_first;
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
+            extern static IntPtr THSNN_RNN_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
 
             /// <summary>
             /// Applies a multi-layer Elman RNN with \tanhtanh or \text{ReLU}ReLU non-linearity to an input sequence.
@@ -35,7 +35,7 @@ namespace TorchSharp
             /// <param name="h0">Tensor of shape (num_layers * num_directions, batch, hidden_size)containing the initial hidden state for each element in the batch.
             /// Defaults to 0 if not provided. If the RNN is bidirectional, num_directions should be 2, else it should be 1.</param>
             /// <returns></returns>
-            public new (Tensor, Tensor) forward(Tensor input, Tensor? h0 = null)
+            public (Tensor, Tensor) forward(Tensor input, Tensor? h0 = null)
             {
                 if (h0 is null) {
                     var N = _batch_first ? input.shape[0] : input.shape[1];
@@ -50,7 +50,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_RNN_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
+            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_RNN_forward_with_packed_input(torch.nn.Module<Tensor, Tensor>.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
 
             /// <summary>
             /// Applies a multi-layer Elman RNN with \tanhtanh or \text{ReLU}ReLU non-linearity to an input sequence.
@@ -76,7 +76,7 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNN_flatten_parameters(torch.nn.Module.HType module);
+            extern static void THSNN_RNN_flatten_parameters(torch.nn.Module<Tensor, Tensor>.HType module);
 
             public void flatten_parameters()
             {
@@ -85,9 +85,9 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_bias_ih(torch.nn.Module.HType module, long idx);
+            extern static IntPtr THSNN_RNN_bias_ih(torch.nn.Module<Tensor, Tensor>.HType module, long idx);
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_bias_hh(torch.nn.Module.HType module, long idx);
+            extern static IntPtr THSNN_RNN_bias_hh(torch.nn.Module<Tensor, Tensor>.HType module, long idx);
 
             public Parameter? get_bias_ih(long idx)
             {
@@ -126,9 +126,9 @@ namespace TorchSharp
 #endif
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_weight_ih(torch.nn.Module.HType module, long idx);
+            extern static IntPtr THSNN_RNN_weight_ih(torch.nn.Module<Tensor, Tensor>.HType module, long idx);
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_weight_hh(torch.nn.Module.HType module, long idx);
+            extern static IntPtr THSNN_RNN_weight_hh(torch.nn.Module<Tensor, Tensor>.HType module, long idx);
 
             public Parameter? get_weight_ih(long idx)
             {

--- a/src/TorchSharp/NN/Recurrent/RNNCell.cs
+++ b/src/TorchSharp/NN/Recurrent/RNNCell.cs
@@ -12,7 +12,7 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class RNNCell : torch.nn.Module
+        public class RNNCell : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal RNNCell(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
@@ -20,12 +20,12 @@ namespace TorchSharp
 
             public new static RNNCell Load(String modelPath)
             {
-                var res = Module.Load(modelPath);
+                var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new RNNCell(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0);
+            extern static IntPtr THSNN_RNNCell_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr input, IntPtr h_0);
 
             /// <summary>
             /// Apply the RNN cell to an input tensor.
@@ -41,13 +41,13 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_bias_ih(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_RNNCell_bias_ih(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNNCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_RNNCell_set_bias_ih(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_bias_hh(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_RNNCell_bias_hh(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNNCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_RNNCell_set_bias_hh(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? bias_ih {
                 get {
@@ -78,13 +78,13 @@ namespace TorchSharp
             }
 
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_weight_ih(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_RNNCell_weight_ih(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNNCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_RNNCell_set_weight_ih(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_weight_hh(torch.nn.Module.HType module);
+            extern static IntPtr THSNN_RNNCell_weight_hh(torch.nn.Module<Tensor, Tensor>.HType module);
             [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNNCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+            extern static void THSNN_RNNCell_set_weight_hh(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public Parameter? weight_ih {
                 get {

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -16,14 +16,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Sequential module.
         /// </summary>
-        public class Sequential : torch.nn.Module
+        public class Sequential : torch.nn.Module<Tensor, Tensor>
         {
-            public void append(string name, torch.nn.Module module)
+            public void append(string name, torch.nn.Module<Tensor, Tensor> module)
             {
                 Add(name, module);
             }
 
-            internal void Add(string name, torch.nn.Module submodule)
+            internal void Add(string name, torch.nn.Module<Tensor, Tensor> submodule)
             {
                 Debug.Assert(!handle.IsInvalid);
                 Debug.Assert(!submodule.handle.IsInvalid);
@@ -33,13 +33,13 @@ namespace TorchSharp
                 _names.Add(name);
             }
 
-            public void append(torch.nn.Module module)
+            public void append(torch.nn.Module<Tensor, Tensor> module)
             {
                 var name = _modules.Count.ToString();
                 Add(name, module);
             }
 
-            internal void Add(torch.nn.Module module)
+            internal void Add(torch.nn.Module<Tensor, Tensor> module)
             {
                 var name = _modules.Count.ToString();
                 Add(name, module);
@@ -186,7 +186,7 @@ namespace TorchSharp
             // The module handles are held in the native runtime, which calls back into managed code,
             // the .NET module instances need to stay alive, and keeping a list of them will do that.
 
-            private List<torch.nn.Module> _modules = new List<nn.Module>();
+            private List<torch.nn.Module<Tensor, Tensor>> _modules = new List<nn.Module<Tensor, Tensor>>();
             private List<string> _names = new List<string>();
         }
     }
@@ -221,7 +221,7 @@ namespace TorchSharp
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <returns></returns>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(params (string name, torch.nn.Module submodule)[] modules)
+            static public Sequential Sequential(params (string name, torch.nn.Module<Tensor, Tensor> submodule)[] modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)
@@ -238,7 +238,7 @@ namespace TorchSharp
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <returns></returns>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(params torch.nn.Module[] modules)
+            static public Sequential Sequential(params torch.nn.Module<Tensor, Tensor>[] modules)
             {
                 var res = Sequential();
                 foreach (var m in modules)
@@ -255,7 +255,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(params System.Tuple<string, torch.nn.Module>[] modules)
+            static public Sequential Sequential(params System.Tuple<string, torch.nn.Module<Tensor, Tensor>>[] modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)
@@ -272,7 +272,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(IEnumerable<(string name, torch.nn.Module submodule)> modules)
+            static public Sequential Sequential(IEnumerable<(string name, torch.nn.Module<Tensor, Tensor> submodule)> modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)
@@ -289,7 +289,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(IEnumerable<System.Tuple<string, torch.nn.Module>> modules)
+            static public Sequential Sequential(IEnumerable<System.Tuple<string, torch.nn.Module<Tensor, Tensor>>> modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)
@@ -306,7 +306,7 @@ namespace TorchSharp
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <returns></returns>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(IEnumerable<torch.nn.Module> modules)
+            static public Sequential Sequential(IEnumerable<torch.nn.Module<Tensor, Tensor>> modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)

--- a/src/TorchSharp/NN/Shuffle/ChannelShuffle.cs
+++ b/src/TorchSharp/NN/Shuffle/ChannelShuffle.cs
@@ -11,7 +11,7 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a ChannelShuffle module.
         /// </summary>
-        public class ChannelShuffle : torch.nn.Module
+        public class ChannelShuffle : torch.nn.Module<Tensor, Tensor>
         {
             internal ChannelShuffle(long groups) : base(nameof(ChannelShuffle))
             {

--- a/src/TorchSharp/NN/Transformer.cs
+++ b/src/TorchSharp/NN/Transformer.cs
@@ -9,12 +9,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class Transformer : torch.nn.Module
+        public class Transformer : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal Transformer(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Transformer_forward(torch.nn.Module.HType module, IntPtr src, IntPtr tgt, IntPtr src_mask, IntPtr tgt_mask, IntPtr memory_mask, IntPtr src_key_padding_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
+            private static extern IntPtr THSNN_Transformer_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr src, IntPtr tgt, IntPtr src_mask, IntPtr tgt_mask, IntPtr memory_mask, IntPtr src_key_padding_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
 
             /// <summary>
             /// Take in and process masked source/target sequences.

--- a/src/TorchSharp/NN/TransformerDecoder.cs
+++ b/src/TorchSharp/NN/TransformerDecoder.cs
@@ -9,12 +9,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class TransformerDecoder : torch.nn.Module
+        public class TransformerDecoder : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal TransformerDecoder(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerDecoder_forward(torch.nn.Module.HType module, IntPtr tgt, IntPtr memory, IntPtr tgt_mask, IntPtr memory_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
+            private static extern IntPtr THSNN_TransformerDecoder_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tgt, IntPtr memory, IntPtr tgt_mask, IntPtr memory_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
 
             /// <summary>
             /// Pass the inputs (and mask) through the decoder layers in turn.
@@ -64,7 +64,7 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerDecoder_ctor(torch.nn.Module.HType decoder_layer, long num_layers, out IntPtr pBoxedModule);
+            private static extern IntPtr THSNN_TransformerDecoder_ctor(torch.nn.Module<Tensor, Tensor>.HType decoder_layer, long num_layers, out IntPtr pBoxedModule);
 
             /// <summary>
             /// TransformerDecoder is a stack of N decoder layers

--- a/src/TorchSharp/NN/TransformerDecoderLayer.cs
+++ b/src/TorchSharp/NN/TransformerDecoderLayer.cs
@@ -9,12 +9,12 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class TransformerDecoderLayer : torch.nn.Module
+        public class TransformerDecoderLayer : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal TransformerDecoderLayer(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerDecoderLayer_forward(torch.nn.Module.HType module, IntPtr tgt, IntPtr memory, IntPtr tgt_mask, IntPtr memory_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
+            private static extern IntPtr THSNN_TransformerDecoderLayer_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tgt, IntPtr memory, IntPtr tgt_mask, IntPtr memory_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
 
             /// <summary>
             /// Pass the inputs (and mask) through the decoder layer.

--- a/src/TorchSharp/NN/TransformerEncoder.cs
+++ b/src/TorchSharp/NN/TransformerEncoder.cs
@@ -9,7 +9,7 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class TransformerEncoder : torch.nn.Module
+        public class TransformerEncoder : torch.nn.Module<Tensor, Tensor>
         {
             public enum Activations
             {
@@ -20,7 +20,7 @@ namespace TorchSharp
             internal TransformerEncoder(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerEncoder_forward(torch.nn.Module.HType module, IntPtr src, IntPtr src_mask, IntPtr src_key_padding_mask);
+            private static extern IntPtr THSNN_TransformerEncoder_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr src, IntPtr src_mask, IntPtr src_key_padding_mask);
 
             /// <summary>
             /// Pass the input through the encoder layers in turn.
@@ -29,7 +29,7 @@ namespace TorchSharp
             /// <param name="src_mask">The additive mask for the src sequence (optional).</param>
             /// <param name="src_key_padding_mask">The ByteTensor mask for src keys per batch (optional).</param>
             /// <returns></returns>
-            public override Tensor forward(Tensor src, Tensor src_mask, Tensor src_key_padding_mask)
+            public Tensor forward(Tensor src, Tensor src_mask, Tensor src_key_padding_mask)
             {
                 var res = THSNN_TransformerEncoder_forward(handle,
                     src.Handle,
@@ -45,7 +45,7 @@ namespace TorchSharp
             /// <param name="src">The sequence to the encoder (required).</param>
             /// <param name="src_mask">The additive mask for the src sequence (optional).</param>
             /// <returns></returns>
-            public override Tensor forward(Tensor src, Tensor src_mask)
+            public Tensor forward(Tensor src, Tensor src_mask)
             {
                 var res = THSNN_TransformerEncoder_forward(handle,
                     src.Handle,
@@ -77,7 +77,7 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerEncoder_ctor(torch.nn.Module.HType encoder_layer, long num_layers, out IntPtr pBoxedModule);
+            private static extern IntPtr THSNN_TransformerEncoder_ctor(torch.nn.Module<Tensor, Tensor>.HType encoder_layer, long num_layers, out IntPtr pBoxedModule);
 
             /// <summary>
             /// TransformerEncoder is a stack of N encoder layers

--- a/src/TorchSharp/NN/TransformerEncoderLayer.cs
+++ b/src/TorchSharp/NN/TransformerEncoderLayer.cs
@@ -5,6 +5,7 @@ using static TorchSharp.torch;
 
 namespace TorchSharp
 {
+    using System.Dynamic;
     using Modules;
 
     namespace Modules
@@ -14,7 +15,7 @@ namespace TorchSharp
             internal TransformerEncoderLayer(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerEncoderLayer_forward(torch.nn.Module.HType module, IntPtr src, IntPtr src_mask, IntPtr src_key_padding_mask);
+            private static extern IntPtr THSNN_TransformerEncoderLayer_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr src, IntPtr src_mask, IntPtr src_key_padding_mask);
 
             /// <summary>
             /// Pass the input through the encoder layer.
@@ -23,7 +24,7 @@ namespace TorchSharp
             /// <param name="src_mask">The additive mask for the src sequence (optional).</param>
             /// <param name="src_key_padding_mask">The ByteTensor mask for src keys per batch (optional).</param>
             /// <returns></returns>
-            public override Tensor forward(Tensor src, Tensor src_mask, Tensor src_key_padding_mask)
+            public Tensor forward(Tensor src, Tensor src_mask, Tensor src_key_padding_mask)
             {
                 var res = THSNN_TransformerEncoderLayer_forward(handle,
                     src.Handle,
@@ -38,7 +39,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="src">The sequence to the encoder (required).</param>
             /// <param name="src_mask">The additive mask for the src sequence (optional).</param>
-            public override Tensor forward(Tensor src, Tensor src_mask)
+            public Tensor forward(Tensor src, Tensor src_mask)
             {
                 var res = THSNN_TransformerEncoderLayer_forward(handle,
                     src.Handle,
@@ -52,7 +53,7 @@ namespace TorchSharp
             /// Pass the input through the encoder layer.
             /// </summary>
             /// <param name="src">The sequence to the encoder (required).</param>
-            public override Tensor forward(Tensor src)
+            public Tensor forward(Tensor src)
             {
                 var res = THSNN_TransformerEncoderLayer_forward(handle,
                     src.Handle,

--- a/src/TorchSharp/NN/Unflatten.cs
+++ b/src/TorchSharp/NN/Unflatten.cs
@@ -12,14 +12,14 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent an unflattening operation.
         /// </summary>
-        public class Unflatten : torch.nn.Module
+        public class Unflatten : torch.nn.Module<Tensor, Tensor>
         {
             internal Unflatten(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Unflatten_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Unflatten_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Upsample.cs
+++ b/src/TorchSharp/NN/Upsample.cs
@@ -70,12 +70,12 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent an Upsample module.
         /// </summary>
-        public class Upsample : torch.nn.Module
+        public class Upsample : torch.nn.Module<Tensor, Tensor>
         {
             internal Upsample(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Upsample_forward(torch.nn.Module.HType module, IntPtr tensor);
+            private static extern IntPtr THSNN_Upsample_forward(torch.nn.Module<Tensor, Tensor>.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -6664,7 +6664,7 @@ namespace TorchSharp
             }
 
             // Specifically added to make F# look good.
-            public static Tensor op_MinusMinusGreater(Tensor t, torch.nn.Module m) => m.forward(t);
+            public static Tensor op_MinusMinusGreater(Tensor t, torch.nn.Module<Tensor, Tensor> m) => m.forward(t);
 
             public override string ToString() => ToMetadataString();
 

--- a/src/TorchSharp/TorchAudio/Modules/HuBERTPretrainModel.cs
+++ b/src/TorchSharp/TorchAudio/Modules/HuBERTPretrainModel.cs
@@ -79,7 +79,7 @@ namespace TorchSharp.Modules
         /// The feature mean value for additional penalty loss.
         /// Shape: `(1,)`.
         /// </returns>
-        public new (Tensor?, Tensor?, Tensor) forward(
+        public (Tensor?, Tensor?, Tensor) forward(
             Tensor waveforms,
             Tensor labels,
             Tensor? audio_lengths = null)

--- a/src/TorchSharp/TorchAudio/Modules/Wav2Vec2Model.cs
+++ b/src/TorchSharp/TorchAudio/Modules/Wav2Vec2Model.cs
@@ -24,7 +24,7 @@ namespace TorchSharp.Modules
     {
         internal readonly FeatureExtractor feature_extractor;
         internal readonly Encoder encoder;
-        private readonly nn.Module? aux;
+        private readonly nn.Module<Tensor, Tensor>? aux;
 
         /// <param name="name"></param>
         /// <param name="feature_extractor">Feature extractor that extracts feature vectors from raw audio Tensor.</param>
@@ -35,7 +35,7 @@ namespace TorchSharp.Modules
             string name,
             FeatureExtractor feature_extractor,
             Encoder encoder,
-            nn.Module? aux = null) : base(name)
+            nn.Module<Tensor, Tensor>? aux = null) : base(name)
         {
             this.feature_extractor = feature_extractor;
             this.encoder = encoder;
@@ -102,7 +102,7 @@ namespace TorchSharp.Modules
         /// is returned.
         /// It indicates the valid length in time axis of the output Tensor.
         /// </returns>
-        public new (Tensor, Tensor?) forward(
+        public (Tensor, Tensor?) forward(
             Tensor waveforms,
             Tensor? lengths = null)
         {

--- a/src/TorchSharp/TorchAudio/Wav2Vec2Models.cs
+++ b/src/TorchSharp/TorchAudio/Wav2Vec2Models.cs
@@ -191,7 +191,7 @@ namespace TorchSharp
                     dropout: encoder_dropout,
                     layer_norm_first: encoder_layer_norm_first,
                     layer_drop: encoder_layer_drop);
-                Module? aux = null;
+                Module<Tensor, Tensor>? aux = null;
                 if (aux_num_out != null) {
                     aux = torch.nn.Linear(inputSize: encoder_embed_dim, outputSize: aux_num_out.Value);
                 }

--- a/src/TorchSharp/TorchVision/Ops/Misc.cs
+++ b/src/TorchSharp/TorchVision/Ops/Misc.cs
@@ -21,15 +21,15 @@ namespace TorchSharp
     {
         public static partial class ops
         {
-            private static nn.Module ConvNormActivation(
+            private static nn.Module<Tensor, Tensor> ConvNormActivation(
                 long in_channels,
                 long out_channels,
                 long kernel_size = 3,
                 long stride = 1,
                 long? padding = null,
                 long groups = 1,
-                Func<long, nn.Module>? norm_layer = null,
-                Func<bool, nn.Module>? activation_layer = null,
+                Func<long, nn.Module<Tensor, Tensor>>? norm_layer = null,
+                Func<bool, nn.Module<Tensor, Tensor>>? activation_layer = null,
                 long dilation = 1,
                 bool inplace = true,
                 bool? bias = null,
@@ -43,7 +43,7 @@ namespace TorchSharp
                     bias = norm_layer == null;
                 }
 
-                var layers = new List<nn.Module>();
+                var layers = new List<nn.Module<Tensor, Tensor>>();
                 if (rank == 2) {
                     layers.Add(
                         nn.Conv2d(
@@ -94,15 +94,15 @@ namespace TorchSharp
             /// <param name="dilation">Spacing between kernel elements.</param>
             /// <param name="inplace">Parameter for the activation layer, which can optionally do the operation in-place.</param>
             /// <param name="bias">Whether to use bias in the convolution layer. By default, biases are included if ``norm_layer is null``.</param>
-            public static nn.Module Conv2dNormActivation(
+            public static nn.Module<Tensor, Tensor> Conv2dNormActivation(
                 long in_channels,
                 long out_channels,
                 long kernel_size = 3,
                 long stride = 1,
                 long? padding = null,
                 long groups = 1,
-                Func<long, nn.Module>? norm_layer = null,
-                Func<bool, nn.Module>? activation_layer = null,
+                Func<long, nn.Module<Tensor, Tensor>>? norm_layer = null,
+                Func<bool, nn.Module<Tensor, Tensor>>? activation_layer = null,
                 long dilation = 1,
                 bool inplace = true,
                 bool? bias = null)
@@ -136,15 +136,15 @@ namespace TorchSharp
             /// <param name="dilation">Spacing between kernel elements.</param>
             /// <param name="inplace">Parameter for the activation layer, which can optionally do the operation in-place.</param>
             /// <param name="bias">Whether to use bias in the convolution layer. By default, biases are included if ``norm_layer is null``.</param>
-            public static nn.Module Conv3dNormActivation(
+            public static nn.Module<Tensor, Tensor> Conv3dNormActivation(
                 long in_channels,
                 long out_channels,
                 long kernel_size = 3,
                 long stride = 1,
                 long? padding = null,
                 long groups = 1,
-                Func<long, nn.Module>? norm_layer = null,
-                Func<bool, nn.Module>? activation_layer = null,
+                Func<long, nn.Module<Tensor, Tensor>>? norm_layer = null,
+                Func<bool, nn.Module<Tensor, Tensor>>? activation_layer = null,
                 long dilation = 1,
                 bool inplace = true,
                 bool? bias = null)
@@ -164,13 +164,13 @@ namespace TorchSharp
                     rank: 3);
             }
 
-            internal class SqueezeExcitation : torch.nn.Module
+            internal class SqueezeExcitation : torch.nn.Module<Tensor, Tensor>
             {
-                private readonly nn.Module avgpool;
-                private readonly nn.Module fc1;
-                private readonly nn.Module fc2;
-                private readonly nn.Module activation;
-                private readonly nn.Module scale_activation;
+                private readonly nn.Module<Tensor, Tensor> avgpool;
+                private readonly nn.Module<Tensor, Tensor> fc1;
+                private readonly nn.Module<Tensor, Tensor> fc2;
+                private readonly nn.Module<Tensor, Tensor> activation;
+                private readonly nn.Module<Tensor, Tensor> scale_activation;
 
                 /// <summary>
                 /// This block implements the Squeeze-and-Excitation block from https://arxiv.org/abs/1709.01507 (see Fig. 1).
@@ -185,8 +185,8 @@ namespace TorchSharp
                     string name,
                     long input_channels,
                     long squeeze_channels,
-                    Func<nn.Module> activation,
-                    Func<nn.Module> scale_activation) : base(name)
+                    Func<nn.Module<Tensor, Tensor>> activation,
+                    Func<nn.Module<Tensor, Tensor>> scale_activation) : base(name)
                 {
                     this.avgpool = torch.nn.AdaptiveAvgPool2d(1);
                     this.fc1 = torch.nn.Conv2d(input_channels, squeeze_channels, 1);

--- a/src/TorchSharp/TorchVision/models/AlexNet.cs
+++ b/src/TorchSharp/TorchVision/models/AlexNet.cs
@@ -60,11 +60,11 @@ namespace TorchSharp
         // https://github.com/pytorch/vision/blob/main/torchvision/models/alexnet.py
         // Licence and copypright notice at: https://github.com/pytorch/vision/blob/main/LICENSE
 
-        public class AlexNet : Module
+        public class AlexNet : Module<Tensor, Tensor>
         {
-            private readonly Module features;
-            private readonly Module avgpool;
-            private readonly Module classifier;
+            private readonly Module<Tensor, Tensor> features;
+            private readonly Module<Tensor, Tensor> avgpool;
+            private readonly Module<Tensor, Tensor> classifier;
 
             public AlexNet(int numClasses, float dropout = 0.5f, string weights_file = null, bool skipfc = true, Device device = null) : base(nameof(AlexNet))
             {

--- a/src/TorchSharp/TorchVision/models/GoogleNet.cs
+++ b/src/TorchSharp/TorchVision/models/GoogleNet.cs
@@ -64,28 +64,28 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class GoogleNet : Module
+        public class GoogleNet : Module<Tensor, Tensor>
         {
             // The code here is based on
             // https://github.com/pytorch/vision/blob/main/torchvision/models/googlenet.py
             // Licence and copypright notice at: https://github.com/pytorch/vision/blob/main/LICENSE
 
-            private readonly Module conv1;
-            private readonly Module maxpool1;
-            private readonly Module conv2;
-            private readonly Module conv3;
-            private readonly Module maxpool2;
-            private readonly Module inception3a;
-            private readonly Module inception3b;
-            private readonly Module maxpool3;
-            private readonly Module inception4a;
-            private readonly Module inception4b;
-            private readonly Module inception4c;
-            private readonly Module inception4d;
-            private readonly Module inception4e;
-            private readonly Module maxpool4;
-            private readonly Module inception5a;
-            private readonly Module inception5b;
+            private readonly Module<Tensor, Tensor> conv1;
+            private readonly Module<Tensor, Tensor> maxpool1;
+            private readonly Module<Tensor, Tensor> conv2;
+            private readonly Module<Tensor, Tensor> conv3;
+            private readonly Module<Tensor, Tensor> maxpool2;
+            private readonly Module<Tensor, Tensor> inception3a;
+            private readonly Module<Tensor, Tensor> inception3b;
+            private readonly Module<Tensor, Tensor> maxpool3;
+            private readonly Module<Tensor, Tensor> inception4a;
+            private readonly Module<Tensor, Tensor> inception4b;
+            private readonly Module<Tensor, Tensor> inception4c;
+            private readonly Module<Tensor, Tensor> inception4d;
+            private readonly Module<Tensor, Tensor> inception4e;
+            private readonly Module<Tensor, Tensor> maxpool4;
+            private readonly Module<Tensor, Tensor> inception5a;
+            private readonly Module<Tensor, Tensor> inception5b;
             //private readonly Module aux1;
             //private readonly Module aux2;
 
@@ -165,7 +165,7 @@ namespace TorchSharp
             }
 
 
-            private static Module conv_block(int in_channels, int out_channels, int kernel_size, int stride = 1, int padding = 0)
+            private static Module<Tensor, Tensor> conv_block(int in_channels, int out_channels, int kernel_size, int stride = 1, int padding = 0)
             {
                 return Sequential(
                     ("conv", Conv2d(in_channels, out_channels, bias: false, kernelSize: kernel_size, stride: stride, padding: padding)),
@@ -174,7 +174,7 @@ namespace TorchSharp
                 );
             }
 
-            private static Module conv_block(int in_channels, int out_channels, (long, long) kernel_size, (long, long)? stride = null, (long, long)? padding = null)
+            private static Module<Tensor, Tensor> conv_block(int in_channels, int out_channels, (long, long) kernel_size, (long, long)? stride = null, (long, long)? padding = null)
             {
                 return Sequential(
                     ("conv", Conv2d(in_channels, out_channels, bias: false, kernelSize: kernel_size, stride: stride, padding: padding)),
@@ -183,8 +183,8 @@ namespace TorchSharp
                 );
             }
 
-            private Module inception_block(int in_channels, int ch1x1, int ch3x3red,  int ch3x3, int ch5x5red, int ch5x5, int pool_proj) => new Inception(in_channels, ch1x1, ch3x3red, ch3x3, ch5x5red, ch5x5, pool_proj);
-            private Module inception_aux_block(int in_channels, int num_classes, float dropout) => new InceptionAux(in_channels, num_classes, dropout);
+            private Module<Tensor, Tensor> inception_block(int in_channels, int ch1x1, int ch3x3red,  int ch3x3, int ch5x5red, int ch5x5, int pool_proj) => new Inception(in_channels, ch1x1, ch3x3red, ch3x3, ch5x5red, ch5x5, pool_proj);
+            private Module<Tensor, Tensor> inception_aux_block(int in_channels, int num_classes, float dropout) => new InceptionAux(in_channels, num_classes, dropout);
 
             public override Tensor forward(Tensor x)
             {
@@ -253,7 +253,7 @@ namespace TorchSharp
                 }
             }
 
-            class Inception : Module
+            class Inception : Module<Tensor, Tensor>
             {
                 public Inception(int in_channels, int ch1x1, int ch3x3red, int ch3x3, int ch5x5red, int ch5x5, int pool_proj) : base("Inception")
                 {
@@ -284,18 +284,18 @@ namespace TorchSharp
                     return torch.cat(outputs, 1);
                 }
 
-                private readonly Module branch1;
-                private readonly Module branch2;
-                private readonly Module branch3;
-                private readonly Module branch4;
+                private readonly Module<Tensor, Tensor> branch1;
+                private readonly Module<Tensor, Tensor> branch2;
+                private readonly Module<Tensor, Tensor> branch3;
+                private readonly Module<Tensor, Tensor> branch4;
             }
 
-            class InceptionAux : Module
+            class InceptionAux : Module<Tensor, Tensor>
             {
-                private readonly Module conv;
-                private readonly Module fc1;
-                private readonly Module fc2;
-                private readonly Module dropout;
+                private readonly Module<Tensor, Tensor> conv;
+                private readonly Module<Tensor, Tensor> fc1;
+                private readonly Module<Tensor, Tensor> fc2;
+                private readonly Module<Tensor, Tensor> dropout;
 
                 public InceptionAux(int in_channels, int num_classes, float dropout = 0.7f) : base("InceptionAux")
                 {

--- a/src/TorchSharp/TorchVision/models/InceptionV3.cs
+++ b/src/TorchSharp/TorchVision/models/InceptionV3.cs
@@ -62,32 +62,32 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class InceptionV3 : Module
+        public class InceptionV3 : Module<Tensor, Tensor>
         {
             // The code here is is loosely based on
             // https://github.com/pytorch/vision/blob/main/torchvision/models/inception.py
             // Licence and copypright notice at: https://github.com/pytorch/vision/blob/main/LICENSE
 
-            private readonly Module Conv2d_1a_3x3;
-            private readonly Module Conv2d_2a_3x3;
-            private readonly Module Conv2d_2b_3x3;
-            private readonly Module maxpool1;
-            private readonly Module Conv2d_3b_1x1;
-            private readonly Module Conv2d_4a_3x3;
-            private readonly Module maxpool2;
+            private readonly Module<Tensor, Tensor> Conv2d_1a_3x3;
+            private readonly Module<Tensor, Tensor> Conv2d_2a_3x3;
+            private readonly Module<Tensor, Tensor> Conv2d_2b_3x3;
+            private readonly Module<Tensor, Tensor> maxpool1;
+            private readonly Module<Tensor, Tensor> Conv2d_3b_1x1;
+            private readonly Module<Tensor, Tensor> Conv2d_4a_3x3;
+            private readonly Module<Tensor, Tensor> maxpool2;
 
-            private readonly Module Mixed_5b;
-            private readonly Module Mixed_5c;
-            private readonly Module Mixed_5d;
-            private readonly Module Mixed_6a;
-            private readonly Module Mixed_6b;
-            private readonly Module Mixed_6c;
-            private readonly Module Mixed_6d;
-            private readonly Module Mixed_6e;
-            private readonly Module AuxLogits;
-            private readonly Module Mixed_7a;
-            private readonly Module Mixed_7b;
-            private readonly Module Mixed_7c;
+            private readonly Module<Tensor, Tensor> Mixed_5b;
+            private readonly Module<Tensor, Tensor> Mixed_5c;
+            private readonly Module<Tensor, Tensor> Mixed_5d;
+            private readonly Module<Tensor, Tensor> Mixed_6a;
+            private readonly Module<Tensor, Tensor> Mixed_6b;
+            private readonly Module<Tensor, Tensor> Mixed_6c;
+            private readonly Module<Tensor, Tensor> Mixed_6d;
+            private readonly Module<Tensor, Tensor> Mixed_6e;
+            private readonly Module<Tensor, Tensor> AuxLogits;
+            private readonly Module<Tensor, Tensor> Mixed_7a;
+            private readonly Module<Tensor, Tensor> Mixed_7b;
+            private readonly Module<Tensor, Tensor> Mixed_7c;
             private readonly AdaptiveAvgPool2d avgpool;
             private Dropout dropout;
             private readonly Linear fc;
@@ -165,7 +165,7 @@ namespace TorchSharp
             }
 
 
-            private static Module conv_block(int in_channels, int out_channels, int kernel_size, int stride = 1, int padding = 0)
+            private static Module<Tensor, Tensor> conv_block(int in_channels, int out_channels, int kernel_size, int stride = 1, int padding = 0)
             {
                 return Sequential(
                     ("conv", Conv2d(in_channels, out_channels, bias: false, kernelSize: kernel_size, stride: stride, padding: padding)),
@@ -174,7 +174,7 @@ namespace TorchSharp
                     );
             }
 
-            private static Module conv_block(int in_channels, int out_channels, (long, long) kernel_size, (long, long)? stride = null, (long, long)? padding = null)
+            private static Module<Tensor, Tensor> conv_block(int in_channels, int out_channels, (long, long) kernel_size, (long, long)? stride = null, (long, long)? padding = null)
             {
                 return Sequential(
                     ("conv", Conv2d(in_channels, out_channels, bias: false, kernelSize: kernel_size, stride: stride, padding: padding)),
@@ -183,12 +183,12 @@ namespace TorchSharp
                     );
             }
 
-            private Module inception_a(int in_channels, int pool_features) => new InceptionA(in_channels, pool_features);
-            private Module inception_b(int in_channels) => new InceptionB(in_channels);
-            private Module inception_c(int in_channels, int channels_7x7) => new InceptionC(in_channels, channels_7x7);
-            private Module inception_d(int in_channels) => new InceptionD(in_channels);
-            private Module inception_e(int in_channels) => new InceptionE(in_channels);
-            private Module inception_aux(int in_channels, int num_classes) => new InceptionAux(in_channels, num_classes);
+            private Module<Tensor, Tensor> inception_a(int in_channels, int pool_features) => new InceptionA(in_channels, pool_features);
+            private Module<Tensor, Tensor> inception_b(int in_channels) => new InceptionB(in_channels);
+            private Module<Tensor, Tensor> inception_c(int in_channels, int channels_7x7) => new InceptionC(in_channels, channels_7x7);
+            private Module<Tensor, Tensor> inception_d(int in_channels) => new InceptionD(in_channels);
+            private Module<Tensor, Tensor> inception_e(int in_channels) => new InceptionE(in_channels);
+            private Module<Tensor, Tensor> inception_aux(int in_channels, int num_classes) => new InceptionAux(in_channels, num_classes);
 
             public override Tensor forward(Tensor x)
             {
@@ -253,7 +253,7 @@ namespace TorchSharp
                 }
             }
 
-            class InceptionA : Module
+            class InceptionA : Module<Tensor, Tensor>
             {
                 public InceptionA(int in_channels, int pool_features) : base("InceptionA")
                 {
@@ -286,16 +286,16 @@ namespace TorchSharp
                     return torch.cat(outputs, 1);
                 }
 
-                private readonly Module branch1x1;
-                private readonly Module branch5x5_1;
-                private readonly Module branch5x5_2;
-                private readonly Module branch3x3dbl_1;
-                private readonly Module branch3x3dbl_2;
-                private readonly Module branch3x3dbl_3;
-                private readonly Module branch_pool;
+                private readonly Module<Tensor, Tensor> branch1x1;
+                private readonly Module<Tensor, Tensor> branch5x5_1;
+                private readonly Module<Tensor, Tensor> branch5x5_2;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_1;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_2;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_3;
+                private readonly Module<Tensor, Tensor> branch_pool;
             }
 
-            class InceptionB : Module
+            class InceptionB : Module<Tensor, Tensor>
             {
                 public InceptionB(int in_channels) : base("InceptionB")
                 {
@@ -324,24 +324,24 @@ namespace TorchSharp
                     return torch.cat(outputs, 1);
                 }
 
-                private readonly Module branch3x3;
-                private readonly Module branch3x3dbl_1;
-                private readonly Module branch3x3dbl_2;
-                private readonly Module branch3x3dbl_3;
+                private readonly Module<Tensor, Tensor> branch3x3;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_1;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_2;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_3;
             }
 
-            class InceptionC : Module
+            class InceptionC : Module<Tensor, Tensor>
             {
-                private readonly Module branch1x1;
-                private readonly Module branch7x7_1;
-                private readonly Module branch7x7_2;
-                private readonly Module branch7x7_3;
-                private readonly Module branch7x7dbl_1;
-                private readonly Module branch7x7dbl_2;
-                private readonly Module branch7x7dbl_3;
-                private readonly Module branch7x7dbl_4;
-                private readonly Module branch7x7dbl_5;
-                private readonly Module branch_pool;
+                private readonly Module<Tensor, Tensor> branch1x1;
+                private readonly Module<Tensor, Tensor> branch7x7_1;
+                private readonly Module<Tensor, Tensor> branch7x7_2;
+                private readonly Module<Tensor, Tensor> branch7x7_3;
+                private readonly Module<Tensor, Tensor> branch7x7dbl_1;
+                private readonly Module<Tensor, Tensor> branch7x7dbl_2;
+                private readonly Module<Tensor, Tensor> branch7x7dbl_3;
+                private readonly Module<Tensor, Tensor> branch7x7dbl_4;
+                private readonly Module<Tensor, Tensor> branch7x7dbl_5;
+                private readonly Module<Tensor, Tensor> branch_pool;
 
                 public InceptionC(int in_channels, int channels_7x7) : base("InceptionC")
                 {
@@ -386,14 +386,14 @@ namespace TorchSharp
                 }
             }
 
-            class InceptionD : Module
+            class InceptionD : Module<Tensor, Tensor>
             {
-                private readonly Module branch3x3_1;
-                private readonly Module branch3x3_2;
-                private readonly Module branch7x7x3_1;
-                private readonly Module branch7x7x3_2;
-                private readonly Module branch7x7x3_3;
-                private readonly Module branch7x7x3_4;
+                private readonly Module<Tensor, Tensor> branch3x3_1;
+                private readonly Module<Tensor, Tensor> branch3x3_2;
+                private readonly Module<Tensor, Tensor> branch7x7x3_1;
+                private readonly Module<Tensor, Tensor> branch7x7x3_2;
+                private readonly Module<Tensor, Tensor> branch7x7x3_3;
+                private readonly Module<Tensor, Tensor> branch7x7x3_4;
 
                 public InceptionD(int in_channels) : base("InceptionD")
                 {
@@ -426,17 +426,17 @@ namespace TorchSharp
                 }
             }
 
-            class InceptionE : Module
+            class InceptionE : Module<Tensor, Tensor>
             {
-                private readonly Module branch1x1;
-                private readonly Module branch3x3_1;
-                private readonly Module branch3x3_2a;
-                private readonly Module branch3x3_2b;
-                private readonly Module branch3x3dbl_1;
-                private readonly Module branch3x3dbl_2;
-                private readonly Module branch3x3dbl_3a;
-                private readonly Module branch3x3dbl_3b;
-                private readonly Module branch_pool;
+                private readonly Module<Tensor, Tensor> branch1x1;
+                private readonly Module<Tensor, Tensor> branch3x3_1;
+                private readonly Module<Tensor, Tensor> branch3x3_2a;
+                private readonly Module<Tensor, Tensor> branch3x3_2b;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_1;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_2;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_3a;
+                private readonly Module<Tensor, Tensor> branch3x3dbl_3b;
+                private readonly Module<Tensor, Tensor> branch_pool;
 
                 public InceptionE(int in_channels) : base("InceptionE")
                 {
@@ -478,11 +478,11 @@ namespace TorchSharp
                 }
             }
 
-            class InceptionAux : Module
+            class InceptionAux : Module<Tensor, Tensor>
             {
-                private readonly Module conv0;
-                private readonly Module conv1;
-                private readonly Module fc;
+                private readonly Module<Tensor, Tensor> conv0;
+                private readonly Module<Tensor, Tensor> conv1;
+                private readonly Module<Tensor, Tensor> fc;
 
                 public InceptionAux(int in_channels, int num_classes) : base("InceptionAux")
                 {

--- a/src/TorchSharp/TorchVision/models/MobileNetV2.cs
+++ b/src/TorchSharp/TorchVision/models/MobileNetV2.cs
@@ -25,12 +25,12 @@ namespace TorchSharp
         /// <summary>
         /// MobileNet V2 main class
         /// </summary>
-        public class MobileNetV2 : nn.Module
+        public class MobileNetV2 : nn.Module<Tensor, Tensor>
         {
-            private class InvertedResidual : nn.Module
+            private class InvertedResidual : nn.Module<Tensor, Tensor>
             {
                 private readonly bool _is_cn;
-                private readonly nn.Module conv;
+                private readonly nn.Module<Tensor, Tensor> conv;
                 private readonly long out_channels;
                 private readonly long stride;
                 private readonly bool use_res_connect;
@@ -41,7 +41,7 @@ namespace TorchSharp
                     long oup,
                     long stride,
                     double expand_ratio,
-                    Func<long, nn.Module>? norm_layer = null) : base(name)
+                    Func<long, nn.Module<Tensor, Tensor>>? norm_layer = null) : base(name)
                 {
                     this.stride = stride;
                     if (stride != 1 && stride != 2) {
@@ -55,7 +55,7 @@ namespace TorchSharp
                     var hidden_dim = (long)Math.Round(inp * expand_ratio);
                     this.use_res_connect = this.stride == 1 && inp == oup;
 
-                    var layers = new List<nn.Module>();
+                    var layers = new List<nn.Module<Tensor, Tensor>>();
                     if (expand_ratio != 1) {
                         // pw
                         layers.Add(
@@ -66,7 +66,7 @@ namespace TorchSharp
                                 norm_layer: norm_layer,
                                 activation_layer: (inplace) => nn.ReLU6(inplace)));
                     }
-                    layers.AddRange(new List<nn.Module> {
+                    layers.AddRange(new List<nn.Module<Tensor, Tensor>> {
                         // dw
                         ops.Conv2dNormActivation(
                             hidden_dim,
@@ -95,8 +95,8 @@ namespace TorchSharp
                 }
             }
 
-            private readonly nn.Module classifier;
-            private readonly nn.Module features;
+            private readonly nn.Module<Tensor, Tensor> classifier;
+            private readonly nn.Module<Tensor, Tensor> features;
             private readonly long last_channel;
 
             internal MobileNetV2(
@@ -105,8 +105,8 @@ namespace TorchSharp
                 double width_mult = 1.0,
                 long[][]? inverted_residual_setting = null,
                 long round_nearest = 8,
-                Func<long, long, long, long, Func<long, nn.Module>, nn.Module>? block = null,
-                Func<long, nn.Module>? norm_layer = null,
+                Func<long, long, long, long, Func<long, nn.Module<Tensor, Tensor>>, nn.Module<Tensor, Tensor>>? block = null,
+                Func<long, nn.Module<Tensor, Tensor>>? norm_layer = null,
                 double dropout = 0.2) : base(name)
             {
                 if (block == null) {
@@ -141,7 +141,7 @@ namespace TorchSharp
                 // building first layer
                 input_channel = _make_divisible(input_channel * width_mult, round_nearest);
                 this.last_channel = _make_divisible(last_channel * Math.Max(1.0, width_mult), round_nearest);
-                var features = new List<nn.Module> {
+                var features = new List<nn.Module<Tensor, Tensor>> {
                     ops.Conv2dNormActivation(3, input_channel, stride: 2, norm_layer: norm_layer, activation_layer: (inplace) => nn.ReLU6(inplace))
                 };
                 // building inverted residual blocks
@@ -233,8 +233,8 @@ namespace TorchSharp
                 double width_mult = 1.0,
                 long[][]? inverted_residual_setting = null,
                 long round_nearest = 8,
-                Func<long, long, long, long, Func<long, nn.Module>, nn.Module>? block = null,
-                Func<long, nn.Module>? norm_layer = null,
+                Func<long, long, long, long, Func<long, nn.Module<Tensor, Tensor>>, nn.Module<Tensor, Tensor>>? block = null,
+                Func<long, nn.Module<Tensor, Tensor>>? norm_layer = null,
                 double dropout = 0.2)
             {
                 return new Modules.MobileNetV2(

--- a/src/TorchSharp/TorchVision/models/MobileNetV3.cs
+++ b/src/TorchSharp/TorchVision/models/MobileNetV3.cs
@@ -25,7 +25,7 @@ namespace TorchSharp
 {
     namespace Modules
     {
-        public class MobileNetV3 : nn.Module
+        public class MobileNetV3 : nn.Module<Tensor, Tensor>
         {
             /// <summary>
             /// Stores information listed at Tables 1 and 2 of the MobileNetV3 paper
@@ -71,18 +71,18 @@ namespace TorchSharp
             /// <summary>
             /// Implemented as described at section 5 of MobileNetV3 paper
             /// </summary>
-            private class InvertedResidual : nn.Module
+            private class InvertedResidual : nn.Module<Tensor, Tensor>
             {
                 private readonly bool _is_cn;
-                private readonly nn.Module block;
+                private readonly nn.Module<Tensor, Tensor> block;
                 private readonly long out_channels;
                 private readonly bool use_res_connect;
 
                 public InvertedResidual(
                     string name,
                     InvertedResidualConfig cnf,
-                    Func<long, nn.Module> norm_layer,
-                    Func<long, long, nn.Module>? se_layer = null) : base(name)
+                    Func<long, nn.Module<Tensor, Tensor>> norm_layer,
+                    Func<long, long, nn.Module<Tensor, Tensor>>? se_layer = null) : base(name)
                 {
                     if (!(1 <= cnf.stride && cnf.stride <= 2)) {
                         throw new ArgumentException("illegal stride value");
@@ -90,8 +90,8 @@ namespace TorchSharp
 
                     this.use_res_connect = cnf.stride == 1 && cnf.input_channels == cnf.out_channels;
 
-                    var layers = new List<nn.Module>();
-                    Func<bool, nn.Module> activation_layer = (
+                    var layers = new List<nn.Module<Tensor, Tensor>>();
+                    Func<bool, nn.Module<Tensor, Tensor>> activation_layer = (
                         cnf.use_hs ? (inplace) => nn.Hardswish(inplace) : (inplace) => nn.ReLU(inplace));
 
                     // expand
@@ -152,9 +152,9 @@ namespace TorchSharp
                 }
             }
 
-            private readonly nn.Module avgpool;
-            private readonly nn.Module classifier;
-            private readonly nn.Module features;
+            private readonly nn.Module<Tensor, Tensor> avgpool;
+            private readonly nn.Module<Tensor, Tensor> classifier;
+            private readonly nn.Module<Tensor, Tensor> features;
 
             /// <summary>
             /// MobileNet V3 main class
@@ -172,8 +172,8 @@ namespace TorchSharp
                 InvertedResidualConfig[] inverted_residual_setting,
                 long last_channel,
                 long num_classes = 1000,
-                Func<InvertedResidualConfig, Func<long, nn.Module>, nn.Module>? block = null,
-                Func<long, nn.Module>? norm_layer = null,
+                Func<InvertedResidualConfig, Func<long, nn.Module<Tensor, Tensor>>, nn.Module<Tensor, Tensor>>? block = null,
+                Func<long, nn.Module<Tensor, Tensor>>? norm_layer = null,
                 double dropout = 0.2) : base(name)
             {
                 if (inverted_residual_setting == null || inverted_residual_setting.Length == 0) {
@@ -188,7 +188,7 @@ namespace TorchSharp
                     norm_layer = (features) => nn.BatchNorm2d(features, eps: 0.001, momentum: 0.01);
                 }
 
-                var layers = new List<nn.Module>();
+                var layers = new List<nn.Module<Tensor, Tensor>>();
 
                 // building first layer
                 var firstconv_output_channels = inverted_residual_setting[0].input_channels;

--- a/src/TorchSharp/TorchVision/models/ResNet.cs
+++ b/src/TorchSharp/TorchVision/models/ResNet.cs
@@ -213,25 +213,25 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class ResNet : Module
+        public class ResNet : Module<Tensor, Tensor>
         {
             // The code here is based on
             // https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py
             // Licence and copypright notice at: https://github.com/pytorch/vision/blob/main/LICENSE
 
-            private readonly Module conv1;
-            private readonly Module bn1;
-            private readonly Module relu;
-            private readonly Module maxpool;
+            private readonly Module<Tensor, Tensor> conv1;
+            private readonly Module<Tensor, Tensor> bn1;
+            private readonly Module<Tensor, Tensor> relu;
+            private readonly Module<Tensor, Tensor> maxpool;
 
             private readonly Sequential layer1 = Sequential();
             private readonly Sequential layer2 = Sequential();
             private readonly Sequential layer3 = Sequential();
             private readonly Sequential layer4 = Sequential();
 
-            private readonly Module avgpool;
-            private readonly Module flatten;
-            private readonly Module fc;
+            private readonly Module<Tensor, Tensor> avgpool;
+            private readonly Module<Tensor, Tensor> flatten;
+            private readonly Module<Tensor, Tensor> fc;
 
             private int in_planes = 64;
 
@@ -311,14 +311,14 @@ namespace TorchSharp
             }
 
             public ResNet(string name,
-                Func<int, int, int, Module> block,
+                Func<int, int, int, Module<Tensor, Tensor>> block,
                 int expansion, IList<int> num_blocks,
                 int numClasses,
                 string weights_file = null,
                 bool skipfc = true,
                 Device device = null) : base(name)
             {
-                var modules = new List<(string, Module)>();
+                var modules = new List<(string, Module<Tensor, Tensor>)>();
 
                 conv1 = Conv2d(3, 64, kernelSize: 7, stride: 2, padding: 3, bias: false);
                 bn1 = BatchNorm2d(64);
@@ -358,7 +358,7 @@ namespace TorchSharp
                     this.to(device);
             }
 
-            private void MakeLayer(Sequential modules, Func<int, int, int, Module> block, int expansion, int planes, int num_blocks, int stride)
+            private void MakeLayer(Sequential modules, Func<int, int, int, Module<Tensor, Tensor>> block, int expansion, int planes, int num_blocks, int stride)
             {
                 var strides = new List<int>();
                 strides.Add(stride);
@@ -388,11 +388,11 @@ namespace TorchSharp
                 }
             }
 
-            class BasicBlock : Module
+            class BasicBlock : Module<Tensor, Tensor>
             {
                 public BasicBlock(int in_planes, int planes, int stride) : base("BasicBlock")
                 {
-                    var modules = new List<(string, Module)>();
+                    var modules = new List<(string, Module<Tensor, Tensor>)>();
 
                     conv1 = Conv2d(in_planes, planes, kernelSize: 3, stride: stride, padding: 1, bias: false);
                     bn1 = BatchNorm2d(planes);
@@ -416,25 +416,25 @@ namespace TorchSharp
                     x = bn2.forward(conv2.forward(x));
 
                     var y = input;
-                    foreach (var m in downsample) y = m.forward(y);
+                    foreach (var m in downsample) y = ((nn.Module<Tensor, Tensor>)m).forward(y);
                     return x.add_(y).relu_();
                 }
 
                 public static int expansion = 1;
 
-                private readonly Module conv1;
-                private readonly Module bn1;
-                private readonly Module conv2;
+                private readonly Module<Tensor, Tensor> conv1;
+                private readonly Module<Tensor, Tensor> bn1;
+                private readonly Module<Tensor, Tensor> conv2;
                 private readonly TorchSharp.Modules.BatchNorm2d bn2;
-                private readonly Module relu1;
+                private readonly Module<Tensor, Tensor> relu1;
                 private readonly TorchSharp.Modules.ModuleList downsample = new TorchSharp.Modules.ModuleList();
             }
 
-            class Bottleneck : Module
+            class Bottleneck : Module<Tensor, Tensor>
             {
                 public Bottleneck(int in_planes, int planes, int stride) : base("Bottleneck")
                 {
-                    var modules = new List<(string, Module)>();
+                    var modules = new List<(string, Module<Tensor, Tensor>)>();
 
                     conv1 = Conv2d(in_planes, planes, kernelSize: 1, bias: false);
                     bn1 = BatchNorm2d(planes);
@@ -462,21 +462,21 @@ namespace TorchSharp
                     x = bn3.forward(conv3.forward(x));
 
                     var y = input;
-                    foreach (var m in downsample) y = m.forward(y);
+                    foreach (var m in downsample) y = ((nn.Module<Tensor, Tensor>)m).forward(y);
 
                     return x.add_(y).relu_();
                 }
 
                 public static int expansion = 4;
 
-                private readonly Module conv1;
-                private readonly Module bn1;
-                private readonly Module conv2;
-                private readonly Module bn2;
-                private readonly Module conv3;
+                private readonly Module<Tensor, Tensor> conv1;
+                private readonly Module<Tensor, Tensor> bn1;
+                private readonly Module<Tensor, Tensor> conv2;
+                private readonly Module<Tensor, Tensor> bn2;
+                private readonly Module<Tensor, Tensor> conv3;
                 private readonly TorchSharp.Modules.BatchNorm2d bn3;
-                private readonly Module relu1;
-                private readonly Module relu2;
+                private readonly Module<Tensor, Tensor> relu1;
+                private readonly Module<Tensor, Tensor> relu2;
 
                 private readonly TorchSharp.Modules.ModuleList downsample = new TorchSharp.Modules.ModuleList();
             }

--- a/src/TorchSharp/TorchVision/models/VGG.cs
+++ b/src/TorchSharp/TorchVision/models/VGG.cs
@@ -322,7 +322,7 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public class VGG : Module
+        public class VGG : Module<Tensor, Tensor>
         {
             // The code here is based on
             // https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py
@@ -335,9 +335,9 @@ namespace TorchSharp
                 { "VGG19", new long[] { 64, 64, 0, 128, 128, 0, 256, 256, 256, 256, 0, 512, 512, 512, 512, 0, 512, 512, 512, 512, 0 } }
             };
 
-            private readonly Module features;
-            private readonly Module avgpool;
-            private readonly Module classifier;
+            private readonly Module<Tensor, Tensor> features;
+            private readonly Module<Tensor, Tensor> avgpool;
+            private readonly Module<Tensor, Tensor> classifier;
 
             public VGG(string name,
                 int numClasses,
@@ -347,7 +347,7 @@ namespace TorchSharp
                 bool skipfc = true,
                 Device device = null) : base(name)
             {
-                var layers = new List<Module>();
+                var layers = new List<Module<Tensor, Tensor>>();
 
                 var channels = _channels[name];
 

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1179,12 +1179,12 @@ namespace TorchSharp
             Assert.False(x.requires_grad);
         }
 
-        private class CondModel : Module
+        private class CondModel : Module<Tensor, Tensor>
         {
-            private Module fb = Linear(1000, 100, false);
-            private Module fbT1 = Linear(100, 10, false);
-            private Module fbF1 = Linear(100, 50, false);
-            private Module fbF2 = Linear(50, 10, false);
+            private Module<Tensor, Tensor> fb = Linear(1000, 100, false);
+            private Module<Tensor, Tensor> fbT1 = Linear(100, 10, false);
+            private Module<Tensor, Tensor> fbF1 = Linear(100, 50, false);
+            private Module<Tensor, Tensor> fbF2 = Linear(50, 10, false);
             private bool _isTrue = false;
 
             public CondModel(string name, bool isTrue) : base(name)
@@ -1718,7 +1718,7 @@ namespace TorchSharp
             Assert.True(seq.has_parameter("0.dict.second"));
         }
 
-        private class TestModule1 : Module
+        private class TestModule1 : Module<Tensor, Tensor>
         {
             public TestModule1(Tensor tensor, bool withGrad)
                 : base("TestModule1")
@@ -1740,7 +1740,7 @@ namespace TorchSharp
             private ParameterDict dict = new ParameterDict();
         }
 
-        private class TestModule2 : Module
+        private class TestModule2 : Module<Tensor, Tensor>
         {
             public TestModule2(Tensor tensor, bool withGrad)
                 : base("TestModule1")
@@ -1755,11 +1755,11 @@ namespace TorchSharp
 
             public override Tensor forward(Tensor input)
             {
-                for (int i = 0; i < list.Count; i++) { input = list[i].forward(input); }
+                for (int i = 0; i < list.Count; i++) { input = ((nn.Module<torch.Tensor, torch.Tensor>)list[i]).forward(input); }
                 throw new NotImplementedException();
             }
 
-            public Module submodule;
+            public Module<Tensor, Tensor> submodule;
             private ModuleList list = new ModuleList();
             private ModuleDict dict = new ModuleDict();
         }
@@ -1817,7 +1817,7 @@ namespace TorchSharp
             }
         }
 
-        private class TestModule3 : Module
+        private class TestModule3 : Module<Tensor, Tensor>
         {
             public TestModule3() : base(nameof(TestModule3)) { RegisterComponents(); }
 

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -368,7 +368,7 @@ namespace TorchSharp
             }
         }
 
-        private class TestModule1 : Module
+        private class TestModule1 : Module<torch.Tensor, torch.Tensor>
         {
             public TestModule1() : base("TestModule1")
             {

--- a/test/TorchSharpTest/TestSaveSD.cs
+++ b/test/TorchSharpTest/TestSaveSD.cs
@@ -12,17 +12,17 @@ namespace TorchSharp
 #endif // NET472_OR_GREATER
     public class TestSaveSD
     {
-        private class LSTMModel : Module
+        private class LSTMModel : nn.Module<Tensor, Tensor>
         {
             public static int NUM_WORDS = 100;
             public static int EMBEDDING_VEC_LEN = 100;
             public static int HIDDEN_SIZE = 128;
 
-            private Module embedding;
+            private Module<Tensor, Tensor> embedding;
             private LSTM lstm;
-            private Module dropout;
-            private Module dense;
-            private Module sigmoid;
+            private Module<Tensor, Tensor> dropout;
+            private Module<Tensor, Tensor> dense;
+            private Module<Tensor, Tensor> sigmoid;
             private Device _device;
 
             public LSTMModel(string name, Device device = null) : base(name)
@@ -59,11 +59,11 @@ namespace TorchSharp
             lstm.save("./lstm.dat");
         }
         
-        class LeNet1Model : Module
+        class LeNet1Model : Module<Tensor, Tensor>
         {
             // The names of properties should be the same in C# and Python
             // in this case, we both name the Sequential as layers
-            private readonly Module layers;
+            private readonly Module<Tensor, Tensor> layers;
             private Device _device;
 
             public LeNet1Model(string name, Device device = null) : base(name)
@@ -71,7 +71,7 @@ namespace TorchSharp
                 _device = device;
 
                 // the names of each layer should also be the same in C# and Python
-                var modules = new List<(string, Module)>();
+                var modules = new List<(string, Module<Tensor, Tensor>)>();
                 modules.Add(("conv-1", Conv2d(1, 4, 5, padding: 2)));
                 modules.Add(("bnrm2d-1", BatchNorm2d(4)));
                 modules.Add(("relu-1", ReLU()));

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -179,7 +179,7 @@ namespace TorchSharp
             var lin1 = nn.Linear(1000, 100);
             var lin2 = nn.Linear(100, 10);
 
-            var submodules = new List<(string name, torch.nn.Module submodule)>();
+            var submodules = new List<(string name, torch.nn.Module<Tensor, Tensor> submodule)>();
             submodules.Add(("lin1", lin1));
             submodules.Add(("lin2", lin2));
 
@@ -195,7 +195,7 @@ namespace TorchSharp
             var lin1 = nn.Linear(1000, 100);
             var lin2 = nn.Linear(100, 10);
 
-            var submodules = new List<(string name, torch.nn.Module submodule)>();
+            var submodules = new List<(string name, torch.nn.Module<Tensor, Tensor> submodule)>();
             submodules.Add(("lin1", lin1));
             submodules.Add(("relu1", nn.ReLU()));
             submodules.Add(("lin2", lin2));

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -56,7 +56,7 @@ namespace TorchSharp
             }
         }
 
-        class DoubleIt : nn.Module
+        class DoubleIt : nn.Module<Tensor, Tensor>
         {
             public DoubleIt() : base("double") { }
 
@@ -178,7 +178,7 @@ namespace TorchSharp
             }
         }
 
-        class TestModule : Module
+        class TestModule : Module<Tensor, Tensor>
         {
             public TestModule() : base(nameof(TestModule)) { }
 
@@ -199,7 +199,7 @@ namespace TorchSharp
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            static Module Make() => Sequential(("t", new TestModule()), ("d", Linear(10, 10)));
+            static Module<Tensor, Tensor> Make() => Sequential(("t", new TestModule()), ("d", Linear(10, 10)));
         }
 
         [Fact]
@@ -476,9 +476,9 @@ namespace TorchSharp
             }
         }
 
-        class Module500 : Module
+        class Module500 : Module<Tensor, Tensor>
         {
-            private Module bn1 = BatchNorm1d(28);
+            private Module<Tensor, Tensor> bn1 = BatchNorm1d(28);
 
             public Module500() : base(nameof(TestModule)) { RegisterComponents(); }
 
@@ -518,9 +518,9 @@ namespace TorchSharp
             Assert.Equal(0, nm_.item<long>());
         }
 
-        internal class Module510 : Module
+        internal class Module510 : Module<Tensor, Tensor>
         {
-            private readonly Module stack;
+            private readonly Module<Tensor, Tensor> stack;
 
             public Module510(int in_channels, int out_channels, int kernel_size = 3, int stride = 1, int padding = 0) : base(String.Empty)
             {
@@ -574,7 +574,7 @@ namespace TorchSharp
             }
         }
 
-        internal abstract class BaseModule : torch.nn.Module
+        internal abstract class BaseModule : torch.nn.Module<Tensor, Tensor>
         {
             public int? InstanceId = null;
 
@@ -583,7 +583,7 @@ namespace TorchSharp
             }
         }
 
-        public class TestGradWarningModel : torch.nn.Module
+        public class TestGradWarningModel : torch.nn.Module<Tensor, Tensor>
         {
             public readonly Modules.Parameter Weight;
 
@@ -612,11 +612,11 @@ namespace TorchSharp
             Assert.Equal(pB.Length + pC.Length, p.Length);
         }
 
-        internal class Module532 : Module
+        internal class Module532 : Module<Tensor, Tensor>
         {
-            public Module conv;
-            public Module batch;
-            private Module seq;
+            public Module<Tensor, Tensor> conv;
+            public Module<Tensor, Tensor> batch;
+            private Module<Tensor, Tensor> seq;
 
             public Module532(int in_channels, int out_channels) : base(String.Empty)
             {
@@ -656,9 +656,9 @@ namespace TorchSharp
             File.Delete("bug538.dat");
         }
 
-        internal class Module538 : Module
+        internal class Module538 : Module<Tensor, Tensor>
         {
-            private Module seq;
+            private Module<Tensor, Tensor> seq;
 
             public Module538(int in_channels, int out_channels) : base(String.Empty)
             {
@@ -779,7 +779,7 @@ namespace TorchSharp
         {
             var resnet = resnet18();
             var resnetlist = resnet.named_children();
-            var list = resnetlist.Take(6);
+            var list = resnetlist.Take(6).Select(x => (x.name, (nn.Module<Tensor, Tensor>)x.module));
             var bone = nn.Sequential(list);
 
             var x = torch.zeros(1, 3, 64, 160);

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -29,7 +29,7 @@ namespace TorchSharp
             var lin1 = Linear(1000, 100);
             var lin2 = Linear(100, 10);
 
-            var submodules = new List<(string name, torch.nn.Module submodule)>();
+            var submodules = new List<(string name, torch.nn.Module<Tensor, Tensor> submodule)>();
             submodules.Add(("lin1", lin1));
             submodules.Add(("relu1", ReLU()));
             submodules.Add(("lin2", lin2));
@@ -186,7 +186,7 @@ namespace TorchSharp
             }
         }
 
-        private static float TrainLoop(Module seq, Tensor x, Tensor y, optim.Optimizer optimizer)
+        private static float TrainLoop(Module<Tensor, Tensor> seq, Tensor x, Tensor y, optim.Optimizer optimizer)
         {
             var loss = mse_loss(Reduction.Sum);
 
@@ -213,7 +213,7 @@ namespace TorchSharp
             return finalLoss;
         }
 
-        private static float TrainLoop(Module seq, Tensor x, Tensor y, optim.Optimizer optimizer, optim.lr_scheduler.LRScheduler scheduler, bool check_lr = true, int iters = 10)
+        private static float TrainLoop(Module<Tensor, Tensor> seq, Tensor x, Tensor y, optim.Optimizer optimizer, optim.lr_scheduler.LRScheduler scheduler, bool check_lr = true, int iters = 10)
         {
             var loss = mse_loss(Reduction.Sum);
 
@@ -1770,7 +1770,7 @@ namespace TorchSharp
             if (torch.cuda.is_available()) {
                 var device = torch.CUDA;
 
-                using (Module conv1 = Conv2d(3, 4, 3, stride: 2),
+                using (Module<Tensor, Tensor> conv1 = Conv2d(3, 4, 3, stride: 2),
                       lin1 = Linear(4 * 13 * 13, 32),
                       lin2 = Linear(32, 10))
 


### PR DESCRIPTION
https://github.com/dotnet/TorchSharp/issues/323#issuecomment-927715929

> @NiklasGustafsson There's not really good solution. DiffSharp has a generic Model<TIn, TOut> and we could do that but it doesn't really solve that much. Having one virtual forward with the signature you show seems reasonable in the nature of things, pushing the complexity to Sequential.

This implements generic `nn.Model<T1, ..., TResult>` that is derived from `nn.Module`. `nn.Module` doesn't declare `forward()` functions, but generic subclasses do.

https://github.com/dotnet/TorchSharp/blob/51f37e11f7a7d0ddf5e53bad67281027c0ed7690/src/TorchSharp/NN/Module.cs#L1115
```cs
            public abstract class Module<T1, TResult> : Module
            {
                protected Module(string name) : base(name) { }
                protected Module(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
                internal Module(HType handle, IntPtr? boxedHandle) : base(handle, boxedHandle) { }
                public abstract TResult forward(T1 input1);
            }
```


This can avoid confusing `forward()` functions with `new` and `override`, with explicit type casting. A module may implement both `forward(Tensor)` and `forward(Tensor, Tensor)`, however, it can be derived only from one of `nn.Model<Tensor, Tensor>` and `nn.Model<Tensor, Tensor, Tensor>`.