### PR TITLE
moving P/Invoke declarations into dedicated class

### DIFF
--- a/src/Examples/AdversarialExampleGeneration.cs
+++ b/src/Examples/AdversarialExampleGeneration.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.IO;
-using TorchSharp.Modules;
 using static TorchSharp.torch;
-using static TorchSharp.torch.nn.functional;
 using static TorchSharp.torch.utils.data;
 
 namespace TorchSharp.Examples

--- a/src/Examples/IOReadWrite.cs
+++ b/src/Examples/IOReadWrite.cs
@@ -1,17 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.IO;
-using System.Runtime.InteropServices;
-
-using TorchSharp;
-
-using static TorchSharp.torch;
-
-using SkiaSharp;
 
 namespace TorchSharp.Examples
 {

--- a/src/Examples/MNIST.cs
+++ b/src/Examples/MNIST.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using static TorchSharp.torch;
 
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.nn.functional;
 using static TorchSharp.torch.utils.data;
 
 namespace TorchSharp.Examples

--- a/src/Examples/SequenceToSequence.cs
+++ b/src/Examples/SequenceToSequence.cs
@@ -4,11 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
-
-using TorchSharp;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.nn.functional;
 
 namespace TorchSharp.Examples
 {

--- a/src/Examples/SpeechCommands.cs
+++ b/src/Examples/SpeechCommands.cs
@@ -10,7 +10,6 @@ using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using static TorchSharp.torch.nn.functional;
 using static TorchSharp.torch.utils.data;
-using static TorchSharp.torchaudio;
 using static TorchSharp.torchaudio.datasets;
 
 namespace TorchSharp.Examples

--- a/src/Examples/TextClassification.cs
+++ b/src/Examples/TextClassification.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.nn.functional;
 
 namespace TorchSharp.Examples
 {

--- a/src/TorchAudio/AudioBackend.cs
+++ b/src/TorchAudio/AudioBackend.cs
@@ -1,7 +1,4 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchAudio/Backend.cs
+++ b/src/TorchAudio/Backend.cs
@@ -1,7 +1,4 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchAudio/BackendUtils.cs
+++ b/src/TorchAudio/BackendUtils.cs
@@ -1,7 +1,4 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchAudio/Datasets/SpeechCommandsDataset.cs
+++ b/src/TorchAudio/Datasets/SpeechCommandsDataset.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchAudio/Datasets/SpeechCommandsDatasetItem.cs
+++ b/src/TorchAudio/Datasets/SpeechCommandsDatasetItem.cs
@@ -1,9 +1,4 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchAudio/Datasets/Utils.cs
+++ b/src/TorchAudio/Datasets/Utils.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
+
 using System.IO;
-using System.Linq;
 using System.Text;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;

--- a/src/TorchAudio/Datasets/YesnoDataset.cs
+++ b/src/TorchAudio/Datasets/YesnoDataset.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchAudio/Datasets/YesnoDatasetItem.cs
+++ b/src/TorchAudio/Datasets/YesnoDatasetItem.cs
@@ -1,9 +1,4 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchAudio/Functional.cs
+++ b/src/TorchAudio/Functional.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 using static TorchSharp.torch;
 using System.Diagnostics;
 

--- a/src/TorchAudio/Models.cs
+++ b/src/TorchAudio/Models.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 
-using System;
-using static TorchSharp.torch;
-
 namespace TorchSharp
 {
     public static partial class torchaudio

--- a/src/TorchAudio/Modules/Tacotron2.cs
+++ b/src/TorchAudio/Modules/Tacotron2.cs
@@ -40,8 +40,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using static TorchSharp.torch;
 
 using static TorchSharp.torch.nn;

--- a/src/TorchAudio/Modules/WaveRNN.cs
+++ b/src/TorchAudio/Modules/WaveRNN.cs
@@ -12,12 +12,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using static TorchSharp.torch;
-
-using static TorchSharp.torch.nn;
 using F = TorchSharp.torch.nn.functional;
 
 #nullable enable

--- a/src/TorchAudio/NoBackend.cs
+++ b/src/TorchAudio/NoBackend.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TorchSharp
 {

--- a/src/TorchAudio/Transforms.cs
+++ b/src/TorchAudio/Transforms.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Linq;
-using System.Collections.Generic;
-
 using static TorchSharp.torch;
 using TorchSharp.Transforms;
 

--- a/src/TorchAudio/Transforms/GriffinLim.cs
+++ b/src/TorchAudio/Transforms/GriffinLim.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
 using static TorchSharp.torch;
 using static TorchSharp.torchaudio;
 

--- a/src/TorchAudio/Transforms/InverseSpectrogram.cs
+++ b/src/TorchAudio/Transforms/InverseSpectrogram.cs
@@ -1,8 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Text;
+
 using static TorchSharp.torch;
 using static TorchSharp.torchaudio;
 

--- a/src/TorchAudio/Transforms/Resample.cs
+++ b/src/TorchAudio/Transforms/Resample.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Text;
+
 using static TorchSharp.torch;
 using static TorchSharp.torchaudio;
 

--- a/src/TorchAudio/Transforms/Spectrogram.cs
+++ b/src/TorchAudio/Transforms/Spectrogram.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
-using System.Text;
 using static TorchSharp.torch;
 using static TorchSharp.torchaudio;
 

--- a/src/TorchSharp/Autograd.cs
+++ b/src/TorchSharp/Autograd.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -12,12 +12,6 @@ namespace TorchSharp
     internal class AutoGradMode : IDisposable
     {
         private bool _isPrevGrad;
-
-        [DllImport("LibTorchSharp")]
-        private static extern bool THSAutograd_isGradEnabled();
-
-        [DllImport("LibTorchSharp")]
-        private static extern void THSAutograd_setGrad(bool enabled);
 
         public AutoGradMode(bool enabled)
         {
@@ -99,17 +93,6 @@ namespace TorchSharp
             /// <returns></returns>
             public static bool is_grad_enabled() => AutoGradMode.IsAutogradEnabled();
 
-
-            [DllImport("LibTorchSharp")]
-            private static extern void THSAutograd_grad(
-             IntPtr outputs, long oLength,
-             IntPtr inputs, long iLength,
-             IntPtr grad_outs, long gLength,
-             [MarshalAs(UnmanagedType.U1)] bool retain_graph,
-             [MarshalAs(UnmanagedType.U1)] bool create_graph,
-             [MarshalAs(UnmanagedType.U1)] bool allow_unused,
-             AllocatePinnedArray allocator);
-
             /// <summary>
             /// Computes and returns the sum of gradients of outputs with respect to the inputs.
             /// </summary>
@@ -153,14 +136,6 @@ namespace TorchSharp
                 return result.Select(x => new Tensor(x)).ToList();
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern void THSAutograd_backward(
-                 IntPtr tensors, long tLength,
-                 IntPtr grad_tensors, long gtLength,
-                 [MarshalAs(UnmanagedType.U1)] bool retain_graph,
-                 [MarshalAs(UnmanagedType.U1)] bool create_graph,
-                 IntPtr inputs, long iLength);
-
             /// <summary>
             /// Computes the sum of gradients of given tensors with respect to graph leaves.
             /// </summary>
@@ -181,10 +156,10 @@ namespace TorchSharp
             /// <remarks>
             /// The graph is differentiated using the chain rule. If any of tensors are non-scalar (i.e. their data has more than one element) and require gradient,
             /// then the Jacobian-vector product would be computed, in this case the function additionally requires specifying grad_tensors.
-            /// 
+            ///
             /// It should be a sequence of matching length, that contains the “vector” in the Jacobian-vector product, usually the gradient of the differentiated
             /// function w.r.t. corresponding tensors (null is an acceptable value for all tensors that don’t need gradient tensors).
-            /// 
+            ///
             /// This function accumulates gradients in the leaves - you might need to zero the .grad properties or set them to null before calling it.
             /// </remarks>
             public static void backward(IList<Tensor> tensors, IList<Tensor> grad_tensors = null, bool? retain_graph = null, bool create_graph = false, IList<Tensor> inputs = null)
@@ -226,10 +201,10 @@ namespace TorchSharp
             /// <remarks>
             /// The graph is differentiated using the chain rule. If any of tensors are non-scalar (i.e. their data has more than one element) and require gradient,
             /// then the Jacobian-vector product would be computed, in this case the function additionally requires specifying grad_tensors.
-            /// 
+            ///
             /// It should be a sequence of matching length, that contains the “vector” in the Jacobian-vector product, usually the gradient of the differentiated
             /// function w.r.t. corresponding tensors (null is an acceptable value for all tensors that don’t need gradient tensors).
-            /// 
+            ///
             /// This function accumulates gradients in the leaves - you might need to zero the .grad properties or set them to null before calling it.
             /// </remarks>
             public static void backward(Tensor tensor, IList<Tensor> grad_tensors = null, bool? retain_graph = null, bool create_graph = false, IList<Tensor> inputs = null)
@@ -257,17 +232,16 @@ namespace TorchSharp
             /// <remarks>
             /// The graph is differentiated using the chain rule. If any of tensors are non-scalar (i.e. their data has more than one element) and require gradient,
             /// then the Jacobian-vector product would be computed, in this case the function additionally requires specifying grad_tensors.
-            /// 
+            ///
             /// It should be a sequence of matching length, that contains the “vector” in the Jacobian-vector product, usually the gradient of the differentiated
             /// function w.r.t. corresponding tensors (null is an acceptable value for all tensors that don’t need gradient tensors).
-            /// 
+            ///
             /// This function accumulates gradients in the leaves - you might need to zero the .grad properties or set them to null before calling it.
             /// </remarks>
             public static void backward(Tensor tensor, Tensor grad_tensor, bool? retain_graph = null, bool create_graph = false, IList<Tensor> inputs = null)
             {
                 backward(new[] { tensor }, new[] { grad_tensor }, retain_graph, create_graph, inputs);
             }
-
         }
     }
 }

--- a/src/TorchSharp/Data/DataIterator.cs
+++ b/src/TorchSharp/Data/DataIterator.cs
@@ -4,31 +4,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp.Data
 {
-    /// <summary>
-    /// Wrapper around methods used by the DataITerator class.
-    /// This is mainly because C# does not allow extern methods on generic classes.
-    /// </summary>
-    internal static class ExternMethods
-    {
-        [DllImport("LibTorchSharp")]
-        extern internal static IntPtr THSData_current(IntPtr iterator, IntPtr data, IntPtr target);
-
-        [DllImport("LibTorchSharp")]
-        extern internal static bool THSData_moveNext(IntPtr iterator);
-
-        [DllImport("LibTorchSharp")]
-        extern internal static long THSData_size(IntPtr iterator);
-
-        [DllImport("LibTorchSharp")]
-        extern internal static void THSData_reset(IntPtr iterator);
-
-        [DllImport("LibTorchSharp")]
-        extern internal static void THSData_dispose(IntPtr iterator);
-    }
-
     /// <summary>
     /// Class implementing enumerable over PyTorch's iterator.
     /// </summary>
@@ -84,7 +63,7 @@ namespace TorchSharp.Data
         }
 
         /// <summary>
-        ///   Releases the storage.
+        /// Releases the storage.
         /// </summary>
         public void Dispose()
         {
@@ -93,13 +72,13 @@ namespace TorchSharp.Data
         }
 
         /// <summary>
-        ///   Implements the .NET Dispose pattern.
+        /// Implements the .NET Dispose pattern.
         /// </summary>
         protected void Dispose(bool disposing)
         {
             if (disposing)
             {
-                ExternMethods.THSData_dispose(handle.DangerousGetHandle());
+                THSData_dispose(handle.DangerousGetHandle());
                 handle.Dispose();
                 handle.SetHandleAsInvalid();
             }
@@ -111,7 +90,7 @@ namespace TorchSharp.Data
         /// <returns></returns>
         public long Size()
         {
-            return ExternMethods.THSData_size(handle.DangerousGetHandle());
+            return THSData_size(handle.DangerousGetHandle());
         }
 
         /// <summary>
@@ -155,7 +134,7 @@ namespace TorchSharp.Data
             {
                 get
                 {
-                    ExternMethods.THSData_current(_iterator.handle.DangerousGetHandle(), _dRef, _tRef);   
+                    THSData_current(_iterator.handle.DangerousGetHandle(), _dRef, _tRef);
                     return (new Tensor(_darray.Array[0]), new Tensor(_tarray.Array[0]));
                 }
             }
@@ -170,13 +149,13 @@ namespace TorchSharp.Data
                     return true;
                 }
 
-                return ExternMethods.THSData_moveNext(_iterator.handle.DangerousGetHandle());
+                return THSData_moveNext(_iterator.handle.DangerousGetHandle());
             }
 
             public void Reset()
             {
                 _isFirst = true;
-                ExternMethods.THSData_reset(_iterator.handle.DangerousGetHandle());
+                THSData_reset(_iterator.handle.DangerousGetHandle());
             }
 
             public void Dispose()

--- a/src/TorchSharp/Data/Loader.cs
+++ b/src/TorchSharp/Data/Loader.cs
@@ -1,16 +1,10 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp.Data
 {
     public class Loader
     {
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSData_loaderMNIST([MarshalAs(UnmanagedType.LPStr)]string filename,
-            long batchSize,
-            bool isTrain);
-
         /// <summary>
         /// Create an iterator scanning the MNIST dataset.
         /// </summary>
@@ -18,14 +12,10 @@ namespace TorchSharp.Data
         /// <param name="batchSize">The required batch size</param>
         /// <param name="isTrain">Wheter the iterator is for training or testing</param>
         /// <returns></returns>
-        static public DataIterator MNIST(string filename, long batchSize, bool isTrain = true)
+        public static DataIterator MNIST(string filename, long batchSize, bool isTrain = true)
         {
             return new DataIterator(THSData_loaderMNIST(filename, batchSize, isTrain));
         }
-
-        [DllImport("LibTorchSharp")]
-        private static extern IntPtr THSData_loaderCIFAR10([MarshalAs(UnmanagedType.LPStr)] string path,
-            long batchSize, bool isTrain);
 
         /// <summary>
         /// Create an iterator scanning the CIFAR10 dataset.
@@ -34,7 +24,7 @@ namespace TorchSharp.Data
         /// <param name="batchSize">The required batch size</param>
         /// <param name="isTrain">Wheter the iterator is for training or testing</param>
         /// <returns></returns>
-        static public DataIterator CIFAR10(string path, long batchSize, bool isTrain = true)
+        public static DataIterator CIFAR10(string path, long batchSize, bool isTrain = true)
         {
             return new DataIterator(THSData_loaderCIFAR10(path, batchSize, isTrain));
         }

--- a/src/TorchSharp/DistanceFunctionNative.cs
+++ b/src/TorchSharp/DistanceFunctionNative.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp
+{
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate IntPtr DistanceFunctionNative(IntPtr x, IntPtr y);
+}

--- a/src/TorchSharp/Distributions/ExpRelaxedCategorical.cs
+++ b/src/TorchSharp/Distributions/ExpRelaxedCategorical.cs
@@ -4,7 +4,6 @@ using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 

--- a/src/TorchSharp/Distributions/GumbEL.cs
+++ b/src/TorchSharp/Distributions/GumbEL.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 

--- a/src/TorchSharp/Distributions/HalfCauchy.cs
+++ b/src/TorchSharp/Distributions/HalfCauchy.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
 using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 
@@ -35,7 +33,7 @@ namespace TorchSharp
                 using var _ = torch.NewDisposeScope();
                 value = torch.as_tensor(value, scale.dtype, scale.device);
                 var lp = base_distribution.log_prob(value) + Math.Log(2);
-                lp[value.expand(lp.shape) < 0] = Double.NegativeInfinity;
+                lp[value.expand(lp.shape) < 0] = double.NegativeInfinity;
                 return lp.MoveToOuterDisposeScope();
             }
 

--- a/src/TorchSharp/Distributions/HalfNormal.cs
+++ b/src/TorchSharp/Distributions/HalfNormal.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
 using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 
@@ -34,7 +32,7 @@ namespace TorchSharp
             {
                 using var _ = torch.NewDisposeScope();
                 var lp = base_distribution.log_prob(value) + Math.Log(2);
-                lp[value.expand(lp.shape) < 0] = Double.NegativeInfinity;
+                lp[value.expand(lp.shape) < 0] = double.NegativeInfinity;
                 return lp.MoveToOuterDisposeScope();
             }
 

--- a/src/TorchSharp/Distributions/Kumaraswamy.cs
+++ b/src/TorchSharp/Distributions/Kumaraswamy.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 

--- a/src/TorchSharp/Distributions/LogNormal.cs
+++ b/src/TorchSharp/Distributions/LogNormal.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 

--- a/src/TorchSharp/Distributions/Pareto.cs
+++ b/src/TorchSharp/Distributions/Pareto.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
 using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 
@@ -46,7 +44,7 @@ namespace TorchSharp
             {
                 using var _ = torch.NewDisposeScope();
                 var lp = base_distribution.log_prob(value) + Math.Log(2);
-                lp[value.expand(lp.shape) < 0] = Double.NegativeInfinity;
+                lp[value.expand(lp.shape) < 0] = double.NegativeInfinity;
                 return lp.MoveToOuterDisposeScope();
             }
 

--- a/src/TorchSharp/Distributions/RelaxedBernoulli.cs
+++ b/src/TorchSharp/Distributions/RelaxedBernoulli.cs
@@ -4,7 +4,6 @@ using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 

--- a/src/TorchSharp/Distributions/RelaxedOneHotCategorical.cs
+++ b/src/TorchSharp/Distributions/RelaxedOneHotCategorical.cs
@@ -4,7 +4,6 @@ using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
     using Modules;
     using static torch.distributions;
 

--- a/src/TorchSharp/Distributions/TransformedDistribution.cs
+++ b/src/TorchSharp/Distributions/TransformedDistribution.cs
@@ -6,7 +6,6 @@ using static TorchSharp.torch;
 namespace TorchSharp
 {
     using System.Linq;
-    using Modules;
     using static torch.distributions;
 
     namespace Modules

--- a/src/TorchSharp/Distributions/Transforms.cs
+++ b/src/TorchSharp/Distributions/Transforms.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.Linq;
 
 namespace TorchSharp

--- a/src/TorchSharp/Distributions/Weibull.cs
+++ b/src/TorchSharp/Distributions/Weibull.cs
@@ -1,12 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
+
 using static TorchSharp.torch;
 
 namespace TorchSharp
 {
-    using System.Linq;
-    using System.Net.WebSockets;
     using Modules;
     using static torch.distributions;
 

--- a/src/TorchSharp/FFT.cs
+++ b/src/TorchSharp/FFT.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
-
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
     // This file contains the mathematical operators on Tensor
-
     public enum FFTNormType
     {
         Backward = 0,
@@ -18,9 +16,6 @@ namespace TorchSharp
     {
         public static partial class fft
         {
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fft(IntPtr tensor, long n, long dim, sbyte norm);
-
             /// <summary>
             /// Computes the one dimensional discrete Fourier transform of input.
             /// </summary>
@@ -37,9 +32,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ifft(IntPtr tensor, long n, long dim, sbyte norm);
-
             /// <summary>
             /// Computes the one dimensional inverse discrete Fourier transform of input.
             /// </summary>
@@ -54,9 +46,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
 
             /// <summary>
             /// Computes the two-dimensional discrete Fourier transform of input.
@@ -83,9 +72,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ifft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
-
             /// <summary>
             /// Computes the two-dimensional inverse discrete Fourier transform of input.
             /// </summary>
@@ -109,9 +95,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
 
             /// <summary>
             /// Computes the N-dimensional discrete Fourier transform of input.
@@ -138,9 +121,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ifftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
-
             /// <summary>
             /// Computes the N-dimensional inverse discrete Fourier transform of input.
             /// </summary>
@@ -166,9 +146,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_irfft(IntPtr tensor, long n, long dim, sbyte norm);
-
             /// <summary>
             /// Computes the one dimensional inverse Fourier transform of real-valued input.
             /// </summary>
@@ -182,9 +159,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_rfft(IntPtr tensor, long n, long dim, sbyte norm);
 
             /// <summary>
             /// Computes the one dimensional Fourier transform of real-valued input.
@@ -200,9 +174,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_rfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
 
             /// <summary>
             /// Computes the two-dimensional discrete Fourier transform of real-vaued input.
@@ -228,9 +199,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_irfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
-
             /// <summary>
             /// Computes the two-dimensional inverse discrete Fourier transform of real-valued input.
             /// </summary>
@@ -254,9 +222,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_rfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
 
             /// <summary>
             /// Computes the N-dimensional discrete Fourier transform of real-valued input.
@@ -282,9 +247,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_irfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
-
             /// <summary>
             /// Computes the N-dimensional inverse discrete Fourier transform of real-valued input.
             /// </summary>
@@ -309,9 +271,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_hfft(IntPtr tensor, long n, long dim, sbyte norm);
-
             /// <summary>
             /// Computes the one dimensional discrete Fourier transform of a Hermitian symmetric input signal.
             /// </summary>
@@ -329,9 +288,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ihfft(IntPtr tensor, long n, long dim, sbyte norm);
-
             /// <summary>
             /// Computes the inverse of hfft().
             /// </summary>
@@ -347,9 +303,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fftshift(IntPtr tensor, IntPtr dim, int dim_length);
 
             /// <summary>
             /// Reorders n-dimensional FFT data, as provided by fftn(), to have negative frequency terms first.
@@ -370,9 +323,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ifftshift(IntPtr tensor, IntPtr dim, int dim_length);
-
             /// <summary>
             /// Inverse of fftshift().
             /// </summary>
@@ -390,9 +340,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_fftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
             /// <summary>
             /// Computes the discrete Fourier Transform sample frequencies for a signal of size n.
             /// </summary>
@@ -401,7 +348,7 @@ namespace TorchSharp
             /// <param name="dtype">The desired data type of the returned tensor</param>
             /// <param name="device">the desired device of the returned tensor</param>
             /// <param name="requires_grad">If autograd should record operations on the returned tensor.</param>
-            static public Tensor fftfreq(long n, double d = 1.0, torch.ScalarType? dtype = null, torch.Device device = null, bool requires_grad = false)
+            public static Tensor fftfreq(long n, double d = 1.0, torch.ScalarType? dtype = null, torch.Device device = null, bool requires_grad = false)
             {
                 device = torch.InitializeDevice(device);
                 if (!dtype.HasValue) {
@@ -419,9 +366,6 @@ namespace TorchSharp
                 return new Tensor(handle);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_rfftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
             /// <summary>
             /// Computes the sample frequencies for rfft() with a signal of size n.
             /// </summary>
@@ -430,7 +374,7 @@ namespace TorchSharp
             /// <param name="dtype">The desired data type of the returned tensor</param>
             /// <param name="device">the desired device of the returned tensor</param>
             /// <param name="requires_grad">If autograd should record operations on the returned tensor.</param>
-            static public Tensor rfftfreq(long n, double d = 1.0, torch.ScalarType? dtype = null, torch.Device device = null, bool requires_grad = false)
+            public static Tensor rfftfreq(long n, double d = 1.0, torch.ScalarType? dtype = null, torch.Device device = null, bool requires_grad = false)
             {
                 device = torch.InitializeDevice(device);
                 if (!dtype.HasValue) {
@@ -447,9 +391,6 @@ namespace TorchSharp
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(handle);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_hfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
 
             /// <summary>
             /// Computes the 2-dimensional discrete Fourier transform of a Hermitian symmetric input signal.
@@ -479,9 +420,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_ihfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
-
             /// <summary>
             /// Computes the 2-dimensional inverse discrete Fourier transform of a Hermitian symmetric input signal.
             ///
@@ -509,9 +447,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_hfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
 
             /// <summary>
             /// Computes the n-dimensional discrete Fourier transform of a Herimitian symmetric input signal.
@@ -541,8 +476,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_ihfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
             /// <summary>
             /// Computes the n-dimensional inverse discrete Fourier transform of a Herimitian symmetric input signal.
             ///

--- a/src/TorchSharp/Generator.cs
+++ b/src/TorchSharp/Generator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 
@@ -83,9 +83,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static long THSGenerator_initial_seed(IntPtr handle);
-
             /// <summary>
             /// Returns the initial seed for generating random numbers.
             /// </summary>
@@ -94,24 +91,6 @@ namespace TorchSharp
             {
                 return THSGenerator_initial_seed(Handle);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSGenerator_get_rng_state(IntPtr handle);
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSGenerator_set_rng_state(IntPtr handle, IntPtr tensor);
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSGenerator_gen_manual_seed(IntPtr handle, long seed);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSGenerator_new(ulong seed, long device_type, long device_index);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSGenerator_default_generator();
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSGenerator_dispose(IntPtr handle);
 
             #region Dispose() support
             protected virtual void Dispose(bool disposing)

--- a/src/TorchSharp/JIT/CompilationUnit.cs
+++ b/src/TorchSharp/JIT/CompilationUnit.cs
@@ -1,14 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using static TorchSharp.torch;
-using System.Net;
-using static TorchSharp.torch.nn;
-using static TorchSharp.torch.jit.ScriptModule;
+using TorchSharp.PInvoke;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -32,7 +25,7 @@ namespace TorchSharp
             /// </remarks>
             public class CompilationUnit : IDisposable
             {
-                internal CompilationUnit(IntPtr handle) 
+                internal CompilationUnit(IntPtr handle)
                 {
                     this.handle = handle;
                 }
@@ -58,13 +51,7 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_CompilationUnit_dispose(IntPtr handle);
-
                 internal IntPtr handle;
-
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_CompilationUnit_Invoke(IntPtr module, string name, IntPtr tensors, int length, AllocatePinnedArray allocator, out sbyte typeCode);
 
                 /// <summary>
                 /// Invoke a function from the compilation unit.
@@ -73,7 +60,7 @@ namespace TorchSharp
                 /// <param name="objs">Function arguments.</param>
                 public object invoke(string name, params object[] objs)
                 {
-                    if (String.IsNullOrEmpty(name)) throw new ArgumentNullException("method name");
+                    if (string.IsNullOrEmpty(name)) throw new ArgumentNullException("method name");
 
                     TensorOrScalar[] ptrArray = null;
                     sbyte typeCode = 0;
@@ -108,9 +95,6 @@ namespace TorchSharp
                 public TResult invoke<T, TResult>(string name, params T[] inputs) => (TResult)invoke(name, inputs);
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSJIT_compile(string script);
-
             /// <summary>
             /// Create a TorchScript compilation unit containing TorchScript-compliant Python from a string.
             /// </summary>
@@ -118,7 +102,7 @@ namespace TorchSharp
             /// <returns></returns>
             public static CompilationUnit compile(string script)
             {
-                if (String.IsNullOrEmpty(script))
+                if (string.IsNullOrEmpty(script))
                     throw new ArgumentNullException("empty script");
 
                 var result = THSJIT_compile(script);

--- a/src/TorchSharp/JIT/ScriptModule.cs
+++ b/src/TorchSharp/JIT/ScriptModule.cs
@@ -1,13 +1,11 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
+using System.Linq;
 using System.Runtime.InteropServices;
-using static TorchSharp.torch;
-using System.Net;
-using static TorchSharp.torch.nn;
+using TorchSharp.PInvoke;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,7 +16,7 @@ namespace TorchSharp
             /// <summary>
             /// This class represents a TorchScript module.
             /// </summary>
-            public class ScriptModule : torch.nn.Module
+            public class ScriptModule : nn.Module
             {
                 internal ScriptModule(IntPtr handle) : base(new HType(handle, true, THSJIT_Module_dispose), null)
                 {
@@ -28,12 +26,6 @@ namespace TorchSharp
                 {
                     Dispose(false);
                 }
-
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_dispose(HType handle);
-
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_named_parameters(HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
 
                 protected override (string name, TorchSharp.Modules.Parameter parameter)[] _named_parameters()
                 {
@@ -47,9 +39,6 @@ namespace TorchSharp
                     return ptrArray.Select((x, i) => (Marshal.PtrToStringAnsi(strArray[i]), new TorchSharp.Modules.Parameter(x))).ToArray();
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_named_buffers(HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
-
                 protected override (string name, Tensor buffer)[] _named_buffers()
                 {
                     using var pa = new PinnedArray<IntPtr>();
@@ -61,9 +50,6 @@ namespace TorchSharp
 
                     return ptrArray.Select((x, i) => (Marshal.PtrToStringAnsi(strArray[i]), new Tensor(x))).ToArray();
                 }
-
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_named_modules(HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
 
                 /// <summary>
                 /// Returns an enumerable of all modules in the network, yielding both the name of the module as well as the module itself.
@@ -78,11 +64,8 @@ namespace TorchSharp
                     var ptrArray = pa.Array;
                     var strArray = sa.Array;
 
-                    return ptrArray.Select((x, i) => (Marshal.PtrToStringAnsi(strArray[i]), new ScriptModule(x) as nn.Module)).Where(m => !String.IsNullOrEmpty(m.Item1));
+                    return ptrArray.Select((x, i) => (Marshal.PtrToStringAnsi(strArray[i]), new ScriptModule(x) as nn.Module)).Where(m => !string.IsNullOrEmpty(m.Item1));
                 }
-
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_named_children(HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
 
                 /// <summary>
                 /// Returns an enumerable of immediate children modules, yielding both the name of the module as well as the module itself.
@@ -100,27 +83,15 @@ namespace TorchSharp
                     return ptrArray.Select((x, i) => (Marshal.PtrToStringAnsi(strArray[i]), new ScriptModule(x) as nn.Module));
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern long THSJIT_getNumModules(HType module);
-
-                [DllImport("LibTorchSharp")]
-                private static extern int THSJIT_Module_num_inputs(HType module);
-
                 public int GetNumberOfInputs()
                 {
                     return THSJIT_Module_num_inputs(handle);
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern int THSJIT_Module_num_outputs(HType module);
-
                 public int GetNumberOfOutputs()
                 {
                     return THSJIT_Module_num_outputs(handle);
                 }
-
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_train(HType module, bool on);
 
                 /// <summary>
                 /// Sets the module in evaluation mode.
@@ -135,9 +106,6 @@ namespace TorchSharp
                     CheckForErrors();
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_eval(HType module);
-
                 /// <summary>
                 /// Sets the module in evaluation mode.
                 /// </summary>
@@ -151,9 +119,6 @@ namespace TorchSharp
                     CheckForErrors();
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern bool THSJIT_Module_is_training(HType module);
-
                 /// <summary>
                 /// Check whether the module is set to training or evaluation mode.
                 /// </summary>
@@ -165,16 +130,7 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern void THSJIT_Module_to_device(HType module, long deviceType, long deviceIndex);
-
-                [DllImport("LibTorchSharp")]
-                static extern void THSJIT_Module_to_device_dtype(HType module, sbyte dtype, long deviceType, long deviceIndex);
-
-                [DllImport("LibTorchSharp")]
-                static extern void THSJIT_Module_to_dtype(HType module, sbyte dtype);
-
-                internal protected override nn.Module _to(Device device, ScalarType dtype)
+                protected internal override nn.Module _to(Device device, ScalarType dtype)
                 {
                     if (device.type != DeviceType.CUDA) { device = new Device(device.type, -1); };
 
@@ -196,7 +152,7 @@ namespace TorchSharp
                 /// <param name="deviceType">The device type, e.g. 'CPU' or 'CUDA'.</param>
                 /// <param name="deviceIndex">The optional device index.</param>
                 /// <returns></returns>
-                internal protected override nn.Module _to(DeviceType deviceType, int deviceIndex = -1)
+                protected internal override nn.Module _to(DeviceType deviceType, int deviceIndex = -1)
                 {
                     if (deviceType != DeviceType.CUDA) deviceIndex = -1;
 
@@ -223,7 +179,7 @@ namespace TorchSharp
                 /// Convert the parameters and buffers.
                 /// </summary>
                 /// <returns></returns>
-                internal protected override nn.Module _to(ScalarType dtype)
+                protected internal override nn.Module _to(ScalarType dtype)
                 {
                     THSJIT_Module_to_dtype(handle, (sbyte)dtype);
                     CheckForErrors();
@@ -235,18 +191,12 @@ namespace TorchSharp
 
 #if false   // These functions "work," but the native code doesn't seem to find any interesting information.
 
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSJIT_Module_getInputType(HType module, int index);
-
                 public Type GetInputType(int index)
                 {
                     var type = new Type(THSJIT_Module_getInputType(handle, index), Type.TypeKind.AnyType);
 
                     return GetType(type);
                 }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSJIT_getOutputType(HType module, int index);
 
                 public Type GetOutputType(int index)
                 {
@@ -271,9 +221,6 @@ namespace TorchSharp
                     }
                 }
 #endif
-
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_forward(HType module, IntPtr tensors, int length, AllocatePinnedArray allocator, out sbyte typeCode);
 
                 /// <summary>
                 /// Invoke the 'forward' function of the script with any number of arguments.
@@ -314,16 +261,6 @@ namespace TorchSharp
                     return ProcessReturnValue(name, ptrArray, typeCode);
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern void THSJIT_Module_invoke(HType module, string name, IntPtr tensors, int length, AllocatePinnedArray allocator, out sbyte typeCode);
-
-                [StructLayout(LayoutKind.Sequential)]
-                internal struct TensorOrScalar
-                {
-                    public long TypeCode;
-                    public IntPtr Handle;
-                }
-
                 /// <summary>
                 /// Invoke a function from the script module.
                 /// </summary>
@@ -349,7 +286,7 @@ namespace TorchSharp
                 /// </remarks>
                 public object invoke(string name, params object[] objs)
                 {
-                    if (String.IsNullOrEmpty(name)) throw new ArgumentNullException("method name");
+                    if (string.IsNullOrEmpty(name)) throw new ArgumentNullException("method name");
 
                     TensorOrScalar[] ptrArray = null;
                     sbyte typeCode = 0;
@@ -665,9 +602,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSJIT_load(string filename, long deviceType, long deviceIndex);
-
             /// <summary>
             /// Load a ScriptModule or ScriptFunction previously saved with torch.jit.save
             /// </summary>
@@ -877,12 +811,9 @@ namespace TorchSharp
                 return result;
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern void THSJIT_save(nn.Module.HType handle, string filename);
-
             /// <summary>
             /// Save an offline version of a previously loaded script module.
-            /// 
+            ///
             /// The saved module serializes all of the methods, submodules, parameters, and attributes of this module.
             /// It can be loaded into the C++ API using torch::jit::load(filename) or into the .NET API with torch.jit.load().
             /// </summary>

--- a/src/TorchSharp/JIT/Type/TensorType.cs
+++ b/src/TorchSharp/JIT/Type/TensorType.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -22,17 +22,10 @@ namespace TorchSharp
                     type.Dispose();
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern sbyte THSJIT_TensorType_dtype(HType handle);
-
-                public torch.ScalarType GetScalarType()
+                public ScalarType GetScalarType()
                 {
-                    return (torch.ScalarType)THSJIT_TensorType_dtype(handle);
+                    return (ScalarType)THSJIT_TensorType_dtype(handle);
                 }
-
-
-                [DllImport("LibTorchSharp")]
-                static extern long THSJIT_TensorType_sizes(HType handle, AllocatePinnedArray allocator);
 
                 /// <summary>
                 ///  Retrieves the sizes of all dimensions of the tensor.
@@ -43,23 +36,17 @@ namespace TorchSharp
 
                     using (var pa = new PinnedArray<long>()) {
                         THSJIT_TensorType_sizes(handle, pa.CreateArray);
-                        torch.CheckForErrors();
+                        CheckForErrors();
                         ptrArray = pa.Array;
                     }
 
                     return ptrArray;
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern int THSJIT_getDimensionedTensorTypeDimensions(HType handle);
-
                 public int GetDimensions()
                 {
                     return THSJIT_getDimensionedTensorTypeDimensions(handle);
                 }
-
-                [DllImport("LibTorchSharp")]
-                private static extern string THSJIT_getDimensionedTensorDevice(HType handle);
 
                 public string GetDevice()
                 {

--- a/src/TorchSharp/JIT/Type/Type.cs
+++ b/src/TorchSharp/JIT/Type/Type.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections;
 using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -9,7 +9,6 @@ namespace TorchSharp
     {
         public static partial class jit
         {
-
             public class Type : IDisposable
             {
                 /// <summary>
@@ -29,12 +28,6 @@ namespace TorchSharp
                     internal HType() : base(IntPtr.Zero, true)
                     {
                     }
-
-                    [DllImport("LibTorchSharp")]
-                    private static extern void THSJIT_Type_dispose(HType handle);
-
-                    [DllImport("LibTorchSharp")]
-                    private static extern void THSJIT_TensorType_dispose(HType handle);
 
                     protected override bool ReleaseHandle()
                     {
@@ -88,15 +81,9 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern sbyte THSJIT_Type_kind(HType handle);
-
                 internal TypeKind Kind {
                     get { return (TypeKind)THSJIT_Type_kind(handle); }
                 }
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSJIT_Type_cast(HType module);
 
                 internal TensorType AsTensorType()
                 {

--- a/src/TorchSharp/LinearAlgebra.cs
+++ b/src/TorchSharp/LinearAlgebra.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -11,12 +11,6 @@ namespace TorchSharp
     {
         public static class linalg
         {
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_cholesky(IntPtr tensor);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_cholesky_ex(IntPtr tensor, bool check_errors, out IntPtr pInfo);
-
             /// <summary>
             /// Computes the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix.
             /// </summary>
@@ -47,15 +41,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return (new Tensor(res), new Tensor(pInfo));
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_cond_int(IntPtr tensor, int p);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_cond_float(IntPtr tensor, double p);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_cond_str(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string p);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_cond_none(IntPtr tensor);
 
             public static Tensor cond(Tensor input, int p)
             {
@@ -104,9 +89,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_cross(IntPtr input, IntPtr other, long dim);
-
             /// <summary>
             /// Returns the cross product of vectors in dimension dim of input and other.
             /// input and other must have the same size, and the size of their dim dimension should be 3.
@@ -117,9 +99,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_det(IntPtr tensor);
 
             /// <summary>
             /// Computes the determinant of a square matrix.
@@ -132,9 +111,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_slogdet(IntPtr tensor, out IntPtr pLogabsdet);
 
             /// <summary>
             /// Computes the sign and natural logarithm of the absolute value of the determinant of a square matrix.
@@ -168,9 +144,6 @@ namespace TorchSharp
             /// </remarks>
             public static Tensor diagonal(Tensor input, int offset = 0, int dim1 = -2, int dim2 = -1) => input.diagonal(offset, dim1, dim2);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_eig(IntPtr tensor, out IntPtr pEigenvectors);
-
             /// <summary>
             /// Computes the eigenvalue decomposition of a square matrix if it exists.
             /// </summary>
@@ -183,9 +156,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return (new Tensor(res), new Tensor(vectors));
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_eigh(IntPtr tensor, byte UPLO, out IntPtr pEigenvectors);
 
             /// <summary>
             /// Computes the eigenvalue decomposition of a complex Hermitian or real symmetric matrix.
@@ -201,9 +171,6 @@ namespace TorchSharp
                 return (new Tensor(res), new Tensor(vectors));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_eigvals(IntPtr tensor);
-
             /// <summary>
             /// Computes the eigenvalues of a square matrix.
             /// </summary>
@@ -216,9 +183,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_eigvalsh(IntPtr tensor, byte UPLO);
 
             /// <summary>
             /// Computes the eigenvalues of a complex Hermitian or real symmetric matrix.
@@ -234,9 +198,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_inv(IntPtr tensor);
-
             /// <summary>
             /// Computes the inverse of a square matrix if it exists.
             /// </summary>
@@ -250,9 +211,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_inv_ex(IntPtr tensor, bool check_errors, out IntPtr pInfo);
 
             /// <summary>
             /// Computes the inverse of a square matrix if it is invertible.
@@ -274,11 +232,6 @@ namespace TorchSharp
                 return (new Tensor(res), new Tensor(pInfo));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_lstsq_none(IntPtr tensor, IntPtr other, out IntPtr pResiduals, out IntPtr pRank, out IntPtr pSingularValues);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_lstsq_rcond(IntPtr tensor, IntPtr other, double rcond, out IntPtr pResiduals, out IntPtr pRank, out IntPtr pSingularValues);
-
             /// <summary>
             /// Computes a solution to the least squares problem of a system of linear equations.
             /// </summary>
@@ -292,9 +245,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return (new Tensor(solution), new Tensor(residuals), new Tensor(rank), new Tensor(singularValues));
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_lu_factor(IntPtr tensor, bool pivot, out IntPtr pPivots);
 
             /// <summary>
             /// Computes a compact representation of the LU factorization with partial pivoting of a matrix.
@@ -327,10 +277,7 @@ namespace TorchSharp
             /// <summary>
             /// Computes the matrix exponential of a square matrix or of each square matrix in a batch.
             /// </summary>
-            public static Tensor matrix_exp(Tensor input) => input.matrix_exp(); 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_matrix_norm_fronuc(IntPtr tensor, byte fronuc, IntPtr dim, int dim_length, bool keepdim);
+            public static Tensor matrix_exp(Tensor input) => input.matrix_exp();
 
             /// <summary>
             /// Computes a matrix norm.
@@ -353,9 +300,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_matrix_norm(IntPtr tensor, IntPtr ord, IntPtr dim, int dim_length, bool keepdim);
-
             /// <summary>
             /// Computes a matrix norm.
             /// </summary>
@@ -376,12 +320,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_matrix_rank(IntPtr tensor, double atol, bool has_atol, double rtol, bool has_rtol, bool hermitian);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_matrix_rank_tensor(IntPtr tensor, IntPtr atol, IntPtr rtol, bool hermitian);
 
             /// <summary>
             /// Computes the numerical rank of a matrix.
@@ -419,9 +357,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSLinalg_multi_dot(IntPtr tensor, int len);
-
             /// <summary>
             /// Efficiently multiplies two or more matrices by reordering the multiplications so that the fewest arithmetic operations are performed.
             /// </summary>
@@ -444,16 +379,6 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_norm_str(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string p, IntPtr dim, int dim_length, bool keepdim);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_norm_float(IntPtr tensor, double p, IntPtr dim, int dim_length, bool keepdim);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_norm_int(IntPtr tensor, int p, IntPtr dim, int dim_length, bool keepdim);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_norm_opt(IntPtr tensor, IntPtr dim, int dim_length, bool keepdim);
-
 
             /// <summary>
             /// Computes a vector or matrix norm.
@@ -531,12 +456,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_pinv(IntPtr tensor, double atol, bool has_atol, double rtol, bool has_rtol, bool hermitian);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_pinv_tensor(IntPtr tensor, IntPtr atol, IntPtr rtol, bool hermitian);
-
             /// <summary>
             /// Computes the numerical rank of a matrix.
             /// The matrix rank is computed as the number of singular values(or eigenvalues in absolute value when hermitian = True) that are greater than the specified tol threshold.
@@ -580,9 +499,6 @@ namespace TorchSharp
                 R = 2
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_qr(IntPtr tensor, byte mode, out IntPtr pR);
-
             /// <summary>
             /// Computes the QR decomposition of a matrix.
             /// </summary>
@@ -596,9 +512,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return (new Tensor(Q), new Tensor(R));
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_solve(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Computes the solution of a square system of linear equations with a unique solution.
@@ -614,9 +527,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_svd(IntPtr tensor, bool fullMatrices, out IntPtr pS, out IntPtr pVh);
-
             /// <summary>
             /// Computes the singular value decomposition (SVD) of a matrix.
             /// </summary>
@@ -631,9 +541,6 @@ namespace TorchSharp
                 return (new Tensor(U), new Tensor(S), new Tensor(Vh));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_svdvals(IntPtr tensor);
-
             /// <summary>
             /// Computes the singular values of a matrix.
             /// </summary>
@@ -646,9 +553,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_tensorinv(IntPtr tensor, long ind);
 
             /// <summary>
             /// Computes the multiplicative inverse of torch.tensordot().
@@ -663,9 +567,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_tensorsolve(IntPtr tensor, IntPtr other, IntPtr dim, int dim_length);
 
             /// <summary>
             /// Computes the solution X to the system torch.tensordot(A, X) = B.
@@ -684,9 +585,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_vector_norm(IntPtr tensor, IntPtr ord, IntPtr dim, int dim_length, bool keepdim);
 
             /// <summary>
             /// Computes a vector norm.

--- a/src/TorchSharp/NN/Activation/CELU.cs
+++ b/src/TorchSharp/NN/Activation/CELU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -16,9 +16,6 @@ namespace TorchSharp
         {
             internal CELU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_CELU_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_CELU_forward(handle, tensor.Handle);
@@ -31,23 +28,19 @@ namespace TorchSharp
                 return typeof(CELU).Name;
             }
         }
-
     }
 
     public static partial class torch
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_CELU_ctor(double alpha, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Continuously Differentiable Exponential Linear Unit
             /// </summary>
             /// <param name="alpha">The α value for the CELU formulation. Default: 1.0</param>
             /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public CELU CELU(double alpha = 1.0, bool inplace = false)
+            public static CELU CELU(double alpha = 1.0, bool inplace = false)
             {
                 var handle = THSNN_CELU_ctor(alpha, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -63,7 +56,7 @@ namespace TorchSharp
                 /// <param name="alpha">The α value for the CELU formulation. Default: 1.0</param>
                 /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor celu(Tensor x, double alpha, bool inplace = false)
+                public static Tensor celu(Tensor x, double alpha, bool inplace = false)
                 {
                     using (var m = nn.CELU(alpha, inplace)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/ELU.cs
+++ b/src/TorchSharp/NN/Activation/ELU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ELU : torch.nn.Module<Tensor, Tensor>
         {
             internal ELU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ELU_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,16 +34,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ELU_ctor(double alpha, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Exponential Linear Unit
             /// </summary>
             /// <param name="alpha">The α value for the ELU formulation. Default: 1.0</param>
             /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public ELU ELU(double alpha = 1.0, bool inplace = false)
+            public static ELU ELU(double alpha = 1.0, bool inplace = false)
             {
                 var handle = THSNN_ELU_ctor(alpha, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -62,7 +56,7 @@ namespace TorchSharp
                 /// <param name="alpha">The α value for the ELU formulation. Default: 1.0</param>
                 /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor elu(Tensor x, double alpha, bool inplace = false)
+                public static Tensor elu(Tensor x, double alpha, bool inplace = false)
                 {
                     using (var m = nn.ELU(alpha, inplace)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/GELU.cs
+++ b/src/TorchSharp/NN/Activation/GELU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class GELU : torch.nn.Module<Tensor, Tensor>
         {
             internal GELU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GELU_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,14 +34,11 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GELU_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// Gaussian Error Linear Units
             /// </summary>
             /// <returns></returns>
-            static public GELU GELU()
+            public static GELU GELU()
             {
                 var handle = THSNN_GELU_ctor(out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -58,7 +52,7 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor gelu(Tensor x)
+                public static Tensor gelu(Tensor x)
                 {
                     using (var m = nn.GELU()) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/GLU.cs
+++ b/src/TorchSharp/NN/Activation/GLU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class GLU : torch.nn.Module<Tensor, Tensor>
         {
             internal GLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GLU_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GLU_ctor(long dim, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Gated Linear Unit
             /// </summary>
             /// <param name="dim">the dimension on which to split the input. Default: -1</param>
             /// <returns></returns>
-            static public GLU GLU(long dim = -1)
+            public static GLU GLU(long dim = -1)
             {
                 var handle = THSNN_GLU_ctor(dim, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -60,7 +54,7 @@ namespace TorchSharp
                 /// <param name="input">The input tensor</param>
                 /// <param name="dim">the dimension on which to split the input. Default: -1</param>
                 /// <returns></returns>
-                static public Tensor glu(Tensor input, long dim = -1)
+                public static Tensor glu(Tensor input, long dim = -1)
                 {
                     using (var m = nn.GLU(dim)) {
                         return m.forward(input);

--- a/src/TorchSharp/NN/Activation/Hardshrink.cs
+++ b/src/TorchSharp/NN/Activation/Hardshrink.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Hardshrink : torch.nn.Module<Tensor, Tensor>
         {
             internal Hardshrink(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Hardshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Hardshrink_ctor(double lambd, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Hardshrink
             /// </summary>
             /// <param name="lambda"> the λ value for the Hardshrink formulation. Default: 0.5</param>
             /// <returns></returns>
-            static public Hardshrink Hardshrink(double lambda = 0.5)
+            public static Hardshrink Hardshrink(double lambda = 0.5)
             {
                 var handle = THSNN_Hardshrink_ctor(lambda, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -60,7 +54,7 @@ namespace TorchSharp
                 /// <param name="x">The input tensor</param>
                 /// <param name="lambda">The λ value for the Hardshrink formulation. Default: 0.5</param>
                 /// <returns></returns>
-                static public Tensor Hardshrink(Tensor x, double lambda = 0.5)
+                public static Tensor Hardshrink(Tensor x, double lambda = 0.5)
                 {
                     using (var m = nn.Hardshrink(lambda)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Hardsigmoid.cs
+++ b/src/TorchSharp/NN/Activation/Hardsigmoid.cs
@@ -41,7 +41,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="inplace">Do the operation in-place</param>
             /// <returns></returns>
-            static public Hardsigmoid Hardsigmoid(bool inplace = false)
+            public static Hardsigmoid Hardsigmoid(bool inplace = false)
             {
                 return new Hardsigmoid(inplace);
             }

--- a/src/TorchSharp/NN/Activation/Hardtanh.cs
+++ b/src/TorchSharp/NN/Activation/Hardtanh.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Hardtanh : torch.nn.Module<Tensor, Tensor>
         {
             internal Hardtanh(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Hardtanh_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,9 +34,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Hardtanh_ctor(double min_val, double max_val, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Hardtanh
             /// </summary>
@@ -47,7 +41,7 @@ namespace TorchSharp
             /// <param name="max_val">Maximum value of the linear region range.</param>
             /// <param name="inplace">Do the operation in-place</param>
             /// <returns></returns>
-            static public Hardtanh Hardtanh(double min_val = -1.0, double max_val = 1.0, bool inplace = false)
+            public static Hardtanh Hardtanh(double min_val = -1.0, double max_val = 1.0, bool inplace = false)
             {
                 var handle = THSNN_Hardtanh_ctor(min_val, max_val, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -64,7 +58,7 @@ namespace TorchSharp
                 /// <param name="max_val">Maximum value of the linear region range.</param>
                 /// <param name="inplace">Do the operation in-place</param>
                 /// <returns></returns>
-                static public Tensor Hardtanh(Tensor x, double min_val = -1.0, double max_val = 1.0, bool inplace = false)
+                public static Tensor Hardtanh(Tensor x, double min_val = -1.0, double max_val = 1.0, bool inplace = false)
                 {
                     using (var m = nn.Hardtanh(min_val, max_val, inplace)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/LeakyReLU.cs
+++ b/src/TorchSharp/NN/Activation/LeakyReLU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class LeakyReLU : torch.nn.Module<Tensor, Tensor>
         {
             internal LeakyReLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LeakyReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,16 +34,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LeakyReLU_ctor(double negative_slope, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Continuously Differentiable Exponential Linear Unit
             /// </summary>
             /// <param name="negative_slope">The α value for the LeakyReLU formulation.</param>
             /// <param name="inplace">Do the operation in-place.</param>
             /// <returns></returns>
-            static public LeakyReLU LeakyReLU(double negative_slope = 0.01, bool inplace = false)
+            public static LeakyReLU LeakyReLU(double negative_slope = 0.01, bool inplace = false)
             {
                 var handle = THSNN_LeakyReLU_ctor(negative_slope, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -62,7 +56,7 @@ namespace TorchSharp
                 /// <param name="negative_slope">The α value for the LeakyReLU formulation. Default: 1.0</param>
                 /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor leaky_relu(Tensor input, double negative_slope = 0.01, bool inplace = false)
+                public static Tensor leaky_relu(Tensor input, double negative_slope = 0.01, bool inplace = false)
                 {
                     using (var m = nn.LeakyReLU(negative_slope, inplace)) {
                         return m.forward(input);

--- a/src/TorchSharp/NN/Activation/LogSoftMax.cs
+++ b/src/TorchSharp/NN/Activation/LogSoftMax.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LogSoftmax_forward(torch.nn.Module.HType handle, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_LogSoftmax_forward(handle, tensor.Handle);
@@ -34,10 +31,7 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LogSoftmax_ctor(long dim, out IntPtr pBoxedModule);
-
-            static public LogSoftmax LogSoftmax(long dim)
+            public static LogSoftmax LogSoftmax(long dim)
             {
                 var handle = THSNN_LogSoftmax_ctor(dim, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -46,7 +40,7 @@ namespace TorchSharp
 
             public static partial class functional
             {
-                static public Tensor log_softmax(Tensor x, long dim)
+                public static Tensor log_softmax(Tensor x, long dim)
                 {
                     return torch.special.log_softmax(x, dim);
                 }

--- a/src/TorchSharp/NN/Activation/Mish.cs
+++ b/src/TorchSharp/NN/Activation/Mish.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Mish : torch.nn.Module<Tensor, Tensor>
         {
             internal Mish(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Mish_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,14 +34,11 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Mish_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// A Self Regularized Non-Monotonic Neural Activation Function.
             /// </summary>
             /// <returns></returns>
-            static public Mish Mish()
+            public static Mish Mish()
             {
                 var handle = THSNN_Mish_ctor(out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -58,7 +52,7 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor Mish(Tensor x)
+                public static Tensor Mish(Tensor x)
                 {
                     using (var m = nn.Mish()) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/RReLU.cs
+++ b/src/TorchSharp/NN/Activation/RReLU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class RReLU : torch.nn.Module<Tensor, Tensor>
         {
             internal RReLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_RReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,9 +34,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RReLU_ctor(double lower, double upper, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Randomized Rectified Linear Unit
             /// </summary>
@@ -47,7 +41,7 @@ namespace TorchSharp
             /// <param name="upper">Upper bound of the uniform distribution. Default: 1/3</param>
             /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public RReLU RReLU(double lower = one_eighth, double upper = one_third, bool inplace = false)
+            public static RReLU RReLU(double lower = one_eighth, double upper = one_third, bool inplace = false)
             {
                 var handle = THSNN_RReLU_ctor(lower, upper, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -67,7 +61,7 @@ namespace TorchSharp
                 /// <param name="upper">Upper bound of the uniform distribution. Default: 1/3</param>
                 /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor rrelu(Tensor x, double lower, double upper, bool inplace = false)
+                public static Tensor rrelu(Tensor x, double lower, double upper, bool inplace = false)
                 {
                     using (var m = nn.RReLU(lower, upper, inplace)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/ReLU6.cs
+++ b/src/TorchSharp/NN/Activation/ReLU6.cs
@@ -17,7 +17,7 @@ namespace TorchSharp
             internal ReLU6(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
             [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReLU6_forward(torch.nn.Module.HType module, IntPtr tensor);
+            internal static extern IntPtr THSNN_ReLU6_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -38,7 +38,7 @@ namespace TorchSharp
         public static partial class nn
         {
             [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ReLU6_ctor([MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+            internal static extern IntPtr THSNN_ReLU6_ctor([MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
 
             /// <summary>
             /// Rectified Linear Unit
@@ -47,7 +47,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public ReLU6 ReLU6(bool inplace = false)
+            public static ReLU6 ReLU6(bool inplace = false)
             {
                 var handle = THSNN_ReLU6_ctor(inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -64,7 +64,7 @@ namespace TorchSharp
                 /// <param name="x">The input tensor</param>
                 /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor relu6(Tensor x, bool inplace = false)
+                public static Tensor relu6(Tensor x, bool inplace = false)
                 {
                     using (var m = nn.ReLU6(inplace)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/ReLu.cs
+++ b/src/TorchSharp/NN/Activation/ReLu.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ReLU : torch.nn.Module<Tensor, Tensor>
         {
             internal ReLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -36,15 +33,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ReLU_ctor([MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Rectified Linear Unit
             /// </summary>
             /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public ReLU ReLU(bool inplace = false)
+            public static ReLU ReLU(bool inplace = false)
             {
                 var handle = THSNN_ReLU_ctor(inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -59,7 +53,7 @@ namespace TorchSharp
                 /// <param name="x">The input tensor</param>
                 /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor relu(Tensor x, bool inplace = false)
+                public static Tensor relu(Tensor x, bool inplace = false)
                 {
                     using (var m = nn.ReLU(inplace)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/SELU.cs
+++ b/src/TorchSharp/NN/Activation/SELU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class SELU : torch.nn.Module<Tensor, Tensor>
         {
             internal SELU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_SELU_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_SELU_ctor([MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Scaled Exponential Linear Unit
             /// </summary>
             /// <param name="inplace">Do the operation in-place. Default: False</param>
             /// <returns></returns>
-            static public SELU SELU(bool inplace = false)
+            public static SELU SELU(bool inplace = false)
             {
                 var handle = THSNN_SELU_ctor(inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -60,7 +54,7 @@ namespace TorchSharp
                 /// <param name="x">The input tensor</param>
                 /// <param name="inplace">Do the operation in-place. Default: False</param>
                 /// <returns></returns>
-                static public Tensor selu(Tensor x, bool inplace = false)
+                public static Tensor selu(Tensor x, bool inplace = false)
                 {
                     using (var m = nn.SELU(inplace)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/SiLU.cs
+++ b/src/TorchSharp/NN/Activation/SiLU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class SiLU : torch.nn.Module<Tensor, Tensor>
         {
             internal SiLU(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_SiLU_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -36,15 +33,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_SiLU_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// Sigmoid-Weighted Linear Unit
             /// </summary>
             /// <returns></returns>
             /// <remarks>The native libreary does not take an 'inplace' option, even though the PyTorch documentation mentions the parameter.</remarks>
-            static public SiLU SiLU()
+            public static SiLU SiLU()
             {
                 var handle = THSNN_SiLU_ctor(out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -58,7 +52,7 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor SiLU(Tensor x)
+                public static Tensor SiLU(Tensor x)
                 {
                     using (var m = nn.SiLU()) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Sigmoid.cs
+++ b/src/TorchSharp/NN/Activation/Sigmoid.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Sigmoid : torch.nn.Module<Tensor, Tensor>
         {
             internal Sigmoid(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Sigmoid_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -36,14 +33,11 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Sigmoid_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// Sigmoid activation
             /// </summary>
             /// <returns></returns>
-            static public Sigmoid Sigmoid()
+            public static Sigmoid Sigmoid()
             {
                 var handle = THSNN_Sigmoid_ctor(out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -57,7 +51,7 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor Sigmoid(Tensor x)
+                public static Tensor Sigmoid(Tensor x)
                 {
                     using (var m = nn.Sigmoid()) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Softmax.cs
+++ b/src/TorchSharp/NN/Activation/Softmax.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Softmax : torch.nn.Module<Tensor, Tensor>
         {
             internal Softmax(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softmax_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Softmax_ctor(long dim, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Softmax
             /// </summary>
             /// <param name="dim">A dimension along which Softmax will be computed (so every slice along dim will sum to 1)</param>
             /// <returns></returns>
-            static public Softmax Softmax(long dim)
+            public static Softmax Softmax(long dim)
             {
                 var handle = THSNN_Softmax_ctor(dim, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -60,7 +54,7 @@ namespace TorchSharp
                 /// <param name="x">The input tensor</param>
                 /// <param name="dim">A dimension along which Softmax will be computed (so every slice along dim will sum to 1)</param>
                 /// <returns></returns>
-                static public Tensor softmax(Tensor x, long dim)
+                public static Tensor softmax(Tensor x, long dim)
                 {
                     using (var m = nn.Softmax(dim)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Softmax2d.cs
+++ b/src/TorchSharp/NN/Activation/Softmax2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Softmax2d : torch.nn.Module<Tensor, Tensor>
         {
             internal Softmax2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softmax2d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -36,14 +33,11 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Softmax2d_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Softmax over features to each spatial location
             /// </summary>
             /// <returns></returns>
-            static public Softmax2d Softmax2d()
+            public static Softmax2d Softmax2d()
             {
                 var handle = THSNN_Softmax2d_ctor(out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -57,7 +51,7 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor softmax2d(Tensor x)
+                public static Tensor softmax2d(Tensor x)
                 {
                     using (var m = nn.Softmax2d()) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Softmin.cs
+++ b/src/TorchSharp/NN/Activation/Softmin.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Softmin : torch.nn.Module<Tensor, Tensor>
         {
             internal Softmin(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softmin_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Softmin_ctor(long dim, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Softmin
             /// </summary>
             /// <param name="dim">A dimension along which Softmin will be computed (so every slice along dim will sum to 1)</param>
             /// <returns></returns>
-            static public Softmin Softmin(long dim)
+            public static Softmin Softmin(long dim)
             {
                 var handle = THSNN_Softmin_ctor(dim, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -60,7 +54,7 @@ namespace TorchSharp
                 /// <param name="x">The input tensor</param>
                 /// <param name="dim">A dimension along which Softmin will be computed (so every slice along dim will sum to 1)</param>
                 /// <returns></returns>
-                static public Tensor softmin(Tensor x, long dim)
+                public static Tensor softmin(Tensor x, long dim)
                 {
                     using (var m = nn.Softmin(dim)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Softplus.cs
+++ b/src/TorchSharp/NN/Activation/Softplus.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Softplus : torch.nn.Module<Tensor, Tensor>
         {
             internal Softplus(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softplus_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,16 +34,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Softplus_ctor(double beta, double threshold, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Softplus
             /// </summary>
             /// <param name="beta">The β value for the Softplus formulation.</param>
             /// <param name="threshold">Values above this revert to a linear function</param>
             /// <returns></returns>
-            static public Softplus Softplus(double beta = 1.0, double threshold = 20.0)
+            public static Softplus Softplus(double beta = 1.0, double threshold = 20.0)
             {
                 var handle = THSNN_Softplus_ctor(beta, threshold, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -62,7 +56,7 @@ namespace TorchSharp
                 /// <param name="beta">The β value for the Softplus formulation.</param>
                 /// <param name="threshold">Values above this revert to a linear function</param>
                 /// <returns></returns>
-                static public Tensor softplus(Tensor x, double beta = 1.0, double threshold = 20.0)
+                public static Tensor softplus(Tensor x, double beta = 1.0, double threshold = 20.0)
                 {
                     using (var m = nn.Softplus(beta, threshold)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Softshrink.cs
+++ b/src/TorchSharp/NN/Activation/Softshrink.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Softshrink : torch.nn.Module<Tensor, Tensor>
         {
             internal Softshrink(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Softshrink_ctor(double lambd, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Softshrink
             /// </summary>
             /// <param name="lambda"> the λ value for the Softshrink formulation. Default: 0.5</param>
             /// <returns></returns>
-            static public Softshrink Softshrink(double lambda = 0.5)
+            public static Softshrink Softshrink(double lambda = 0.5)
             {
                 var handle = THSNN_Softshrink_ctor(lambda, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -60,7 +54,7 @@ namespace TorchSharp
                 /// <param name="x">The input tensor</param>
                 /// <param name="lambda">The λ value for the Softshrink formulation. Default: 0.5</param>
                 /// <returns></returns>
-                static public Tensor Softshrink(Tensor x, double lambda = 0.5)
+                public static Tensor Softshrink(Tensor x, double lambda = 0.5)
                 {
                     using (var m = nn.Softshrink(lambda)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Softsign.cs
+++ b/src/TorchSharp/NN/Activation/Softsign.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Softsign : torch.nn.Module<Tensor, Tensor>
         {
             internal Softsign(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Softsign_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,14 +34,11 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Softsign_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// Softsign
             /// </summary>
             /// <returns></returns>
-            static public Softsign Softsign()
+            public static Softsign Softsign()
             {
                 var handle = THSNN_Softsign_ctor(out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -58,7 +52,7 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor Softsign(Tensor x)
+                public static Tensor Softsign(Tensor x)
                 {
                     using (var m = nn.Softsign()) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Tanh.cs
+++ b/src/TorchSharp/NN/Activation/Tanh.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Tanh : torch.nn.Module<Tensor, Tensor>
         {
             internal Tanh(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Tanh_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,14 +34,11 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Tanh_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// Tanh activation
             /// </summary>
             /// <returns></returns>
-            static public Tanh Tanh()
+            public static Tanh Tanh()
             {
                 var handle = THSNN_Tanh_ctor(out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -58,7 +52,7 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor tanh(Tensor x)
+                public static Tensor tanh(Tensor x)
                 {
                     using (var m = nn.Tanh()) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Tanhshrink.cs
+++ b/src/TorchSharp/NN/Activation/Tanhshrink.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Tanhshrink : torch.nn.Module<Tensor, Tensor>
         {
             internal Tanhshrink(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Tanhshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,14 +34,11 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Tanhshrink_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// Tanhshrink
             /// </summary>
             /// <returns></returns>
-            static public Tanhshrink Tanhshrink()
+            public static Tanhshrink Tanhshrink()
             {
                 var handle = THSNN_Tanhshrink_ctor(out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -58,7 +52,7 @@ namespace TorchSharp
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <returns></returns>
-                static public Tensor Tanhshrink(Tensor x)
+                public static Tensor Tanhshrink(Tensor x)
                 {
                     using (var m = nn.Tanhshrink()) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/Activation/Threshold.cs
+++ b/src/TorchSharp/NN/Activation/Threshold.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Threshold : torch.nn.Module<Tensor, Tensor>
         {
             internal Threshold(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Threshold_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -37,9 +34,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Threshold_ctor(double threshold, double value, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Threshold
             /// </summary>
@@ -47,7 +41,7 @@ namespace TorchSharp
             /// <param name="value">The value to replace with</param>
             /// <param name="inplace">Do the operation in-place</param>
             /// <returns></returns>
-            static public Threshold Threshold(double threshold, double value, bool inplace = false)
+            public static Threshold Threshold(double threshold, double value, bool inplace = false)
             {
                 var handle = THSNN_Threshold_ctor(threshold, value, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -64,7 +58,7 @@ namespace TorchSharp
                 /// <param name="value">The value to replace with</param>
                 /// <param name="inplace">Do the operation in-place</param>
                 /// <returns></returns>
-                static public Tensor Threshold(Tensor x, double threshold, double value, bool inplace = false)
+                public static Tensor Threshold(Tensor x, double threshold, double value, bool inplace = false)
                 {
                     using (var m = nn.Threshold(threshold, value, inplace)) {
                         return m.forward(x);

--- a/src/TorchSharp/NN/AlphaDropout.cs
+++ b/src/TorchSharp/NN/AlphaDropout.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -21,9 +21,6 @@ namespace TorchSharp
         {
             internal AlphaDropout(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AlphaDropout_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             /// <summary>
             /// Forward pass.
             /// </summary>
@@ -42,9 +39,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AlphaDropout_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor \text{input}[i, j]input[i,j] ).
             /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
@@ -52,23 +46,21 @@ namespace TorchSharp
             /// <param name="p">Probability of an element to be zeroed. Default: 0.5</param>
             /// <param name="inplace">If set to true, will do this operation in-place. Default: false</param>
             /// <returns></returns>
-            static public AlphaDropout AlphaDropout(double p = 0.5, bool inplace = false)
+            public static AlphaDropout AlphaDropout(double p = 0.5, bool inplace = false)
             {
                 var handle = THSNN_AlphaDropout_ctor(p, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new AlphaDropout(handle, boxedHandle);
             }
+
             public static partial class functional
             {
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_alpha_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
-
                 /// <summary>
                 /// Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor \text{input}[i, j]input[i,j] ).
                 /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
                 /// </summary>
                 /// <returns></returns>
-                static public Tensor alpha_dropout(Tensor input, double p = 0.5, bool training = false, bool inplace = false)
+                public static Tensor alpha_dropout(Tensor input, double p = 0.5, bool training = false, bool inplace = false)
                 {
                     var res = THSNN_alpha_dropout(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Bilinear.cs
+++ b/src/TorchSharp/NN/Bilinear.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -11,56 +11,45 @@ namespace TorchSharp
 
     namespace Modules
     {
-        public sealed class Bilinear : torch.nn.Module<Tensor, Tensor, Tensor>
+        public sealed class Bilinear : Module<Tensor, Tensor, Tensor>
         {
             internal Bilinear(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            public new static Bilinear Load(String modelPath)
+            public new static Bilinear Load(string modelPath)
             {
                 var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new Bilinear(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Bilinear_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
-
             public override Tensor forward(Tensor input1, Tensor input2)
             {
                 var res = THSNN_Bilinear_forward(handle, input1.Handle, input2.Handle);
-                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                if (res == IntPtr.Zero) { CheckForErrors(); }
                 return new Tensor(res);
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Bilinear_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Bilinear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
                     var res = THSNN_Bilinear_bias(handle);
-                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    if (res == IntPtr.Zero) { CheckForErrors(); }
                     return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
-                    THSNN_Bilinear_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
-                    torch.CheckForErrors();
+                    THSNN_Bilinear_set_bias(handle, value?.Handle ?? IntPtr.Zero);
+                    CheckForErrors();
                     ConditionallyRegisterParameter("bias", value);
                 }
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Bilinear_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Bilinear_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {
                     var res = THSNN_Bilinear_weight(handle);
-                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    if (res == IntPtr.Zero) { CheckForErrors(); }
                     return (res == IntPtr.Zero) ? null : new Parameter(res);
                 }
                 set {
-                    THSNN_Bilinear_set_weight(handle, (value is null ? IntPtr.Zero : value.Handle));
-                    torch.CheckForErrors();
+                    THSNN_Bilinear_set_weight(handle, value?.Handle ?? IntPtr.Zero);
+                    CheckForErrors();
                     ConditionallyRegisterParameter("weight", value);
                 }
             }
@@ -71,11 +60,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Bilinear_ctor(long in1_features, long in2_features, long output_size, bool bias, out IntPtr pBoxedModule);
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_functional_bilinear(IntPtr input1, IntPtr input2, IntPtr weights, IntPtr bias);
 
             /// <summary>
             /// Applies a bilinear transformation to the incoming data
@@ -87,10 +71,10 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public Bilinear Bilinear(long in1Features, long in2Features, long outputSize, bool hasBias = true, Device? device = null, ScalarType? dtype = null)
+            public static Bilinear Bilinear(long in1Features, long in2Features, long outputSize, bool hasBias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Bilinear_ctor(in1Features, in2Features, outputSize, hasBias, out var boxedHandle);
-                if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                if (res == IntPtr.Zero) { CheckForErrors(); }
 
                 return new Bilinear(res, boxedHandle).MoveModule<Bilinear>(device, dtype);
             }
@@ -106,11 +90,11 @@ namespace TorchSharp
                 /// <param name="bias">Optional bias of shape (Hout)</param>
                 /// <returns>Tensor of shape (N,*,Hout)</returns>
                 /// <remarks>The '*' sub-shape must be the same among the two inputs.</remarks>
-                static public Tensor bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias = null)
+                public static Tensor bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias = null)
                 {
-                    IntPtr bPtr = bias is null ? IntPtr.Zero : bias.Handle;
+                    IntPtr bPtr = bias?.Handle ?? IntPtr.Zero;
                     var res = THSNN_functional_bilinear(input1.Handle, input2.Handle, weight.Handle, bPtr);
-                    if (res == IntPtr.Zero) { torch.CheckForErrors(); }
+                    if (res == IntPtr.Zero) { CheckForErrors(); }
                     return new Tensor(res);
                 }
             }

--- a/src/TorchSharp/NN/Convolution/Conv1D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv1D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -29,20 +29,12 @@ namespace TorchSharp
         {
             internal Conv1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv1d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_Conv1d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv1d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv1d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -56,11 +48,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("bias", value);
                 }
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv1d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv1d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
-
             public Parameter? weight {
                 get {
                     var res = THSNN_Conv1d_weight(handle);
@@ -80,9 +67,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv1d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D convolution over an input signal composed of several input planes.
             /// </summary>
@@ -98,7 +82,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-            static public Conv1d Conv1d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv1d Conv1d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Conv1d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -120,7 +104,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-            static public Conv1d Conv1d(long inputChannel, long outputChannel, long kernelSize, Padding padding, long stride = 1, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv1d Conv1d(long inputChannel, long outputChannel, long kernelSize, Padding padding, long stride = 1, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Conv1d_ctor(inputChannel, outputChannel, kernelSize, stride, padding == Padding.Valid ? 0 : -1, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Convolution/Conv2D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv2D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -14,20 +14,12 @@ namespace TorchSharp
         {
             internal Conv2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv2d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_Conv2d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv2d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv2d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -41,11 +33,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("bias", value);
                 }
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv2d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv2d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
-
             public Parameter? weight {
                 get {
                     var res = THSNN_Conv2d_weight(handle);
@@ -65,12 +52,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv2d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv2d_ctor_1(long inputChannel, long outputChannel, long kernelSizeX, long kernelSizeY, long strideX, long strideY, long paddingX, long paddingY, long dilationX, long dilationY, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D convolution over an input signal composed of several input planes
             /// </summary>
@@ -86,7 +67,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public Conv2d Conv2d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv2d Conv2d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Conv2d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -108,7 +89,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public Conv2d Conv2d(long inputChannel, long outputChannel, (long, long) kernelSize, (long, long)? stride = null, (long, long)? padding = null, (long, long)? dilation = null, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv2d Conv2d(long inputChannel, long outputChannel, (long, long) kernelSize, (long, long)? stride = null, (long, long)? padding = null, (long, long)? dilation = null, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 if (stride == null) stride = (1, 1);
                 if (padding == null) padding = (0, 0);
@@ -134,7 +115,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public Conv2d Conv2d(long inputChannel, long outputChannel, long kernelSize, Padding padding, long stride = 1, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv2d Conv2d(long inputChannel, long outputChannel, long kernelSize, Padding padding, long stride = 1, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Conv2d_ctor(inputChannel, outputChannel, kernelSize, stride, padding == Padding.Valid ? 0 : -1, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -156,7 +137,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public Conv2d Conv2d(long inputChannel, long outputChannel, (long, long) kernelSize, Padding padding, (long, long)? stride = null, (long, long)? dilation = null, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv2d Conv2d(long inputChannel, long outputChannel, (long, long) kernelSize, Padding padding, (long, long)? stride = null, (long, long)? dilation = null, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 if (stride == null) stride = (1, 1);
                 if (dilation == null) dilation = (1, 1);

--- a/src/TorchSharp/NN/Convolution/Conv3D.cs
+++ b/src/TorchSharp/NN/Convolution/Conv3D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -14,20 +14,12 @@ namespace TorchSharp
         {
             internal Conv3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv3d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_Conv3d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv3d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv3d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -41,11 +33,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("bias", value);
                 }
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Conv3d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Conv3d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
-
             public Parameter? weight {
                 get {
                     var res = THSNN_Conv3d_weight(handle);
@@ -65,12 +52,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Conv3d_ctor_1(long inputChannel, long outputChannel, long kernelSizeX, long kernelSizeY, long kernelSizeZ, long strideX, long strideY, long strideZ, long paddingX, long paddingY, long paddingZ, long dilationX, long dilationY, long dilationZ, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 3D convolution over an input signal composed of several input planes
             /// </summary>
@@ -85,7 +66,7 @@ namespace TorchSharp
             /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
-            static public Conv3d Conv3d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv3d Conv3d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -106,7 +87,7 @@ namespace TorchSharp
             /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
-            static public Conv3d Conv3d(long inputChannel, long outputChannel, (long, long, long) kernelSize, (long, long, long)? stride = null, (long, long, long)? padding = null, (long, long, long)? dilation = null, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv3d Conv3d(long inputChannel, long outputChannel, (long, long, long) kernelSize, (long, long, long)? stride = null, (long, long, long)? padding = null, (long, long, long)? dilation = null, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 if (stride == null) stride = (1, 1, 1);
                 if (padding == null) padding = (0, 0, 0);
@@ -131,7 +112,7 @@ namespace TorchSharp
             /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
-            static public Conv3d Conv3d(long inputChannel, long outputChannel, long kernelSize, Padding padding, long stride = 1, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv3d Conv3d(long inputChannel, long outputChannel, long kernelSize, Padding padding, long stride = 1, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Conv3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding == Padding.Valid ? 0 : -1, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -152,7 +133,7 @@ namespace TorchSharp
             /// <param name="bias">If true, adds a learnable bias to the output. Default: true</param>
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
-            static public Conv3d Conv3d(long inputChannel, long outputChannel, (long, long, long) kernelSize, Padding padding, (long, long, long)? stride = null, (long, long, long)? dilation = null, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static Conv3d Conv3d(long inputChannel, long outputChannel, (long, long, long) kernelSize, Padding padding, (long, long, long)? stride = null, (long, long, long)? dilation = null, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 if (stride == null) stride = (1, 1, 1);
                 if (dilation == null) dilation = (1, 1, 1);

--- a/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose1D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -14,20 +14,12 @@ namespace TorchSharp
         {
             internal ConvTranspose1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose1d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_ConvTranspose1d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose1d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose1d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -41,11 +33,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("bias", value);
                 }
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose1d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose1d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
-
             public Parameter? weight {
                 get {
                     var res = THSNN_ConvTranspose1d_weight(handle);
@@ -65,9 +52,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose1d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D convolution over an input signal composed of several input planes.
             /// </summary>
@@ -84,7 +68,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-            static public ConvTranspose1d ConvTranspose1d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static ConvTranspose1d ConvTranspose1d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_ConvTranspose1d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose2D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -14,20 +14,12 @@ namespace TorchSharp
         {
             internal ConvTranspose2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose2d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_ConvTranspose2d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose2d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose2d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -41,11 +33,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("bias", value);
                 }
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose2d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose2d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
-
             public Parameter? weight
                 {
                 get {
@@ -66,9 +53,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose2d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D convolution over an input signal composed of several input planes.
             /// </summary>
@@ -85,7 +69,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-            static public ConvTranspose2d ConvTranspose2d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static ConvTranspose2d ConvTranspose2d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_ConvTranspose2d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
+++ b/src/TorchSharp/NN/Convolution/ConvTranspose3D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -14,20 +14,12 @@ namespace TorchSharp
         {
             internal ConvTranspose3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose3d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_ConvTranspose3d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose3d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose3d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias {
                 get {
@@ -41,11 +33,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("bias", value);
                 }
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConvTranspose3d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_ConvTranspose3d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
-
             public Parameter? weight {
                 get {
                     var res = THSNN_ConvTranspose3d_weight(handle);
@@ -65,9 +52,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConvTranspose3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D convolution over an input signal composed of several input planes.
             /// </summary>
@@ -84,7 +68,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns>Tensor of shape (N,C_out,L_out)</returns>
-            static public ConvTranspose3d ConvTranspose3d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static ConvTranspose3d ConvTranspose3d(long inputChannel, long outputChannel, long kernelSize, long stride = 1, long padding = 0, long outputPadding = 0, long dilation = 1, PaddingModes paddingMode = PaddingModes.Zeros, long groups = 1, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_ConvTranspose3d_ctor(inputChannel, outputChannel, kernelSize, stride, padding, outputPadding, dilation, (long)paddingMode, groups, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/CosineSimilarity.cs
+++ b/src/TorchSharp/NN/CosineSimilarity.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_CosineSimilarity_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
-
             public override Tensor forward(Tensor input1, Tensor input2)
             {
                 var res = THSNN_CosineSimilarity_forward(handle, input1.Handle, input2.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_CosineSimilarity_ctor(long dim, double eps, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Returns cosine similarity between x1 and x2, computed along dim. Inputs must have same shape.
             /// </summary>
             /// <param name="dim">Dimension where cosine similarity is computed. Default: 1</param>
             /// <param name="eps">Small value to avoid division by zero. Default: 1e-8</param>
             /// <returns></returns>
-            static public CosineSimilarity CosineSimilarity(long dim = 1, double eps = 1e-8)
+            public static CosineSimilarity CosineSimilarity(long dim = 1, double eps = 1e-8)
             {
                 var handle = THSNN_CosineSimilarity_ctor(dim, eps, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -60,7 +54,7 @@ namespace TorchSharp
                 /// <param name="dim">Dimension where cosine similarity is computed. Default: 1</param>
                 /// <param name="eps">Small value to avoid division by zero. Default: 1e-8</param>
                 /// <returns></returns>
-                static public Tensor cosine_similarity(Tensor x1, Tensor x2, long dim = 1, double eps = 1e-8)
+                public static Tensor cosine_similarity(Tensor x1, Tensor x2, long dim = 1, double eps = 1e-8)
                 {
                     using (var f = nn.CosineSimilarity(dim, eps)) {
                         return f.forward(x1, x2);

--- a/src/TorchSharp/NN/Dropout.cs
+++ b/src/TorchSharp/NN/Dropout.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class Dropout : torch.nn.Module<Tensor, Tensor>
         {
             internal Dropout(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Dropout_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,9 +34,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Dropout_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// During training, randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution.
             /// Each channel will be zeroed out independently on every forward call.
@@ -47,7 +41,7 @@ namespace TorchSharp
             /// <param name="p">Probability of an element to be zeroed. Default: 0.5</param>
             /// <param name="inplace">If set to true, will do this operation in-place. Default: false</param>
             /// <returns></returns>
-            static public Dropout Dropout(double p = 0.5, bool inplace = false)
+            public static Dropout Dropout(double p = 0.5, bool inplace = false)
             {
                 var handle = THSNN_Dropout_ctor(p, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -56,15 +50,12 @@ namespace TorchSharp
 
             public static partial class functional
             {
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
-
                 /// <summary>
                 /// During training, randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution.
                 /// Each channel will be zeroed out independently on every forward call.
                 /// </summary>
                 /// <returns></returns>
-                static public Tensor dropout(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
+                public static Tensor dropout(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
                 {
                     var res = THSNN_dropout(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -72,6 +63,5 @@ namespace TorchSharp
                 }
             }
         }
-
     }
 }

--- a/src/TorchSharp/NN/Dropout2d.cs
+++ b/src/TorchSharp/NN/Dropout2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -16,9 +16,6 @@ namespace TorchSharp
         {
             internal Dropout2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Dropout2d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_Dropout2d_forward(handle, tensor.Handle);
@@ -32,9 +29,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Dropout2d_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor).
             /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
@@ -42,7 +36,7 @@ namespace TorchSharp
             /// <param name="p">Probability of an element to be zeroed. Default: 0.5</param>
             /// <param name="inplace">If set to true, will do this operation in-place. Default: false</param>
             /// <returns></returns>
-            static public Dropout2d Dropout2d(double p = 0.5, bool inplace = false)
+            public static Dropout2d Dropout2d(double p = 0.5, bool inplace = false)
             {
                 var handle = THSNN_Dropout2d_ctor(p, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -51,15 +45,13 @@ namespace TorchSharp
 
             public static partial class functional
             {
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_dropout2d(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
 
                 /// <summary>
                 /// Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor).
                 /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
                 /// </summary>
                 /// <returns></returns>
-                static public Tensor dropout2d(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
+                public static Tensor dropout2d(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
                 {
                     var res = THSNN_dropout2d(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Dropout3d.cs
+++ b/src/TorchSharp/NN/Dropout3d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -12,12 +12,9 @@ namespace TorchSharp
         /// <summary>
         /// This class is used to represent a Dropout3d module.
         /// </summary>
-        public sealed class Dropout3d : torch.nn.Module<Tensor, Tensor>
+        public sealed class Dropout3d : nn.Module<Tensor, Tensor>
         {
             internal Dropout3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Dropout3d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -32,9 +29,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Dropout3d_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Randomly zero out entire channels (a channel is a 3D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 3D tensor \text{input}[i, j]input[i,j] ).
             /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
@@ -42,7 +36,7 @@ namespace TorchSharp
             /// <param name="p">Probability of an element to be zeroed. Default: 0.5</param>
             /// <param name="inplace">If set to true, will do this operation in-place. Default: false</param>
             /// <returns></returns>
-            static public Dropout3d Dropout3d(double p = 0.5, bool inplace = false)
+            public static Dropout3d Dropout3d(double p = 0.5, bool inplace = false)
             {
                 var handle = THSNN_Dropout3d_ctor(p, inplace, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -51,14 +45,11 @@ namespace TorchSharp
 
             public static partial class functional
             {
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_dropout3d(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
-
                 /// <summary>
                 /// Randomly zero out entire channels (a channel is a 3D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 3D tensor \text{input}[i, j]input[i,j] ).
                 /// Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.
                 /// </summary>
-                static public Tensor dropout3d(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
+                public static Tensor dropout3d(Tensor input, double p = 0.5, bool training = true, bool inplace = false)
                 {
                     var res = THSNN_dropout3d(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Embedding.cs
+++ b/src/TorchSharp/NN/Embedding.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -14,21 +14,12 @@ namespace TorchSharp
         {
             internal Embedding(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Embedding_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor input)
             {
                 var res = THSNN_Embedding_forward(handle, input.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Embedding_weight(torch.nn.Module.HType module);
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Embedding_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {
@@ -49,9 +40,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Embedding_ctor(long num_embeddings, long embedding_dims, long padding_idx, bool hasPI, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, bool sparse, out IntPtr pBoxedModule);
-
             /// <summary>
             /// A simple lookup table that stores embeddings of a fixed dictionary and size.
             /// This module is often used to store word embeddings and retrieve them using indices. The input to the module is a list of indices, and the output is the corresponding word embeddings.
@@ -67,7 +55,7 @@ namespace TorchSharp
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
             /// <remarks>Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (CUDA and CPU), optim.SparseAdam (CUDA and CPU) and optim.Adagrad (CPU)</remarks>
-            static public Embedding Embedding(long num_embeddings, long embedding_dims, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false, Device? device = null, ScalarType? dtype = null)
+            public static Embedding Embedding(long num_embeddings, long embedding_dims, long? padding_idx = null, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, bool sparse = false, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Embedding_ctor(num_embeddings, embedding_dims,
                     padding_idx.HasValue ? padding_idx.Value : -1, padding_idx.HasValue,
@@ -76,11 +64,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Embedding(res, boxedHandle).MoveModule<Embedding>(device,dtype);
             }
-
-
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Embedding_from_pretrained(IntPtr embeddings, bool freeze, long padding_idx, bool hasPI, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, bool sparse, out IntPtr pBoxedModule);
 
             /// <summary>
             /// A simple lookup table that stores embeddings of a fixed dictionary and size.
@@ -105,7 +88,6 @@ namespace TorchSharp
                     norm_type, scale_grad_by_freq, sparse, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Embedding(res, boxedHandle).MoveModule<Embedding>(device, dtype);
-
             }
         }
     }

--- a/src/TorchSharp/NN/EmbeddingBag.cs
+++ b/src/TorchSharp/NN/EmbeddingBag.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -20,9 +20,6 @@ namespace TorchSharp
         public sealed class EmbeddingBag : torch.nn.Module<Tensor, Tensor>, torch.nn.IModule<Tensor, Tensor, Tensor>, torch.nn.IModule<Tensor, Tensor, Tensor, Tensor>
         {
             internal EmbeddingBag(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_EmbeddingBag_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr offsets, IntPtr per_sample_weights);
 
             /// <summary>
             /// Forward pass of EmbeddingBag.
@@ -84,12 +81,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_EmbeddingBag_weight(torch.nn.Module.HType module);
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_EmbeddingBag_set_weight(torch.nn.Module.HType module, IntPtr tensor);
-
             public Parameter? weight {
                 get {
                     var res = THSNN_EmbeddingBag_weight(handle);
@@ -107,12 +98,8 @@ namespace TorchSharp
 
     public static partial class torch
     {
-
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_EmbeddingBag_ctor(long num_embeddings, long embedding_dims, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, long mode, bool sparse, bool include_last_offset, long padding_idx, out IntPtr pBoxedModule);
-
             /// <summary>
             /// A simple lookup table that stores embeddings of a fixed dictionary and size.
             /// This module is often used to store word embeddings and retrieve them using indices. The input to the module is a list of indices, and the output is the corresponding word embeddings.
@@ -132,7 +119,7 @@ namespace TorchSharp
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
             /// <remarks>Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (CUDA and CPU), optim.SparseAdam (CUDA and CPU) and optim.Adagrad (CPU)</remarks>
-            static public EmbeddingBag EmbeddingBag(long num_embeddings, long embedding_dims, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, EmbeddingBagMode mode = EmbeddingBagMode.Mean, bool sparse = false, bool include_last_offset = false, long padding_index = -1, Device? device = null, ScalarType? dtype = null)
+            public static EmbeddingBag EmbeddingBag(long num_embeddings, long embedding_dims, double? max_norm = null, double norm_type = 2.0, bool scale_grad_by_freq = false, EmbeddingBagMode mode = EmbeddingBagMode.Mean, bool sparse = false, bool include_last_offset = false, long padding_index = -1, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_EmbeddingBag_ctor(num_embeddings, embedding_dims,
                     max_norm.HasValue ? max_norm.Value : 0.0, max_norm.HasValue,
@@ -140,9 +127,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new EmbeddingBag(res, boxedHandle).MoveModule<EmbeddingBag>(device, dtype);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_EmbeddingBag_from_pretrained(IntPtr embeddings, bool freeze, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, long mode, bool sparse, bool include_last_offset, long padding_idx, out IntPtr pBoxedModule);
 
             /// <summary>
             /// A simple lookup table that stores embeddings of a fixed dictionary and size.

--- a/src/TorchSharp/NN/FeatureDropout.cs
+++ b/src/TorchSharp/NN/FeatureDropout.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FeatureAlphaDropout_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_FeatureAlphaDropout_forward(handle, tensor.Handle);
@@ -34,9 +31,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_FeatureAlphaDropout_ctor(double p, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Randomly masks out entire channels (a channel is a feature map, e.g. the j-th channel of the i-th sample in the batch input is a tensor input[i,j]) of the input tensor.
             /// Instead of setting activations to zero, as in regular Dropout, the activations are set to the negative saturation value of the SELU activation function.
@@ -44,7 +38,7 @@ namespace TorchSharp
             /// randomized on every forward call, and scaled and shifted to maintain zero mean and unit variance.
             /// </summary>
             /// <param name="p">Dropout probability of a channel to be zeroed. Default: 0.5</param>
-            static public FeatureAlphaDropout FeatureAlphaDropout(double p = 0.5)
+            public static FeatureAlphaDropout FeatureAlphaDropout(double p = 0.5)
             {
                 var handle = THSNN_FeatureAlphaDropout_ctor(p, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -53,16 +47,13 @@ namespace TorchSharp
 
             public static partial class functional
             {
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_feature_alpha_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
-
                 /// <summary>
                 /// Randomly masks out entire channels (a channel is a feature map, e.g. the j-th channel of the i-th sample in the batch input is a tensor input[i,j]) of the input tensor.
                 /// Instead of setting activations to zero, as in regular Dropout, the activations are set to the negative saturation value of the SELU activation function.
                 /// Each element will be masked independently on every forward call with probability p using samples from a Bernoulli distribution.The elements to be masked are
                 /// randomized on every forward call, and scaled and shifted to maintain zero mean and unit variance.
                 /// </summary>
-                static public Tensor feature_alpha_dropout(Tensor input, double p = 0.5, bool training = false, bool inplace = false)
+                public static Tensor feature_alpha_dropout(Tensor input, double p = 0.5, bool training = false, bool inplace = false)
                 {
                     var res = THSNN_feature_alpha_dropout(input.Handle, p, training, inplace);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Flatten.cs
+++ b/src/TorchSharp/NN/Flatten.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Flatten_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_Flatten_forward(handle, tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Flatten_ctor(long startDim, long endDim, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Flattens a contiguous range of dims into a tensor. For use with Sequential.
             /// </summary>
             /// <param name="startDim">First dim to flatten (default = 1).</param>
             /// <param name="endDim">Last dim to flatten (default = -1).</param>
             /// <returns></returns>
-            static public Flatten Flatten(long startDim = 1, long endDim = -1)
+            public static Flatten Flatten(long startDim = 1, long endDim = -1)
             {
                 var handle = THSNN_Flatten_ctor(startDim, endDim, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Functional.cs
+++ b/src/TorchSharp/NN/Functional.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Linq;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -11,14 +11,6 @@ namespace TorchSharp
         {
             public static partial class functional
             {
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_conv1d(IntPtr input, IntPtr weight, IntPtr bias,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        long groups);
-
                 /// <summary>
                 /// Applies a 1D convolution over an input signal composed of several input planes.
                 /// </summary>
@@ -53,14 +45,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_conv2d(IntPtr input, IntPtr weight, IntPtr bias,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        long groups);
 
                 /// <summary>
                 /// Applies a 2D convolution over an input image composed of several input planes.
@@ -97,13 +81,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_conv3d(IntPtr input, IntPtr weight, IntPtr bias,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        long groups);
-
                 /// <summary>
                 /// Applies a 3D convolution over an input image composed of several input planes.
                 /// </summary>
@@ -138,14 +115,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_conv_transpose1d(IntPtr input, IntPtr weight, IntPtr bias,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr outputPadding, int outputPaddingLength,
-                        IntPtr dilation, int dilationLength,
-                        long groups);
 
                 /// <summary>
                 /// Applies a 1D transposed convolution operator over an input signal composed of several input planes, sometimes also called “deconvolution”.
@@ -186,14 +155,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_conv_transpose2d(IntPtr input, IntPtr weight, IntPtr bias,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr outputPadding, int outputPaddingLength,
-                        IntPtr dilation, int dilationLength,
-                        long groups);
-
                 /// <summary>
                 /// Applies a 2D transposed convolution operator over an input image composed of several input planes, sometimes also called “deconvolution”.
                 /// </summary>
@@ -232,14 +193,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_conv_transpose3d(IntPtr input, IntPtr weight, IntPtr bias,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr outputPadding, int outputPaddingLength,
-                        IntPtr dilation, int dilationLength,
-                        long groups);
 
                 /// <summary>
                 /// Applies a 3D transposed convolution operator over an input image composed of several input planes, sometimes also called “deconvolution”.
@@ -280,14 +233,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_max_pool1d(IntPtr input,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        bool ceil_mode);
-
                 /// <summary>
                 /// Applies a 1D max pooling over an input signal composed of several input planes.
                 /// </summary>
@@ -319,14 +264,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern void THSTensor_max_pool1d_with_indices(IntPtr input, AllocatePinnedArray allocator,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        bool ceil_mode);
 
                 /// <summary>
                 /// Applies a 1D max pooling over an input signal composed of several input planes.
@@ -364,14 +301,6 @@ namespace TorchSharp
                     }
                     return (new Tensor(ptrArray[0]), new Tensor(ptrArray[1]));
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_max_pool2d(IntPtr input,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        bool ceil_mode);
 
                 /// <summary>
                 /// Applies a 2D max pooling over an input signal composed of several input planes.
@@ -473,14 +402,6 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern void THSTensor_max_pool2d_with_indices(IntPtr input, AllocatePinnedArray allocator,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        bool ceil_mode);
-
                 /// <summary>
                 /// Applies a 2D max pooling over an input signal composed of several input planes.
                 /// </summary>
@@ -517,14 +438,6 @@ namespace TorchSharp
                     return (new Tensor(ptrArray[0]), new Tensor(ptrArray[1]));
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_max_pool3d(IntPtr input,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        bool ceil_mode);
-
                 /// <summary>
                 /// Applies a 3D max pooling over an input signal composed of several input planes.
                 /// </summary>
@@ -555,14 +468,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern void THSTensor_max_pool3d_with_indices(IntPtr input, AllocatePinnedArray allocator,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        IntPtr dilation, int dilationLength,
-                        bool ceil_mode);
 
                 /// <summary>
                 /// Applies a 3D max pooling over an input signal composed of several input planes.
@@ -600,9 +505,6 @@ namespace TorchSharp
                     return (new Tensor(ptrArray[0]), new Tensor(ptrArray[1]));
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_maxunpool2d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength);
-
                 /// <summary>
                 /// Computes a partial inverse of MaxPool2d.
                 /// </summary>
@@ -621,10 +523,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_maxunpool3d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength, IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength);
 
                 /// <summary>
                 /// Computes a partial inverse of MaxPool3d.
@@ -648,14 +546,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_avg_pool1d(IntPtr input,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        bool ceil_mode,
-                        bool count_include_pad);
 
                 /// <summary>
                 /// Applies a 1D average pooling over an input signal composed of several input planes.
@@ -687,14 +577,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_avg_pool2d(IntPtr input,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        bool ceil_mode,
-                        bool count_include_pad);
 
                 /// <summary>
                 /// Applies 2D average-pooling operation in kH × kW regions by step size sH * sW steps. The number of output features is equal to the number of input planes.
@@ -799,14 +681,6 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_avg_pool3d(IntPtr input,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        bool ceil_mode,
-                        bool count_include_pad);
-
                 /// <summary>
                 /// Applies 3D average-pooling operation in kT x kH x kW regions by step size sT x sH x sW steps.
                 /// </summary>
@@ -840,15 +714,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_avg_pool2d_backward(IntPtr gradOutput, IntPtr originalInput,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        bool ceil_mode,
-                        bool count_include_pad,
-                        long divisorOverride);
-
                 public static Tensor avg_pool2d_backward(Tensor input, Tensor originalInput,
                     long[] kernelSizes,
                     long[] strides = null,
@@ -874,15 +739,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_avg_pool3d_backward(IntPtr gradOutput, IntPtr originalInput,
-                        IntPtr kernelSize, int kernelSizeLength,
-                        IntPtr strides, int stridesLength,
-                        IntPtr padding, int paddingLength,
-                        bool ceil_mode,
-                        bool count_include_pad,
-                        long divisorOverride);
 
                 public static Tensor avg_pool3d_backward(Tensor input, Tensor originalInput,
                     long[] kernelSizes,
@@ -910,10 +766,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_adaptive_avg_pool1d(IntPtr input,
-                        IntPtr outputSize, int outputSizeLength);
-
                 /// <summary>
                 /// Applies a 1D adaptive average pooling over an input signal composed of several input planes.
                 /// </summary>
@@ -932,10 +784,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_adaptive_avg_pool2d(IntPtr input,
-                        IntPtr outputSize, int outputSizeLength);
 
                 /// <summary>
                 /// Applies a 2D adaptive average pooling over an input signal composed of several input planes.
@@ -984,9 +832,6 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_adaptive_avg_pool3d(IntPtr input, IntPtr outputSize, int outputSizeLength);
-
                 /// <summary>
                 /// Applies a 3D adaptive average pooling over an input signal composed of several input planes.
                 /// </summary>
@@ -1032,20 +877,12 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_adaptive_avg_pool3d_backward_out(IntPtr gradInput, IntPtr gradOutput, IntPtr originalInput);
-
                 public static Tensor adaptive_avg_pool3d_backward(Tensor gradInput, Tensor gradOutput, Tensor originalInput)
                 {
                     var res = THSTensor_adaptive_avg_pool3d_backward_out(gradInput.Handle, gradOutput.Handle, originalInput.Handle);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_upsample_nearest1d(IntPtr input,
-                        IntPtr outputSize, int outputSizeLength,
-                        IntPtr scaleFactors, int scaleFactorsLength);
 
                 /// <summary>
                 /// Upsamples the input, using nearest neighbours’ pixel values.
@@ -1074,12 +911,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_upsample_nearest1d_backward(IntPtr grad_output,
-                        IntPtr outputSize, int outputSizeLength,
-                        IntPtr inputSize, int inputSizeLength,
-                        IntPtr scaleFactors, int scaleFactorsLength);
-
                 public static Tensor upsample_nearest1d_backward(Tensor grad_output, long? outputSize, long inputSize, double? scaleFactor)
                 {
                     var outputSizes = outputSize.HasValue ? new long[] { outputSize.Value } : null;
@@ -1101,11 +932,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_upsample_nearest2d(IntPtr input,
-                        IntPtr outputSize, int outputSizeLength,
-                        IntPtr scaleFactors, int scaleFactorsLength);
 
                 /// <summary>
                 /// Upsamples the input, using nearest neighbours’ pixel values.
@@ -1132,12 +958,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_upsample_nearest2d_backward(IntPtr grad_output,
-                        IntPtr outputSize, int outputSizeLength,
-                        IntPtr inputSize, int inputSizeLength,
-                        IntPtr scaleFactors, int scaleFactorsLength);
-
                 public static Tensor upsample_nearest2d_backward(Tensor grad_output, long[] inputSizes, long[] outputSizes = null, double[] scaleFactors = null)
                 {
                     var outputSizesLength = outputSizes == null ? 0 : outputSizes.Length;
@@ -1157,12 +977,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_upsample_nearest3d_backward(IntPtr grad_output,
-                        IntPtr outputSize, int outputSizeLength,
-                        IntPtr inputSize, int inputSizeLength,
-                        IntPtr scaleFactors, int scaleFactorsLength);
-
                 public static Tensor upsample_nearest3d_backward(Tensor grad_output, long[] inputSizes, long[] outputSizes = null, double[] scaleFactors = null)
                 {
                     var outputSizesLength = outputSizes == null ? 0 : outputSizes.Length;
@@ -1181,11 +995,6 @@ namespace TorchSharp
                         }
                     }
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern IntPtr THSTensor_upsample_nearest3d(IntPtr input,
-                        IntPtr outputSize, int outputSizeLength,
-                        IntPtr scaleFactors, int scaleFactorsLength);
 
                 /// <summary>
                 /// Upsamples the input, using nearest neighbours’ pixel values.

--- a/src/TorchSharp/NN/Identity.cs
+++ b/src/TorchSharp/NN/Identity.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -13,9 +13,6 @@ namespace TorchSharp
         public sealed class Identity : torch.nn.Module<Tensor, Tensor>
         {
             internal Identity(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Identity_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -30,14 +27,11 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Identity_ctor(out IntPtr pBoxedModule);
-
             /// <summary>
             /// A placeholder identity operator.
             /// </summary>
             /// <returns>The same tensor as is input.</returns>
-            static public Identity Identity()
+            public static Identity Identity()
             {
                 var res = THSNN_Identity_ctor(out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Init.cs
+++ b/src/TorchSharp/NN/Init.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -219,26 +219,6 @@ namespace TorchSharp
                         return (numInputFMaps * receptiveFieldSize, numOutputFMaps * receptiveFieldSize);
                     }
                 }
-
-                [DllImport("LibTorchSharp")] private static extern double THSInit_calculate_gain(long nonlinearity, double param);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_constant_(IntPtr tensor, IntPtr value);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_dirac_(IntPtr tensor);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_eye_(IntPtr matrix);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_normal_(IntPtr tensor, double mean, double std);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_trunc_normal_(IntPtr tensor, double mean, double std, double a, double b);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_ones_(IntPtr tensor);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_orthogonal_(IntPtr tensor, double gain);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_sparse_(IntPtr tensor, double sparsity, double std);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_uniform_(IntPtr tensor, double low, double high);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_kaiming_normal_(IntPtr tensor, double a, long mode, long nonlinearity);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_kaiming_uniform_(IntPtr tensor, double a, long mode, long nonlinearity);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_xavier_normal_(IntPtr tensor, double gain);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_xavier_uniform_(IntPtr tensor, double gain);
-                [DllImport("LibTorchSharp")] private static extern IntPtr THSInit_zeros_(IntPtr tensor);
-
-                [DllImport("LibTorchSharp")] private static extern double THSSpecial_erf_scalar(double x);
-                [DllImport("LibTorchSharp")] private static extern double THSSpecial_erfc_scalar(double x);
-
             }
         }
     }

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -1,9 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -18,14 +17,11 @@ namespace TorchSharp
             {
             }
 
-            public new static Linear Load(String modelPath)
+            public new static Linear Load(string modelPath)
             {
                 var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new Linear(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Linear_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             public override Tensor forward(Tensor tensor)
             {
@@ -34,10 +30,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Linear_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Linear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
             public Parameter? bias {
                 get {
                     var res = THSNN_Linear_bias(handle);
@@ -45,16 +37,11 @@ namespace TorchSharp
                     return ((res == IntPtr.Zero) ? null : new Parameter(res));
                 }
                 set {
-                    THSNN_Linear_set_bias(handle, (value is null ? IntPtr.Zero : value.Handle));
+                    THSNN_Linear_set_bias(handle, value?.Handle ?? IntPtr.Zero);
                     torch.CheckForErrors();
                     ConditionallyRegisterParameter("bias", value);
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Linear_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_Linear_set_weight(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? weight {
                 get {
@@ -75,12 +62,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Linear_ctor(long input_size, long output_size, bool bias, out IntPtr pBoxedModule);
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_functional_linear(IntPtr input, IntPtr weights, IntPtr bias);
-
             /// <summary>
             /// Applies a linear transformation to the incoming data.
             /// </summary>
@@ -89,7 +70,7 @@ namespace TorchSharp
             /// <param name="hasBias">If set to false, the layer will not learn an additive bias.</param>
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
-            static public Linear Linear(long inputSize, long outputSize, bool hasBias = true, Device? device = null, ScalarType? dtype = null)
+            public static Linear Linear(long inputSize, long outputSize, bool hasBias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_Linear_ctor(inputSize, outputSize, hasBias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -106,9 +87,9 @@ namespace TorchSharp
                 /// <param name="weights">Weights of shape (Hout,Hin) or (Hin)</param>
                 /// <param name="bias">Bias of shape (Hout) or ()</param>
                 /// <returns>A tensor of shape (*,Hout) where '*' is the same as the subshape of the input.</returns>
-                static public Tensor linear(Tensor input, Tensor weights, Tensor? bias = null)
+                public static Tensor linear(Tensor input, Tensor weights, Tensor? bias = null)
                 {
-                    IntPtr bPtr = bias is null ? IntPtr.Zero : bias.Handle;
+                    IntPtr bPtr = bias?.Handle ?? IntPtr.Zero;
                     var res = THSNN_functional_linear(input.Handle, weights.Handle, bPtr);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);

--- a/src/TorchSharp/NN/Losses.cs
+++ b/src/TorchSharp/NN/Losses.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
-using static TorchSharp.torch.distributions.constraints;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.nn.functional;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 
@@ -425,7 +423,7 @@ namespace TorchSharp
                 }
 
                 /// <summary>
-                /// 
+                ///
                 /// </summary>
                 /// <param name="input1">(N,D) or (D), where N is the batch size and D is the embedding dimension.</param>
                 /// <param name="input2">Same shape as input1</param>
@@ -719,73 +717,7 @@ namespace TorchSharp
                     var res = THSNN_triplet_margin_with_distance_loss(anchor.Handle, positive.Handle, negative.Handle, func, margin, swap, (long)reduction);
                     if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                     return new Tensor(res);
-
                 }
-
-                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                public delegate IntPtr DistanceFunctionNative(IntPtr x, IntPtr y);
-
-                #region External functions
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long ignore_index, bool hasII, long reduction, double smoothing);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_binary_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_binary_cross_entropy_with_logits(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction, IntPtr posWeights);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_cosine_embedding_loss(IntPtr input1, IntPtr input2, IntPtr trgt, double margin, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_ctc_loss(IntPtr log_probs, IntPtr targets, IntPtr input_lengths, IntPtr target_lengths, long blank, bool zero_infinity, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_hinge_embedding_loss(IntPtr input, IntPtr trgt, double margin, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_huber_loss(IntPtr input, IntPtr trgt, double delta, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_margin_ranking_loss(IntPtr input1, IntPtr input2, IntPtr target, double margin, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_multilabel_margin_loss(IntPtr input, IntPtr target, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_multilabel_soft_margin_loss(IntPtr input, IntPtr target, IntPtr weight, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_multi_margin_loss(IntPtr input, IntPtr target, long p, double margin, IntPtr weight, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_mse_loss(IntPtr srct, IntPtr trgt, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_l1_loss(IntPtr srct, IntPtr trgt, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_nll_loss(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_poisson_loss(IntPtr srct, IntPtr trgt, bool logInput, bool full, float eps, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_kl_div_loss(IntPtr input, IntPtr target, long reduction, bool logTarget);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_smooth_l1_loss(IntPtr srct, IntPtr trgt, long reduction, double beta);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_soft_margin_loss(IntPtr srct, IntPtr trgt, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_triplet_margin_loss(IntPtr anchor, IntPtr positive, IntPtr negative, double margin, long p, double eps, bool swap, long reduction);
-
-                [DllImport("LibTorchSharp")]
-                internal static extern IntPtr THSNN_triplet_margin_with_distance_loss(IntPtr anchor, IntPtr positive, IntPtr negative, DistanceFunctionNative? distance_function, double margin, bool swap, long reduction);
-                #endregion
             }
 
             public enum Reduction : long
@@ -799,8 +731,6 @@ namespace TorchSharp
 
     namespace Modules
     {
-        using static torch.nn.functional;
-
         public sealed class CrossEntropyLoss : WeightedLoss<Tensor, Tensor, Tensor>
         {
             public CrossEntropyLoss(Tensor? weight = null, long? ignore_index = null, Reduction reduction = Reduction.Mean, double label_smoothing = 0.0) : base(weight, reduction)

--- a/src/TorchSharp/NN/MultiheadAttention.cs
+++ b/src/TorchSharp/NN/MultiheadAttention.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See License.txt in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 using static TorchSharp.torch;
 
 #nullable enable
@@ -14,8 +14,6 @@ namespace TorchSharp
         {
             internal MultiheadAttention(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_MultiheadAttention_forward(torch.nn.Module.HType module, IntPtr query, IntPtr key, IntPtr value, IntPtr key_padding_mask, bool need_weights, IntPtr attn_mask, out IntPtr res1, out IntPtr res2);
             /// <summary>
             /// Applies the MultiheadAttention function element-wise.
             /// </summary>
@@ -48,11 +46,8 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MultiheadAttention_ctor(long embeded_dim, long num_heads, double dropout, bool bias, bool add_bias_kv, bool add_zero_attn, long kdim, long vdim, out IntPtr pBoxedModule);
-
             /// <summary>
-            /// Allows the model to jointly attend to information from different representation subspaces (based on the paper “Attention Is All You Need”). 
+            /// Allows the model to jointly attend to information from different representation subspaces (based on the paper “Attention Is All You Need”).
             /// </summary>
             /// <param name="embedded_dim">total dimension of the model</param>
             /// <param name="num_heads">parallel attention heads</param>
@@ -63,7 +58,7 @@ namespace TorchSharp
             /// <param name="kdim">total number of features in key</param>
             /// <param name="vdim">total number of features in value</param>
             /// <returns></returns>
-            static public MultiheadAttention MultiheadAttention(long embedded_dim, long num_heads, double dropout = 0.0, bool bias = true, bool add_bias_kv = false, bool add_zero_attn = false, long? kdim=null, long? vdim=null)
+            public static MultiheadAttention MultiheadAttention(long embedded_dim, long num_heads, double dropout = 0.0, bool bias = true, bool add_bias_kv = false, bool add_zero_attn = false, long? kdim=null, long? vdim=null)
             {
                 var _kdim = kdim.HasValue ? kdim.Value : embedded_dim;
                 var _vdim = vdim.HasValue ? vdim.Value : embedded_dim;

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -19,9 +19,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (tensor.Dimensions < 2 || tensor.Dimensions > 3) throw new ArgumentException($"Invalid number of dimensions for BatchNorm argument: {tensor.Dimensions}");
@@ -29,27 +26,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_set_bias(torch.nn.Module.HType module, IntPtr bias);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_set_weight(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_reset_stats(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_get_mean(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_get_var(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm1d_get_batches(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_set_mean(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm1d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {
@@ -123,9 +99,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_BatchNorm1d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Batch Normalization over a 2D or 3D input (a mini-batch of 1D inputs with optional additional channel dimension) as described in the paper Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift .
             /// </summary>
@@ -139,7 +112,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public BatchNorm1d BatchNorm1d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true, Device? device = null, ScalarType? dtype = null)
+            public static BatchNorm1d BatchNorm1d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true, Device? device = null, ScalarType? dtype = null)
             {
                 unsafe {
                     var handle = THSNN_BatchNorm1d_ctor(features, eps, momentum, affine, track_running_stats, out var boxedHandle);

--- a/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm2D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -19,9 +19,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (tensor.Dimensions != 4) throw new ArgumentException($"Invalid number of dimensions for BatchNorm argument: {tensor.Dimensions}");
@@ -29,27 +26,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_set_bias(torch.nn.Module.HType module, IntPtr bias);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_set_weight(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_reset_stats(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_get_mean(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_get_var(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm2d_get_batches(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_set_mean(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm2d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {
@@ -123,9 +99,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_BatchNorm2d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Batch Normalization over a 4D input (a mini-batch of 2D inputs with additional channel dimension) as described in the paper Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift.
             /// </summary>
@@ -139,7 +112,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public BatchNorm2d BatchNorm2d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true, Device? device = null, ScalarType? dtype = null)
+            public static BatchNorm2d BatchNorm2d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true, Device? device = null, ScalarType? dtype = null)
             {
                 unsafe {
                     var handle = THSNN_BatchNorm2d_ctor(features, eps, momentum, affine, track_running_stats, out var boxedHandle);

--- a/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm3D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -19,9 +19,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (tensor.Dimensions != 5) throw new ArgumentException($"Invalid number of dimensions for BatchNorm argument: {tensor.Dimensions}");
@@ -29,27 +26,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_set_bias(torch.nn.Module.HType module, IntPtr bias);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_set_weight(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_reset_stats(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_get_mean(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_get_var(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_BatchNorm3d_get_batches(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_set_mean(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_BatchNorm3d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {
@@ -123,9 +99,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_BatchNorm3d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Batch Normalization over a 5D input (a mini-batch of 3D inputs with additional channel dimension) as described in the paper Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift.
             /// </summary>
@@ -139,7 +112,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public BatchNorm3d BatchNorm3d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true, Device? device = null, ScalarType? dtype = null)
+            public static BatchNorm3d BatchNorm3d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = true, bool track_running_stats = true, Device? device = null, ScalarType? dtype = null)
             {
                 unsafe {
                     var handle = THSNN_BatchNorm3d_ctor(features, eps, momentum, affine, track_running_stats, out var boxedHandle);

--- a/src/TorchSharp/NN/Normalization/Functional.cs
+++ b/src/TorchSharp/NN/Normalization/Functional.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -10,9 +10,6 @@ namespace TorchSharp
         {
             public static partial class functional
             {
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_batch_norm(IntPtr input, IntPtr running_mean, IntPtr running_var, IntPtr weight, IntPtr bias, bool training, double momentum, double eps);
-
                 /// <summary>
                 /// Applies Batch Normalization for each channel across a batch of data.
                 /// </summary>
@@ -31,9 +28,6 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
 
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_group_norm(IntPtr input, long num_groups, IntPtr weight, IntPtr bias, double eps);
-
                 /// <summary>
                 /// Applies Group Normalization for last certain number of dimensions.
                 /// </summary>
@@ -49,9 +43,6 @@ namespace TorchSharp
                         torch.CheckForErrors();
                     return new Tensor(res);
                 }
-
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_instance_norm(IntPtr input, IntPtr running_mean, IntPtr running_var, IntPtr weight, IntPtr bias, bool use_input_stats, double momentum, double eps);
 
                 /// <summary>
                 /// Applies Instance Normalization for each channel in each data sample in a batch.
@@ -70,9 +61,6 @@ namespace TorchSharp
                         torch.CheckForErrors();
                     return new Tensor(res);
                 }
-
-                [DllImport("LibTorchSharp")]
-                extern static unsafe IntPtr THSNN_layer_norm(IntPtr input, long* normalized_shape, long normalized_shape_len, IntPtr weight, IntPtr bias, double eps);
 
                 /// <summary>
                 /// Applies Layer Normalization for last certain number of dimensions.
@@ -95,9 +83,6 @@ namespace TorchSharp
                         torch.CheckForErrors();
                     return new Tensor(res);
                 }
-
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSNN_local_response_norm(IntPtr input, long size, double alpha, double beta, double k);
 
                 /// <summary>
                 /// Applies Local Normalization.

--- a/src/TorchSharp/NN/Normalization/GroupNorm.cs
+++ b/src/TorchSharp/NN/Normalization/GroupNorm.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -20,9 +20,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GroupNorm_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (tensor.Dimensions < 3) throw new ArgumentException($"Invalid number of dimensions for GroupNorm argument: {tensor.Dimensions}");
@@ -30,15 +27,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GroupNorm_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_GroupNorm_set_bias(torch.nn.Module.HType module, IntPtr bias);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GroupNorm_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_GroupNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {
@@ -65,7 +53,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("weight", value);
                 }
             }
-
         }
     }
 
@@ -73,9 +60,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GroupNorm_ctor(long num_groups, long num_channels, double eps, [MarshalAs(UnmanagedType.U1)] bool affine, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Group Normalization over a mini-batch of inputs as described in the paper Group Normalization
             /// </summary>
@@ -86,7 +70,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public GroupNorm GroupNorm(long num_groups, long num_channels, double eps = 1e-05, bool affine = true, Device? device = null, ScalarType? dtype = null)
+            public static GroupNorm GroupNorm(long num_groups, long num_channels, double eps = 1e-05, bool affine = true, Device? device = null, ScalarType? dtype = null)
             {
                 unsafe {
                     var handle = THSNN_GroupNorm_ctor(num_groups, num_channels, eps, affine, out var boxedHandle);

--- a/src/TorchSharp/NN/Normalization/InstanceNorm1d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm1d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -20,9 +20,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (tensor.Dimensions < 2 || tensor.Dimensions > 3) throw new ArgumentException($"Invalid number of dimensions for InstanceNorm argument: {tensor.Dimensions}");
@@ -30,27 +27,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_set_bias(torch.nn.Module.HType module, IntPtr bias);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_set_weight(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_reset_stats(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_get_mean(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_get_var(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm1d_get_batches(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_set_mean(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm1d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {
@@ -124,9 +100,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_InstanceNorm1d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Instance Normalization over a 3D input (a mini-batch of 1D inputs with optional additional channel dimension) as described in the paper Instance Normalization: The Missing Ingredient for Fast Stylization.
             /// </summary>
@@ -140,7 +113,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public InstanceNorm1d InstanceNorm1d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = false, bool track_running_stats = false, Device? device = null, ScalarType? dtype = null)
+            public static InstanceNorm1d InstanceNorm1d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = false, bool track_running_stats = false, Device? device = null, ScalarType? dtype = null)
             {
                 unsafe {
                     var handle = THSNN_InstanceNorm1d_ctor(features, eps, momentum, affine, track_running_stats, out var boxedHandle);

--- a/src/TorchSharp/NN/Normalization/InstanceNorm2d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -20,9 +20,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (tensor.Dimensions != 4) throw new ArgumentException($"Invalid number of dimensions for InstanceNorm argument: {tensor.Dimensions}");
@@ -30,27 +27,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_set_bias(torch.nn.Module.HType module, IntPtr bias);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_set_weight(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_reset_stats(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_get_mean(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_get_var(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm2d_get_batches(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_set_mean(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm2d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {
@@ -124,9 +100,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_InstanceNorm2d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Instance Normalization over a 4D input (a mini-batch of 2D inputs with additional channel dimension) as described in the paper Instance Normalization: The Missing Ingredient for Fast Stylization.
             /// </summary>
@@ -140,7 +113,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public InstanceNorm2d InstanceNorm2d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = false, bool track_running_stats = false, Device? device = null, ScalarType? dtype = null)
+            public static InstanceNorm2d InstanceNorm2d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = false, bool track_running_stats = false, Device? device = null, ScalarType? dtype = null)
             {
                 unsafe {
                     var handle = THSNN_InstanceNorm2d_ctor(features, eps, momentum, affine, track_running_stats, out var boxedHandle);

--- a/src/TorchSharp/NN/Normalization/InstanceNorm3d.cs
+++ b/src/TorchSharp/NN/Normalization/InstanceNorm3d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -20,9 +20,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (tensor.Dimensions != 5) throw new ArgumentException($"Invalid number of dimensions for InstanceNorm argument: {tensor.Dimensions}");
@@ -30,27 +27,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_set_bias(torch.nn.Module.HType module, IntPtr bias);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_set_weight(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_reset_stats(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_get_mean(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_get_var(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_InstanceNorm3d_get_batches(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_set_mean(torch.nn.Module.HType module, IntPtr weight);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_InstanceNorm3d_set_var(torch.nn.Module.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {
@@ -124,9 +100,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_InstanceNorm3d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Instance Normalization over a 5D input (a mini-batch of 3D inputs with additional channel dimension) as described in the paper Instance Normalization: The Missing Ingredient for Fast Stylization.
             /// </summary>
@@ -140,7 +113,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public InstanceNorm3d InstanceNorm3d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = false, bool track_running_stats = false, Device? device = null, ScalarType? dtype = null)
+            public static InstanceNorm3d InstanceNorm3d(long features, double eps = 1e-05, double momentum = 0.1, bool affine = false, bool track_running_stats = false, Device? device = null, ScalarType? dtype = null)
             {
                 unsafe {
                     var handle = THSNN_InstanceNorm3d_ctor(features, eps, momentum, affine, track_running_stats, out var boxedHandle);

--- a/src/TorchSharp/NN/Normalization/LayerNorm.cs
+++ b/src/TorchSharp/NN/Normalization/LayerNorm.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -20,24 +20,12 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LayerNorm_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_LayerNorm_forward(handle.DangerousGetHandle(), tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LayerNorm_bias(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_LayerNorm_set_bias(torch.nn.Module.HType module, IntPtr bias);
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LayerNorm_weight(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_LayerNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
 
             public Parameter? bias {
                 get {
@@ -71,9 +59,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LayerNorm_ctor(IntPtr norm_shape, long norm_shape_len, double eps, [MarshalAs(UnmanagedType.U1)] bool elementwise_affine, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies Layer Normalization over a mini-batch of inputs as described in the paper Layer Normalization
             /// </summary>
@@ -83,7 +68,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public LayerNorm LayerNorm(long[] normalized_shape, double eps = 1e-05, bool elementwise_affine = true, Device? device = null, ScalarType? dtype = null)
+            public static LayerNorm LayerNorm(long[] normalized_shape, double eps = 1e-05, bool elementwise_affine = true, Device? device = null, ScalarType? dtype = null)
             {
                 unsafe {
                     fixed (long* pNormShape = normalized_shape) {
@@ -103,7 +88,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public LayerNorm LayerNorm(long normalized_shape, double eps = 1e-05, bool elementwise_affine = true, Device? device = null, ScalarType? dtype = null)
+            public static LayerNorm LayerNorm(long normalized_shape, double eps = 1e-05, bool elementwise_affine = true, Device? device = null, ScalarType? dtype = null)
             {
                 return LayerNorm(new[] { normalized_shape }, eps, elementwise_affine, device, dtype);
             }

--- a/src/TorchSharp/NN/Normalization/LocalResponseNorm.cs
+++ b/src/TorchSharp/NN/Normalization/LocalResponseNorm.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LocalResponseNorm_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (tensor.Dimensions < 3) throw new ArgumentException($"Invalid number of dimensions for LocalResponseNorm argument: {tensor.Dimensions}");
@@ -35,13 +32,10 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LocalResponseNorm_ctor(long size, double alpha, double beta, double k, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies local response normalization over an input signal composed of several input planes, where channels occupy the second dimension. Applies normalization across channels.
             /// </summary>
-            static public LocalResponseNorm LocalResponseNorm(long size, double alpha = 0.0001, double beta = 0.75, double k = 1.0)
+            public static LocalResponseNorm LocalResponseNorm(long size, double alpha = 0.0001, double beta = 0.75, double k = 1.0)
             {
                 unsafe {
                     var handle = THSNN_LocalResponseNorm_ctor(size, alpha, beta, k, out var boxedHandle);

--- a/src/TorchSharp/NN/OneHot.cs
+++ b/src/TorchSharp/NN/OneHot.cs
@@ -1,19 +1,15 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
-
     public static partial class torch
     {
         public static partial class nn
         {
             public static partial class functional
             {
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_one_hot(IntPtr self, long num_classes);
-
                 /// <summary>
                 /// Takes LongTensor with index values of shape (*) and returns a tensor of shape (*, num_classes) that have zeros
                 /// everywhere except where the index of last dimension matches the corresponding value of the input tensor, in which case it will be 1.
@@ -22,7 +18,7 @@ namespace TorchSharp
                 /// <param name="num_classes">Total number of classes.
                 /// If set to -1, the number of classes will be inferred as one greater than the largest class value in the input tensor</param>
                 /// <returns></returns>
-                static public Tensor one_hot(Tensor x, long num_classes = -1)
+                public static Tensor one_hot(Tensor x, long num_classes = -1)
                 {
                     if (x.dtype != ScalarType.Int64) throw new ArgumentException("OneHot input tensor must have elements of type Int64");
                     var res = THSNN_one_hot(x.Handle, num_classes);

--- a/src/TorchSharp/NN/Padding/ConstantPad1d.cs
+++ b/src/TorchSharp/NN/Padding/ConstantPad1d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ConstantPad1d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConstantPad1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConstantPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,16 +34,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConstantPad1d_ctor(double value, long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor using replication of the input boundary.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <param name="value"></param>
             /// <returns></returns>
-            static public ConstantPad1d ConstantPad1d(long padding, double value)
+            public static ConstantPad1d ConstantPad1d(long padding, double value)
             {
                 var handle = THSNN_ConstantPad1d_ctor(value, padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ConstantPad2d.cs
+++ b/src/TorchSharp/NN/Padding/ConstantPad2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ConstantPad2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConstantPad2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConstantPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,16 +34,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConstantPad2d_ctor(double value, long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor using replication of the input boundary.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <param name="value"></param>
             /// <returns></returns>
-            static public ConstantPad2d ConstantPad2d(long padding, double value)
+            public static ConstantPad2d ConstantPad2d(long padding, double value)
             {
                 var handle = THSNN_ConstantPad2d_ctor(value, padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ConstantPad3d.cs
+++ b/src/TorchSharp/NN/Padding/ConstantPad3d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ConstantPad3d : torch.nn.Module<Tensor, Tensor>
         {
             internal ConstantPad3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ConstantPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,16 +34,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ConstantPad3d_ctor(double value, long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor using replication of the input boundary.
             /// </summary>
             /// <param name="value"></param>
             /// <param name="padding">The size of the padding.</param>
             /// <returns></returns>
-            static public ConstantPad3d ConstantPad3d(long padding, double value)
+            public static ConstantPad3d ConstantPad3d(long padding, double value)
             {
                 var handle = THSNN_ConstantPad3d_ctor(value, padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ReflectionPad1d.cs
+++ b/src/TorchSharp/NN/Padding/ReflectionPad1d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ReflectionPad1d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReflectionPad1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReflectionPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ReflectionPad1d_ctor(long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor boundaries with zero.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <returns></returns>
-            static public ReflectionPad1d ReflectionPad1d(long padding)
+            public static ReflectionPad1d ReflectionPad1d(long padding)
             {
                 var handle = THSNN_ReflectionPad1d_ctor(padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ReflectionPad2d.cs
+++ b/src/TorchSharp/NN/Padding/ReflectionPad2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ReflectionPad2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReflectionPad2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReflectionPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ReflectionPad2d_ctor(long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor using the reflection of the input boundary.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <returns></returns>
-            static public ReflectionPad2d ReflectionPad2d(long padding)
+            public static ReflectionPad2d ReflectionPad2d(long padding)
             {
                 var handle = THSNN_ReflectionPad2d_ctor(padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ReflectionPad3d.cs
+++ b/src/TorchSharp/NN/Padding/ReflectionPad3d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ReflectionPad3d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReflectionPad3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReflectionPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ReflectionPad3d_ctor(long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor using the reflection of the input boundary.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <returns></returns>
-            static public ReflectionPad3d ReflectionPad3d(long padding)
+            public static ReflectionPad3d ReflectionPad3d(long padding)
             {
                 var handle = THSNN_ReflectionPad3d_ctor(padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ReplicationPad1d.cs
+++ b/src/TorchSharp/NN/Padding/ReplicationPad1d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ReplicationPad1d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReplicationPad1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReplicationPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ReplicationPad1d_ctor(long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor using replication of the input boundary.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <returns></returns>
-            static public ReplicationPad1d ReplicationPad1d(long padding)
+            public static ReplicationPad1d ReplicationPad1d(long padding)
             {
                 var handle = THSNN_ReplicationPad1d_ctor(padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ReplicationPad2d.cs
+++ b/src/TorchSharp/NN/Padding/ReplicationPad2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ReplicationPad2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReplicationPad2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReplicationPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ReplicationPad2d_ctor(long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor using replication of the input boundary.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <returns></returns>
-            static public ReplicationPad2d ReplicationPad2d(long padding)
+            public static ReplicationPad2d ReplicationPad2d(long padding)
             {
                 var handle = THSNN_ReplicationPad2d_ctor(padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ReplicationPad3d.cs
+++ b/src/TorchSharp/NN/Padding/ReplicationPad3d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ReplicationPad3d : torch.nn.Module<Tensor, Tensor>
         {
             internal ReplicationPad3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ReplicationPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ReplicationPad3d_ctor(long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor using replication of the input boundary.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <returns></returns>
-            static public ReplicationPad3d ReplicationPad3d(long padding)
+            public static ReplicationPad3d ReplicationPad3d(long padding)
             {
                 var handle = THSNN_ReplicationPad3d_ctor(padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Padding/ZeroPad2d.cs
+++ b/src/TorchSharp/NN/Padding/ZeroPad2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class ZeroPad2d : torch.nn.Module<Tensor, Tensor>
         {
             internal ZeroPad2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_ZeroPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,15 +34,12 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_ZeroPad2d_ctor(long padding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Pads the input tensor boundaries with zero.
             /// </summary>
             /// <param name="padding">The size of the padding.</param>
             /// <returns></returns>
-            static public ZeroPad2d ZeroPad2d(long padding)
+            public static ZeroPad2d ZeroPad2d(long padding)
             {
                 var handle = THSNN_ZeroPad2d_ctor(padding, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/PairwiseDistance.cs
+++ b/src/TorchSharp/NN/PairwiseDistance.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_PairwiseDistance_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
-
             public override Tensor forward(Tensor input1, Tensor input2)
             {
                 var res = THSNN_PairwiseDistance_forward(handle, input1.Handle, input2.Handle);
@@ -34,15 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_PairwiseDistance_ctor(double p, double eps, [MarshalAs(UnmanagedType.U1)] bool keep_dim, out IntPtr pBoxedModule);
-
-            static public PairwiseDistance PairwiseDistance(double p = 2.0, double eps = 1e-6, bool keep_dim = false)
+            public static PairwiseDistance PairwiseDistance(double p = 2.0, double eps = 1e-6, bool keep_dim = false)
             {
                 var handle = THSNN_PairwiseDistance_ctor(p, eps, keep_dim, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new PairwiseDistance(handle, boxedHandle);
             }
+
             public static partial class functional
             {
                 /// <summary>
@@ -54,7 +49,7 @@ namespace TorchSharp
                 /// <param name="eps">Small value to avoid division by zero.</param>
                 /// <param name="keep_dim">Determines whether or not to keep the vector dimension.</param>
                 /// <returns></returns>
-                static public Tensor pairwise_distance(Tensor input1, Tensor input2, double p = 2.0, double eps = 1e-6, bool keep_dim = false)
+                public static Tensor pairwise_distance(Tensor input1, Tensor input2, double p = 2.0, double eps = 1e-6, bool keep_dim = false)
                 {
                     using (var f = nn.PairwiseDistance(p, eps, keep_dim)) {
                         return f.forward(input1, input2);

--- a/src/TorchSharp/NN/PixelShuffle.cs
+++ b/src/TorchSharp/NN/PixelShuffle.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class PixelShuffle : torch.nn.Module<Tensor, Tensor>
         {
             internal PixelShuffle(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_PixelShuffle_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,16 +34,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_PixelShuffle_ctor(long upscaleFactor, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Rearranges elements in a tensor of shape (*, C * r^2, H, W) to a tensor of shape(*, C, H * r, W * r), where r is an upscale factor.
             /// This is useful for implementing efficient sub-pixel convolution with a stride of 1/r.
             /// </summary>
             /// <param name="upscaleFactor">Factor to increase spatial resolution by</param>
             /// <returns></returns>
-            static public PixelShuffle PixelShuffle(long upscaleFactor)
+            public static PixelShuffle PixelShuffle(long upscaleFactor)
             {
                 var handle = THSNN_PixelShuffle_ctor(upscaleFactor, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -63,7 +57,7 @@ namespace TorchSharp
                 /// <param name="upscaleFactor">Factor to increase spatial resolution by</param>
                 /// <returns></returns>
                 /// <returns></returns>
-                static public Tensor pixel_shuffle(Tensor x, long upscaleFactor)
+                public static Tensor pixel_shuffle(Tensor x, long upscaleFactor)
                 {
                     using (var d = nn.PixelShuffle(upscaleFactor)) {
                         return d.forward(x);

--- a/src/TorchSharp/NN/PixelUnshuffle.cs
+++ b/src/TorchSharp/NN/PixelUnshuffle.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
         public sealed class PixelUnshuffle : torch.nn.Module<Tensor, Tensor>
         {
             internal PixelUnshuffle(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_PixelUnshuffle_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.
@@ -37,15 +34,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_PixelUnshuffle_ctor(long downscaleFactor, out IntPtr pBoxedModule);
 
             /// <summary>
             /// Reverses the PixelShuffle operation by rearranging elements in a tensor of shape (*, C, H * r, W * r) to a tensor of shape (*, C * r^2, H, W), where r is an downscale factor.
             /// </summary>
             /// <param name="downscaleFactor">Factor to increase spatial resolution by</param>
             /// <returns></returns>
-            static public PixelUnshuffle PixelUnshuffle(long downscaleFactor)
+            public static PixelUnshuffle PixelUnshuffle(long downscaleFactor)
             {
                 var handle = THSNN_PixelUnshuffle_ctor(downscaleFactor, out var boxedHandle);
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -62,7 +57,7 @@ namespace TorchSharp
                 /// <param name="downscaleFactor">Factor to increase spatial resolution by</param>
                 /// <returns></returns>
                 /// <returns></returns>
-                static public Tensor pixel_unshuffle(Tensor x, long downscaleFactor)
+                public static Tensor pixel_unshuffle(Tensor x, long downscaleFactor)
                 {
                     using (var d = nn.PixelUnshuffle(downscaleFactor)) {
                         return d.forward(x);

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool1D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AdaptiveAvgPool1d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AdaptiveAvgPool1d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AdaptiveAvgPool1d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D adaptive average pooling over an input signal composed of several input planes.
             /// The output size is H, for any input size.The number of output features is equal to the number of input planes.
             /// </summary>
             /// <param name="outputSize">the target output size H</param>
             /// <returns></returns>
-            static public unsafe AdaptiveAvgPool1d AdaptiveAvgPool1d(long outputSize)
+            public static unsafe AdaptiveAvgPool1d AdaptiveAvgPool1d(long outputSize)
             {
                 long* pkernelSize = stackalloc long[1] { outputSize };
                 var handle = THSNN_AdaptiveAvgPool1d_ctor((IntPtr)pkernelSize, 1, out var boxedHandle);

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool2D.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AdaptiveAvgPool2d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AdaptiveAvgPool2d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AdaptiveAvgPool2d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D adaptive average pooling over an input signal composed of several input planes.
             /// The output is of size H x W, for any input size.The number of output features is equal to the number of input planes.
             /// </summary>
             /// <param name="outputSize">The target output size (H,W) of the image of the form H x W.</param>
             /// <returns></returns>
-            static public unsafe AdaptiveAvgPool2d AdaptiveAvgPool2d(long[] outputSize)
+            public static unsafe AdaptiveAvgPool2d AdaptiveAvgPool2d(long[] outputSize)
             {
                 fixed (long* poutputSize = outputSize) {
                     var handle = THSNN_AdaptiveAvgPool2d_ctor((IntPtr)poutputSize, outputSize.Length, out var boxedHandle);
@@ -58,7 +52,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="outputSize">The target output size (H,W) of the image of the form H x W.</param>
             /// <returns></returns>
-            static public unsafe AdaptiveAvgPool2d AdaptiveAvgPool2d((long,long) outputSize)
+            public static unsafe AdaptiveAvgPool2d AdaptiveAvgPool2d((long,long) outputSize)
             {
                 long* poutputSize = stackalloc long[2] { outputSize.Item1, outputSize.Item2 };
                 var handle = THSNN_AdaptiveAvgPool2d_ctor((IntPtr)poutputSize, 2, out var boxedHandle);
@@ -72,7 +66,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="outputSize">The target output size (H,W) of the image of the form H x W.</param>
             /// <returns></returns>
-            static public unsafe AdaptiveAvgPool2d AdaptiveAvgPool2d(long outputSize)
+            public static unsafe AdaptiveAvgPool2d AdaptiveAvgPool2d(long outputSize)
             {
                 long* poutputSize = stackalloc long[2] { outputSize, outputSize };
                 var handle = THSNN_AdaptiveAvgPool2d_ctor((IntPtr)poutputSize, 2, out var boxedHandle);

--- a/src/TorchSharp/NN/Pooling/AdaptiveAvgPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveAvgPool3D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AdaptiveAvgPool3d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AdaptiveAvgPool3d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AdaptiveAvgPool3d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 3D adaptive average pooling over an input signal composed of several input planes.
             /// The output is of size D x H x W, for any input size.The number of output features is equal to the number of input planes.
             /// </summary>
             /// <param name="outputSize">The target output size of the image of the form D x H x W.</param>
             /// <returns></returns>
-            static public unsafe AdaptiveAvgPool3d AdaptiveAvgPool3d(long[] outputSize)
+            public static unsafe AdaptiveAvgPool3d AdaptiveAvgPool3d(long[] outputSize)
             {
                 fixed (long* pkernelSize = outputSize) {
                     var handle = THSNN_AdaptiveAvgPool3d_ctor((IntPtr)pkernelSize, outputSize.Length, out var boxedHandle);
@@ -58,7 +52,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="outputSize">The target output size (D,H,W) of the image of the form D x H x W.</param>
             /// <returns></returns>
-            static public unsafe AdaptiveAvgPool3d AdaptiveAvgPool3d((long, long, long) outputSize)
+            public static unsafe AdaptiveAvgPool3d AdaptiveAvgPool3d((long, long, long) outputSize)
             {
                 long* pkernelSize = stackalloc long[3] { outputSize.Item1, outputSize.Item2, outputSize.Item3 };
 
@@ -73,7 +67,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="outputSize">The target output size (D,H,W) of the image of the form H x W.</param>
             /// <returns></returns>
-            static public unsafe AdaptiveAvgPool3d AdaptiveAvgPool3d(long outputSize)
+            public static unsafe AdaptiveAvgPool3d AdaptiveAvgPool3d(long outputSize)
             {
                 long* pkernelSize = stackalloc long[3] { outputSize, outputSize, outputSize};
                 var handle = THSNN_AdaptiveAvgPool3d_ctor((IntPtr)pkernelSize, 3, out var boxedHandle);

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool1D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AdaptiveMaxPool1d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AdaptiveMaxPool1d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AdaptiveMaxPool1d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D adaptive max pooling over an input signal composed of several input planes.
             /// The output size is H, for any input size.The number of output features is equal to the number of input planes.
             /// </summary>
             /// <param name="outputSize">The target output size H.</param>
             /// <returns></returns>
-            static public AdaptiveMaxPool1d AdaptiveMaxPool1d(long outputSize)
+            public static AdaptiveMaxPool1d AdaptiveMaxPool1d(long outputSize)
             {
                 unsafe {
                     fixed (long* pkernelSize = new long[] { outputSize }) {
@@ -63,7 +57,7 @@ namespace TorchSharp
                 /// <param name="x"></param>
                 /// <param name="outputSize">The target output size H.</param>
                 /// <returns></returns>
-                static public Tensor adaptive_max_pool1d(Tensor x, long outputSize)
+                public static Tensor adaptive_max_pool1d(Tensor x, long outputSize)
                 {
                     using (var d = nn.AdaptiveMaxPool1d(outputSize)) {
                         return d.forward(x);

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool2D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AdaptiveMaxPool2d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AdaptiveMaxPool2d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,9 +31,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AdaptiveMaxPool2d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D adaptive max pooling over an input signal composed of several input planes.
             /// The output is of size H x W, for any input size.The number of output features is equal to the number of input planes.
@@ -44,7 +38,7 @@ namespace TorchSharp
             /// <param name="outputSize">Applies a 2D adaptive max pooling over an input signal composed of several input planes.
             /// The output is of size H x W, for any input size.The number of output features is equal to the number of input planes.</param>
             /// <returns></returns>
-            static public AdaptiveMaxPool2d AdaptiveMaxPool2d(long[] outputSize)
+            public static AdaptiveMaxPool2d AdaptiveMaxPool2d(long[] outputSize)
             {
                 unsafe {
                     fixed (long* pkernelSize = outputSize) {
@@ -65,7 +59,7 @@ namespace TorchSharp
                 /// <param name="outputSize">Applies a 2D adaptive max pooling over an input signal composed of several input planes.
                 /// The output is of size H x W, for any input size.The number of output features is equal to the number of input planes.</param>
                 /// <returns></returns>
-                static public Tensor adaptive_max_pool2d(Tensor x, long[] outputSize)
+                public static Tensor adaptive_max_pool2d(Tensor x, long[] outputSize)
                 {
                     using (var d = nn.AdaptiveMaxPool2d(outputSize)) {
                         return d.forward(x);

--- a/src/TorchSharp/NN/Pooling/AdaptiveMaxPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AdaptiveMaxPool3D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AdaptiveMaxPool3d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AdaptiveMaxPool3d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,9 +31,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AdaptiveMaxPool3d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 3D adaptive max pooling over an input signal composed of several input planes.
             /// The output is of size D x H x W, for any input size.The number of output features is equal to the number of input planes.
@@ -44,7 +38,7 @@ namespace TorchSharp
             /// <param name="outputSize">The target output size of the image of the form D x H x W.
             /// Can be a tuple (D, H, W) or a single D for a cube D x D x D. D, H and W can be either a int, or null which means the size will be the same as that of the input.</param>
             /// <returns></returns>
-            static public AdaptiveMaxPool3d AdaptiveMaxPool3d(long[] outputSize)
+            public static AdaptiveMaxPool3d AdaptiveMaxPool3d(long[] outputSize)
             {
                 unsafe {
                     fixed (long* pkernelSize = outputSize) {
@@ -65,7 +59,7 @@ namespace TorchSharp
                 /// <param name="outputSize">The target output size of the image of the form D x H x W.
                 /// Can be a tuple (D, H, W) or a single D for a cube D x D x D. D, H and W can be either a int, or null which means the size will be the same as that of the input.</param>
                 /// <returns></returns>
-                static public Tensor adaptive_max_pool3d(Tensor x, long[] outputSize)
+                public static Tensor adaptive_max_pool3d(Tensor x, long[] outputSize)
                 {
                     using (var d = nn.AdaptiveMaxPool3d(outputSize)) {
                         return d.forward(x);

--- a/src/TorchSharp/NN/Pooling/AvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool1D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AvgPool1d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AvgPool1d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AvgPool1d_ctor(IntPtr pkernelSize, IntPtr pstrides, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D average pooling over an input signal composed of several input planes.
             /// </summary>
             /// <param name="kernelSize">The size of the window</param>
             /// <param name="stride">The stride of the window. Default value is kernel_size</param>
             /// <returns></returns>
-            static public AvgPool1d AvgPool1d(long kernelSize, long? stride = null)
+            public static AvgPool1d AvgPool1d(long kernelSize, long? stride = null)
             {
                 return stride.HasValue ?
                     AvgPool1d(new long[] { kernelSize }, new long[] { stride.Value }) :
@@ -56,7 +50,7 @@ namespace TorchSharp
             /// <param name="kernelSize">The size of the window</param>
             /// <param name="strides">The stride of the window. Default value is kernel_size</param>
             /// <returns></returns>
-            static private AvgPool1d AvgPool1d(long[] kernelSize, long[] strides = null)
+            private static AvgPool1d AvgPool1d(long[] kernelSize, long[] strides = null)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernelSize, pstrides = strides) {

--- a/src/TorchSharp/NN/Pooling/AvgPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool2D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AvgPool2d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AvgPool2d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AvgPool2d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D average pooling over an input signal composed of several input planes.
             /// </summary>
             /// <param name="kernel_size">The size of the window</param>
             /// <param name="strides">The stride of the window. Default value is kernel_size</param>
             /// <returns></returns>
-            static public unsafe AvgPool2d AvgPool2d(long[] kernel_size, long[] strides = null)
+            public static unsafe AvgPool2d AvgPool2d(long[] kernel_size, long[] strides = null)
             {
                 fixed (long* pkernelSize = kernel_size, pstrides = strides) {
                     var handle = THSNN_AvgPool2d_ctor((IntPtr)pkernelSize, kernel_size.Length, (IntPtr)pstrides, (strides == null ? 0 : strides.Length), out var boxedHandle);
@@ -58,7 +52,7 @@ namespace TorchSharp
             /// <param name="kernel_size">The size of the window</param>
             /// <param name="stride">The stride of the window.</param>
             /// <returns></returns>
-            static public unsafe AvgPool2d AvgPool2d((long,long) kernel_size, (long,long)? stride = null)
+            public static unsafe AvgPool2d AvgPool2d((long,long) kernel_size, (long,long)? stride = null)
             {
                 long svalue1 = (stride == null) ? kernel_size.Item1 : stride.Value.Item1;
                 long svalue2 = (stride == null) ? kernel_size.Item2 : stride.Value.Item2;
@@ -77,7 +71,7 @@ namespace TorchSharp
             /// <param name="kernel_size">The size of the window</param>
             /// <param name="stride">The stride of the window.</param>
             /// <returns></returns>
-            static public unsafe AvgPool2d AvgPool2d(long kernel_size, long? stride = null)
+            public static unsafe AvgPool2d AvgPool2d(long kernel_size, long? stride = null)
             {
                 long svalue = (stride == null) ? kernel_size : stride.Value;
 

--- a/src/TorchSharp/NN/Pooling/AvgPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool3D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_AvgPool3d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_AvgPool3d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_AvgPool3d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 3D average pooling over an input signal composed of several input planes.
             /// </summary>
             /// <param name="kernel_size">The size of the window</param>
             /// <param name="strides">The stride of the window. Default value is kernel_size</param>
             /// <returns></returns>
-            static public AvgPool3d AvgPool3d(long[] kernel_size, long[] strides = null)
+            public static AvgPool3d AvgPool3d(long[] kernel_size, long[] strides = null)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernel_size, pstrides = strides) {
@@ -60,7 +54,7 @@ namespace TorchSharp
             /// <param name="kernel_size">The size of the window</param>
             /// <param name="stride">The stride of the window. Default value is kernel_size</param>
             /// <returns></returns>
-            static public unsafe AvgPool3d AvgPool3d((long, long, long) kernel_size, (long, long, long)? stride = null)
+            public static unsafe AvgPool3d AvgPool3d((long, long, long) kernel_size, (long, long, long)? stride = null)
             {
                 long svalue1 = (stride == null) ? kernel_size.Item1 : stride.Value.Item1;
                 long svalue2 = (stride == null) ? kernel_size.Item2 : stride.Value.Item2;
@@ -80,7 +74,7 @@ namespace TorchSharp
             /// <param name="kernel_size">The size of the window</param>
             /// <param name="stride">The stride of the window. Default value is kernel_size</param>
             /// <returns></returns>
-            static public unsafe AvgPool3d AvgPool3d(long kernel_size, long? stride = null)
+            public static unsafe AvgPool3d AvgPool3d(long kernel_size, long? stride = null)
             {
                 long svalue = (stride == null) ? kernel_size : stride.Value;
 

--- a/src/TorchSharp/NN/Pooling/FractionalMaxPool2d.cs
+++ b/src/TorchSharp/NN/Pooling/FractionalMaxPool2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,18 +18,12 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FractionalMaxPool2d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_FractionalMaxPool2d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FractionalMaxPool2d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {
@@ -44,9 +38,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_FractionalMaxPool2d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pOutputSize, int sizeLength, IntPtr pOutputRatio, int ratioLength, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D fractional max pooling over an input signal composed of several input planes.
             ///
@@ -57,7 +48,7 @@ namespace TorchSharp
             /// <param name="output_size">The target output size of the image of the form oH x oW. Can be a tuple (oH, oW) or a single number oH for a square image oH x oH</param>
             /// <param name="output_ratio">If one wants to have an output size as a ratio of the input size, this option can be given. This has to be a number or tuple in the range (0, 1)</param>
             /// <returns></returns>
-            static public FractionalMaxPool2d FractionalMaxPool2d(long kernel_size, long? output_size = null, double? output_ratio = null)
+            public static FractionalMaxPool2d FractionalMaxPool2d(long kernel_size, long? output_size = null, double? output_ratio = null)
             {
                 var pSize = output_size.HasValue ? new long[] { output_size.Value, output_size.Value } : null;
                 var pRatio = output_ratio.HasValue ? new double[] { output_ratio.Value, output_ratio.Value } : null;
@@ -74,7 +65,7 @@ namespace TorchSharp
             /// <param name="output_size">The target output size of the image of the form oH x oW. Can be a tuple (oH, oW) or a single number oH for a square image oH x oH</param>
             /// <param name="output_ratio">If one wants to have an output size as a ratio of the input size, this option can be given. This has to be a number or tuple in the range (0, 1)</param>
             /// <returns></returns>
-            static public FractionalMaxPool2d FractionalMaxPool2d((long, long) kernel_size, (long, long)? output_size = null, (double, double)? output_ratio = null)
+            public static FractionalMaxPool2d FractionalMaxPool2d((long, long) kernel_size, (long, long)? output_size = null, (double, double)? output_ratio = null)
             {
                 var pSize = output_size.HasValue ? new long[] { output_size.Value.Item1, output_size.Value.Item2 } : null;
                 var pRatio = output_ratio.HasValue ? new double[] { output_ratio.Value.Item1, output_ratio.Value.Item2 } : null;
@@ -91,7 +82,7 @@ namespace TorchSharp
             /// <param name="output_size">The target output size of the image of the form oH x oW. Can be a tuple (oH, oW) or a single number oH for a square image oH x oH</param>
             /// <param name="output_ratio">If one wants to have an output size as a ratio of the input size, this option can be given. This has to be a number or tuple in the range (0, 1)</param>
             /// <returns></returns>
-            static public FractionalMaxPool2d FractionalMaxPool2d(long[] kernel_size, long[] output_size = null, double[] output_ratio = null)
+            public static FractionalMaxPool2d FractionalMaxPool2d(long[] kernel_size, long[] output_size = null, double[] output_ratio = null)
             {
                 if (kernel_size == null || kernel_size.Length != 2)
                     throw new ArgumentException("Kernel size must contain two elements.");

--- a/src/TorchSharp/NN/Pooling/FractionalMaxPool3d.cs
+++ b/src/TorchSharp/NN/Pooling/FractionalMaxPool3d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -19,9 +19,6 @@ namespace TorchSharp
                 _used_ratio = ratio;
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FractionalMaxPool3d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 if (_used_ratio && tensor.ndim != 5)
@@ -32,9 +29,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_FractionalMaxPool3d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {
@@ -55,9 +49,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_FractionalMaxPool3d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pOutputSize, int sizeLength, IntPtr pOutputRatio, int ratioLength, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 3d fractional max pooling over an input signal composed of several input planes.
             ///
@@ -68,7 +59,7 @@ namespace TorchSharp
             /// <param name="output_size">The target output size of the image of the form oH x oW. Can be a tuple (oH, oW) or a single number oH for a square image oH x oH</param>
             /// <param name="output_ratio">If one wants to have an output size as a ratio of the input size, this option can be given. This has to be a number or tuple in the range (0, 1)</param>
             /// <returns></returns>
-            static public FractionalMaxPool3d FractionalMaxPool3d(long kernel_size, long? output_size = null, double? output_ratio = null)
+            public static FractionalMaxPool3d FractionalMaxPool3d(long kernel_size, long? output_size = null, double? output_ratio = null)
             {
                 var pSize = output_size.HasValue ? new long[] { output_size.Value, output_size.Value, output_size.Value } : null;
                 var pRatio = output_ratio.HasValue ? new double[] { output_ratio.Value, output_ratio.Value, output_ratio.Value } : null;
@@ -85,7 +76,7 @@ namespace TorchSharp
             /// <param name="output_size">The target output size of the image of the form oH x oW. Can be a tuple (oH, oW) or a single number oH for a square image oH x oH</param>
             /// <param name="output_ratio">If one wants to have an output size as a ratio of the input size, this option can be given. This has to be a number or tuple in the range (0, 1)</param>
             /// <returns></returns>
-            static public FractionalMaxPool3d FractionalMaxPool3d((long, long, long) kernel_size, (long, long, long)? output_size = null, (double, double, double)? output_ratio = null)
+            public static FractionalMaxPool3d FractionalMaxPool3d((long, long, long) kernel_size, (long, long, long)? output_size = null, (double, double, double)? output_ratio = null)
             {
                 var pSize = output_size.HasValue ? new long[] { output_size.Value.Item1, output_size.Value.Item2, output_size.Value.Item3 } : null;
                 var pRatio = output_ratio.HasValue ? new double[] { output_ratio.Value.Item1, output_ratio.Value.Item2, output_ratio.Value.Item3 } : null;
@@ -102,7 +93,7 @@ namespace TorchSharp
             /// <param name="output_size">The target output size of the image of the form oH x oW. Can be a tuple (oH, oW) or a single number oH for a square image oH x oH</param>
             /// <param name="output_ratio">If one wants to have an output size as a ratio of the input size, this option can be given. This has to be a number or tuple in the range (0, 1)</param>
             /// <returns></returns>
-            static public FractionalMaxPool3d FractionalMaxPool3d(long[] kernel_size, long[] output_size = null, double[] output_ratio = null)
+            public static FractionalMaxPool3d FractionalMaxPool3d(long[] kernel_size, long[] output_size = null, double[] output_ratio = null)
             {
                 if (kernel_size == null || kernel_size.Length != 3)
                     throw new ArgumentException("Kernel size must contain three elements.");

--- a/src/TorchSharp/NN/Pooling/LPPool1d.cs
+++ b/src/TorchSharp/NN/Pooling/LPPool1d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LPPool1d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_LPPool1d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,9 +31,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LPPool1d_ctor(double norm_type, IntPtr pkernelSize, IntPtr pstrides, [MarshalAs(UnmanagedType.U1)] bool ceil_mode, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D power-average pooling over an input signal composed of several input planes.
             /// </summary>
@@ -45,7 +39,7 @@ namespace TorchSharp
             /// <param name="stride">The stride of the window. Default value is kernel_size</param>
             /// <param name="ceil_mode">Use ceil instead of floor to compute the output shape</param>
             /// <returns></returns>
-            static public LPPool1d LPPool1d(double norm_type, long kernelSize, long? stride = null, bool ceil_mode = false)
+            public static LPPool1d LPPool1d(double norm_type, long kernelSize, long? stride = null, bool ceil_mode = false)
             {
                 return stride.HasValue ?
                     LPPool1d(norm_type, new long[] { kernelSize }, new long[] { stride.Value }, ceil_mode) :
@@ -60,7 +54,7 @@ namespace TorchSharp
             /// <param name="strides">The stride of the window. Default value is kernel_size</param>
             /// <param name="ceil_mode">Use ceil instead of floor to compute the output shape</param>
             /// <returns></returns>
-            static private LPPool1d LPPool1d(double norm_type, long[] kernelSize, long[] strides = null, bool ceil_mode = false)
+            private static LPPool1d LPPool1d(double norm_type, long[] kernelSize, long[] strides = null, bool ceil_mode = false)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernelSize, pstrides = strides) {

--- a/src/TorchSharp/NN/Pooling/LPPool2d.cs
+++ b/src/TorchSharp/NN/Pooling/LPPool2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LPPool2d_forward(IntPtr module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_LPPool2d_forward(handle.DangerousGetHandle(), tensor.Handle);
@@ -34,9 +31,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LPPool2d_ctor(double norm_type, IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, [MarshalAs(UnmanagedType.U1)] bool ceil_mode, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D power-average pooling over an input signal composed of several input planes.
             /// </summary>
@@ -45,7 +39,7 @@ namespace TorchSharp
             /// <param name="strides">The stride of the window. Default value is kernel_size</param>
             /// <param name="ceil_mode">Use ceil instead of floor to compute the output shape</param>
             /// <returns></returns>
-            static public LPPool2d LPPool2d(double norm_type, long[] kernel_size, long[] strides = null, bool ceil_mode = false)
+            public static LPPool2d LPPool2d(double norm_type, long[] kernel_size, long[] strides = null, bool ceil_mode = false)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernel_size, pstrides = strides) {
@@ -64,7 +58,7 @@ namespace TorchSharp
             /// <param name="stride">The stride of the window.</param>
             /// <param name="ceil_mode">Use ceil instead of floor to compute the output shape</param>
             /// <returns></returns>
-            static public LPPool2d LPPool2d(double norm_type, long kernel_size, long? stride = null, bool ceil_mode = false)
+            public static LPPool2d LPPool2d(double norm_type, long kernel_size, long? stride = null, bool ceil_mode = false)
             {
                 return stride.HasValue ?
                     LPPool2d(norm_type, new long[] { kernel_size, kernel_size }, new long[] { stride.Value, stride.Value }, ceil_mode) :

--- a/src/TorchSharp/NN/Pooling/MaxPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool1D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,18 +18,12 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool1d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_MaxPool1d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool1d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {
@@ -44,9 +38,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_MaxPool1d_ctor(IntPtr pkernelSize, IntPtr pStrides, IntPtr pPadding, IntPtr pDilation, [MarshalAs(UnmanagedType.U1)] bool ceilMode, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D max pooling over an input signal composed of several input planes.
             /// </summary>
@@ -56,7 +47,7 @@ namespace TorchSharp
             /// <param name="dilation">The stride between elements within a sliding window, must be > 0.</param>
             /// <param name="ceilMode">If true, will use ceil instead of floor to compute the output shape. This ensures that every element in the input tensor is covered by a sliding window.</param>
             /// <returns></returns>
-            static public MaxPool1d MaxPool1d(long kernelSize, long? stride = null, long? padding = null, long? dilation = null, bool ceilMode = false)
+            public static MaxPool1d MaxPool1d(long kernelSize, long? stride = null, long? padding = null, long? dilation = null, bool ceilMode = false)
             {
                 var pStride = stride.HasValue ? new long[] { stride.Value } : null;
                 var pPadding = padding.HasValue ? new long[] { padding.Value } : null;
@@ -64,7 +55,7 @@ namespace TorchSharp
                 return MaxPool1d(new long[] { kernelSize }, pStride, pPadding, pDilation, ceilMode);
             }
 
-            static private MaxPool1d MaxPool1d(long[] kernelSize, long[] strides = null, long[] padding = null, long[] dilation = null, bool ceilMode = false)
+            private static MaxPool1d MaxPool1d(long[] kernelSize, long[] strides = null, long[] padding = null, long[] dilation = null, bool ceilMode = false)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernelSize, pstrides = strides, pPadding = padding, pDilation = dilation) {

--- a/src/TorchSharp/NN/Pooling/MaxPool2D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool2D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,19 +18,12 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool2d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_MaxPool2d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool2d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
-
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {
                 var res = THSNN_MaxPool2d_forward_with_indices(handle, tensor.Handle, out var indices);
@@ -44,9 +37,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_MaxPool2d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, IntPtr pPadding, int paddingLength, IntPtr pDilation, int dilationLength, [MarshalAs(UnmanagedType.U1)] bool ceilMode, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D max pooling over an input signal composed of several input planes.
             /// </summary>
@@ -56,7 +46,7 @@ namespace TorchSharp
             /// <param name="dilation">The stride between elements within a sliding window, must be > 0.</param>
             /// <param name="ceilMode">If true, will use ceil instead of floor to compute the output shape. This ensures that every element in the input tensor is covered by a sliding window.</param>
             /// <returns></returns>
-            static public unsafe MaxPool2d MaxPool2d(long kernelSize, long? stride = null, long? padding = null, long? dilation = null, bool ceilMode = false)
+            public static unsafe MaxPool2d MaxPool2d(long kernelSize, long? stride = null, long? padding = null, long? dilation = null, bool ceilMode = false)
             {
                 long svalue = stride.HasValue ? stride.Value : kernelSize;
                 long pvalue = padding.HasValue ? padding.Value : 0;
@@ -82,7 +72,7 @@ namespace TorchSharp
             /// <param name="dilation">The stride between elements within a sliding window, must be > 0.</param>
             /// <param name="ceilMode">If true, will use ceil instead of floor to compute the output shape. This ensures that every element in the input tensor is covered by a sliding window.</param>
             /// <returns></returns>
-            static public unsafe MaxPool2d MaxPool2d((long, long) kernelSize, (long, long)? stride = null, (long, long)? padding = null, (long, long)? dilation = null, bool ceilMode = false)
+            public static unsafe MaxPool2d MaxPool2d((long, long) kernelSize, (long, long)? stride = null, (long, long)? padding = null, (long, long)? dilation = null, bool ceilMode = false)
             {
                 long svalue1 = stride != null ? stride.Value.Item1 : kernelSize.Item1;
                 long svalue2 = stride != null ? stride.Value.Item2 : kernelSize.Item2;
@@ -111,7 +101,7 @@ namespace TorchSharp
             /// <param name="dilation">The stride between elements within a sliding window, must be > 0.</param>
             /// <param name="ceilMode">If true, will use ceil instead of floor to compute the output shape. This ensures that every element in the input tensor is covered by a sliding window.</param>
             /// <returns></returns>
-            static public unsafe MaxPool2d MaxPool2d(long[] kernelSize, long[] strides = null, long[] padding = null, long[] dilation = null, bool ceilMode = false)
+            public static unsafe MaxPool2d MaxPool2d(long[] kernelSize, long[] strides = null, long[] padding = null, long[] dilation = null, bool ceilMode = false)
             {
                 fixed (long* pkernelSize = kernelSize, pstrides = strides, pPadding = padding, pDilation = dilation) {
                     var handle = THSNN_MaxPool2d_ctor((IntPtr)pkernelSize, kernelSize.Length, (IntPtr)pstrides, (strides == null ? 0 : strides.Length), (IntPtr)pPadding, (padding == null ? 0 : padding.Length), (IntPtr)pDilation, (dilation == null ? 0 : dilation.Length), ceilMode, out var boxedHandle);

--- a/src/TorchSharp/NN/Pooling/MaxPool3D.cs
+++ b/src/TorchSharp/NN/Pooling/MaxPool3D.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,18 +18,12 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool3d_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_MaxPool3d_forward(handle, tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxPool3d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
 
             public (Tensor Values, Tensor Indices) forward_with_indices(Tensor tensor)
             {
@@ -44,9 +38,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_MaxPool3d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, IntPtr pPadding, int paddingLength, IntPtr pDilation, int dilationLength, [MarshalAs(UnmanagedType.U1)] bool ceilMode, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 3D max pooling over an input signal composed of several input planes.
             /// </summary>
@@ -56,7 +47,7 @@ namespace TorchSharp
             /// <param name="dilation">The stride between elements within a sliding window, must be > 0.</param>
             /// <param name="ceilMode">If true, will use ceil instead of floor to compute the output shape. This ensures that every element in the input tensor is covered by a sliding window.</param>
             /// <returns></returns>
-            static public MaxPool3d MaxPool3d(long kernelSize, long? stride = null, long? padding = null, long? dilation = null, bool ceilMode = false)
+            public static MaxPool3d MaxPool3d(long kernelSize, long? stride = null, long? padding = null, long? dilation = null, bool ceilMode = false)
             {
                 var pStride = stride.HasValue ? new long[] { stride.Value, stride.Value, stride.Value } : null;
                 var pPadding = padding.HasValue ? new long[] { padding.Value, padding.Value, padding.Value } : null;
@@ -73,7 +64,7 @@ namespace TorchSharp
             /// <param name="dilation">The stride between elements within a sliding window, must be > 0.</param>
             /// <param name="ceilMode">If true, will use ceil instead of floor to compute the output shape. This ensures that every element in the input tensor is covered by a sliding window.</param>
             /// <returns></returns>
-            static public MaxPool3d MaxPool3d((long,long,long) kernelSize, (long, long, long)? stride = null, (long, long, long)? padding = null, (long, long, long)? dilation = null, bool ceilMode = false)
+            public static MaxPool3d MaxPool3d((long,long,long) kernelSize, (long, long, long)? stride = null, (long, long, long)? padding = null, (long, long, long)? dilation = null, bool ceilMode = false)
             {
                 var pStride = stride.HasValue ? new long[] { stride.Value.Item1, stride.Value.Item2, stride.Value.Item3 } : null;
                 var pPadding = padding.HasValue ? new long[] { padding.Value.Item1, padding.Value.Item2, padding.Value.Item3 } : null;
@@ -90,7 +81,7 @@ namespace TorchSharp
             /// <param name="dilation">The stride between elements within a sliding window, must be > 0.</param>
             /// <param name="ceilMode">If true, will use ceil instead of floor to compute the output shape. This ensures that every element in the input tensor is covered by a sliding window.</param>
             /// <returns></returns>
-            static public MaxPool3d MaxPool3d(long[] kernelSize, long[] strides = null, long[] padding = null, long[] dilation = null, bool ceilMode = false)
+            public static MaxPool3d MaxPool3d(long[] kernelSize, long[] strides = null, long[] padding = null, long[] dilation = null, bool ceilMode = false)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernelSize, pstrides = strides, pPadding = padding, pDilation = dilation) {

--- a/src/TorchSharp/NN/Pooling/MaxUnpool1d.cs
+++ b/src/TorchSharp/NN/Pooling/MaxUnpool1d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -17,9 +17,6 @@ namespace TorchSharp
             internal MaxUnpool1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxUnpool1d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize);
 
             public override Tensor forward(Tensor tensor, Tensor indices, long[] output_size = null)
             {
@@ -38,9 +35,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_MaxUnpool1d_ctor(IntPtr pkernelSize, IntPtr pStrides, IntPtr pPadding, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 1D max pooling over an input signal composed of several input planes.
             /// </summary>
@@ -48,14 +42,14 @@ namespace TorchSharp
             /// <param name="stride">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
             /// <param name="padding">Implicit negative infinity padding to be added on both sides, must be >= 0 and less than or equal to kernel_size / 2</param>
             /// <returns></returns>
-            static public MaxUnpool1d MaxUnpool1d(long kernelSize, long? stride = null, long? padding = null)
+            public static MaxUnpool1d MaxUnpool1d(long kernelSize, long? stride = null, long? padding = null)
             {
                 var pStride = stride.HasValue ? new long[] { stride.Value } : null;
                 var pPadding = padding.HasValue ? new long[] { padding.Value } : null;
                 return MaxUnpool1d(new long[] { kernelSize }, pStride, pPadding);
             }
 
-            static private MaxUnpool1d MaxUnpool1d(long[] kernelSize, long[] strides = null, long[] padding = null)
+            private static MaxUnpool1d MaxUnpool1d(long[] kernelSize, long[] strides = null, long[] padding = null)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernelSize, pstrides = strides, pPadding = padding) {

--- a/src/TorchSharp/NN/Pooling/MaxUnpool2d.cs
+++ b/src/TorchSharp/NN/Pooling/MaxUnpool2d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -17,9 +17,6 @@ namespace TorchSharp
             internal MaxUnpool2d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxUnpool2d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize, int outputSizeLength);
 
             public override Tensor forward(Tensor tensor, Tensor indices, long[] output_size = null)
             {
@@ -38,9 +35,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_MaxUnpool2d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, IntPtr pPadding, int paddingLength, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D max pooling over an input signal composed of several input planes.
             /// </summary>
@@ -48,7 +42,7 @@ namespace TorchSharp
             /// <param name="stride">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
             /// <param name="padding">Implicit negative infinity padding to be added on both sides, must be >= 0 and less than or equal to kernel_size / 2</param>
             /// <returns></returns>
-            static public MaxUnpool2d MaxUnpool2d(long kernelSize, long? stride = null, long? padding = null)
+            public static MaxUnpool2d MaxUnpool2d(long kernelSize, long? stride = null, long? padding = null)
             {
                 var pStride = stride.HasValue ? new long[] { stride.Value, stride.Value } : null;
                 var pPadding = padding.HasValue ? new long[] { padding.Value, padding.Value } : null;
@@ -62,7 +56,7 @@ namespace TorchSharp
             /// <param name="stride">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
             /// <param name="padding">Implicit negative infinity padding to be added on both sides, must be >= 0 and less than or equal to kernel_size / 2</param>
             /// <returns></returns>
-            static public MaxUnpool2d MaxUnpool2d((long, long) kernelSize, (long, long)? stride = null, (long, long)? padding = null)
+            public static MaxUnpool2d MaxUnpool2d((long, long) kernelSize, (long, long)? stride = null, (long, long)? padding = null)
             {
                 var pStride = stride.HasValue ? new long[] { stride.Value.Item1, stride.Value.Item2 } : null;
                 var pPadding = padding.HasValue ? new long[] { padding.Value.Item1, padding.Value.Item2 } : null;
@@ -76,7 +70,7 @@ namespace TorchSharp
             /// <param name="strides">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
             /// <param name="padding">Implicit negative infinity padding to be added on both sides, must be >= 0 and less than or equal to kernel_size / 2</param>
             /// <returns></returns>
-            static public MaxUnpool2d MaxUnpool2d(long[] kernelSize, long[] strides = null, long[] padding = null)
+            public static MaxUnpool2d MaxUnpool2d(long[] kernelSize, long[] strides = null, long[] padding = null)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernelSize, pstrides = strides, pPadding = padding) {

--- a/src/TorchSharp/NN/Pooling/MaxUnpool3d.cs
+++ b/src/TorchSharp/NN/Pooling/MaxUnpool3d.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -17,9 +17,6 @@ namespace TorchSharp
             internal MaxUnpool3d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_MaxUnpool3d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize, int outputSizeLength);
 
             public override Tensor forward(Tensor tensor, Tensor indices, long[] output_size = null)
             {
@@ -38,9 +35,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_MaxUnpool3d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, IntPtr pPadding, int paddingLength, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Applies a 2D max pooling over an input signal composed of several input planes.
             /// </summary>
@@ -48,7 +42,7 @@ namespace TorchSharp
             /// <param name="stride">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
             /// <param name="padding">Implicit negative infinity padding to be added on both sides, must be >= 0 and less than or equal to kernel_size / 2</param>
             /// <returns></returns>
-            static public MaxUnpool3d MaxUnpool3d(long kernelSize, long? stride = null, long? padding = null)
+            public static MaxUnpool3d MaxUnpool3d(long kernelSize, long? stride = null, long? padding = null)
             {
                 var pStride = stride.HasValue ? new long[] { stride.Value, stride.Value, stride.Value } : null;
                 var pPadding = padding.HasValue ? new long[] { padding.Value, padding.Value, padding.Value } : null;
@@ -62,7 +56,7 @@ namespace TorchSharp
             /// <param name="stride">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
             /// <param name="padding">Implicit negative infinity padding to be added on both sides, must be >= 0 and less than or equal to kernel_size / 2</param>
             /// <returns></returns>
-            static public MaxUnpool3d MaxUnpool3d((long, long, long) kernelSize, (long, long, long)? stride = null, (long, long, long)? padding = null)
+            public static MaxUnpool3d MaxUnpool3d((long, long, long) kernelSize, (long, long, long)? stride = null, (long, long, long)? padding = null)
             {
                 var pStride = stride.HasValue ? new long[] { stride.Value.Item1, stride.Value.Item2, stride.Value.Item3 } : null;
                 var pPadding = padding.HasValue ? new long[] { padding.Value.Item1, padding.Value.Item2, padding.Value.Item3 } : null;
@@ -76,7 +70,7 @@ namespace TorchSharp
             /// <param name="strides">The stride of the sliding window, must be > 0. Default value is kernel_size.</param>
             /// <param name="padding">Implicit negative infinity padding to be added on both sides, must be >= 0 and less than or equal to kernel_size / 2</param>
             /// <returns></returns>
-            static public MaxUnpool3d MaxUnpool3d(long[] kernelSize, long[] strides = null, long[] padding = null)
+            public static MaxUnpool3d MaxUnpool3d(long[] kernelSize, long[] strides = null, long[] padding = null)
             {
                 unsafe {
                     fixed (long* pkernelSize = kernelSize, pstrides = strides, pPadding = padding) {

--- a/src/TorchSharp/NN/Recurrent/GRU.cs
+++ b/src/TorchSharp/NN/Recurrent/GRU.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -24,9 +24,6 @@ namespace TorchSharp
             private bool _bidirectional;
             private bool _batch_first;
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRU_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
-
             /// <summary>
             /// Applies a multi-layer gated recurrent unit (GRU) RNN to an input sequence.
             /// </summary>
@@ -48,9 +45,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero || hN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return (new Tensor(res), new Tensor(hN));
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_GRU_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
 
             /// <summary>
             /// Applies a multi-layer gated recurrent unit (GRU) RNN to an input sequence.
@@ -76,9 +70,6 @@ namespace TorchSharp
                 return (new torch.nn.utils.rnn.PackedSequence(res), new Tensor(hN));
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRU_flatten_parameters(torch.nn.Module.HType module);
-
             public void flatten_parameters()
             {
                 THSNN_GRU_flatten_parameters(handle);
@@ -91,9 +82,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GRU_ctor(long input_size, long hidden_size, long num_layers, bool bias, bool batchFirst, double dropout, bool bidirectional, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Creates multi-layer gated recurrent unit (GRU) RNN module.
             /// </summary>
@@ -107,7 +95,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public GRU GRU(long inputSize, long hiddenSize, long numLayers = 1, bool bias = true, bool batchFirst = false, double dropout = 0.0, bool bidirectional = false, Device device = null, ScalarType? dtype = null)
+            public static GRU GRU(long inputSize, long hiddenSize, long numLayers = 1, bool bias = true, bool batchFirst = false, double dropout = 0.0, bool bidirectional = false, Device device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_GRU_ctor(inputSize, hiddenSize, numLayers, bias, batchFirst, dropout, bidirectional, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/GRUCell.cs
+++ b/src/TorchSharp/NN/Recurrent/GRUCell.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -15,14 +15,11 @@ namespace TorchSharp
         {
             internal GRUCell(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            public new static GRUCell Load(String modelPath)
+            public new static GRUCell Load(string modelPath)
             {
                 var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new GRUCell(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0);
 
             /// <summary>
             /// Apply the GRU cell to an input tensor.
@@ -36,15 +33,6 @@ namespace TorchSharp
                 if (hN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(hN);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_bias_ih(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRUCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_bias_hh(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRUCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias_ih {
                 get {
@@ -71,15 +59,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("bias_hh", value);
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_weight_ih(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRUCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_GRUCell_weight_hh(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_GRUCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? weight_ih {
                 get {
@@ -113,9 +92,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_GRUCell_ctor(long input_size, long hidden_size, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// A gated recurrent unit (GRU) cell
             /// </summary>
@@ -124,7 +100,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <param name="bias">If False, then the layer does not use bias weights b_ih and b_hh. Default: True</param>
-            static public GRUCell GRUCell(long inputSize, long hiddenSize, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static GRUCell GRUCell(long inputSize, long hiddenSize, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_GRUCell_ctor(inputSize, hiddenSize, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/LSTM.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTM.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -24,9 +24,6 @@ namespace TorchSharp
             private long _num_layers;
             private bool _bidirectional;
             private bool _batch_first;
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTM_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, IntPtr c_0, out IntPtr h_n, out IntPtr c_n);
 
             /// <summary>
             /// Applies a multi-layer long short-term memory (LSTM) RNN to an input sequence.
@@ -53,9 +50,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero || hN == IntPtr.Zero || cN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return (new Tensor(res), new Tensor(hN), new Tensor(cN));
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_LSTM_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, IntPtr c_0, out IntPtr h_n, out IntPtr c_n);
 
             /// <summary>
             /// Applies a multi-layer long short-term memory (LSTM) RNN to an input sequence.
@@ -85,9 +79,6 @@ namespace TorchSharp
                 return (new torch.nn.utils.rnn.PackedSequence(res), new Tensor(hN), new Tensor(cN));
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTM_flatten_parameters(torch.nn.Module.HType module);
-
             public void flatten_parameters()
             {
                 THSNN_LSTM_flatten_parameters(handle);
@@ -100,9 +91,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LSTM_ctor(long input_size, long hidden_size, long num_layers, bool bias, bool batchFirst, double dropout, bool bidirectional, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Creates a multi-layer long short-term memory (LSTM) RNN module.
             /// </summary>
@@ -116,7 +104,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public LSTM LSTM(long inputSize, long hiddenSize, long numLayers = 1, bool bias = true, bool batchFirst = false, double dropout = 0.0, bool bidirectional = false, Device? device = null, ScalarType? dtype = null)
+            public static LSTM LSTM(long inputSize, long hiddenSize, long numLayers = 1, bool bias = true, bool batchFirst = false, double dropout = 0.0, bool bidirectional = false, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_LSTM_ctor(inputSize, hiddenSize, numLayers, bias, batchFirst, dropout, bidirectional, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/LSTMCell.cs
+++ b/src/TorchSharp/NN/Recurrent/LSTMCell.cs
@@ -1,9 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -16,14 +15,11 @@ namespace TorchSharp
         {
             internal LSTMCell(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
 
-            public new static LSTMCell Load(String modelPath)
+            public new static LSTMCell Load(string modelPath)
             {
                 var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new LSTMCell(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, IntPtr c_0, out IntPtr c_n);
 
             /// <summary>
             /// Apply the RNN cell to an input tensor.
@@ -37,15 +33,6 @@ namespace TorchSharp
                 if (hN == IntPtr.Zero || cN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return (new Tensor(hN), new Tensor(cN));
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_bias_ih(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTMCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_bias_hh(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTMCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias_ih {
                 get {
@@ -72,15 +59,6 @@ namespace TorchSharp
                     ConditionallyRegisterParameter("bias_hh", value);
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_weight_ih(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTMCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_LSTMCell_weight_hh(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_LSTMCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? weight_ih {
                 get {
@@ -114,9 +92,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LSTMCell_ctor(long input_size, long hidden_size, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// A long short-term memory (LSTM) cell.
             /// </summary>
@@ -125,7 +100,7 @@ namespace TorchSharp
             /// <param name="bias">If False, then the layer does not use bias weights b_ih and b_hh. Default: True</param>
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
-            static public LSTMCell LSTMCell(long inputSize, long hiddenSize, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static LSTMCell LSTMCell(long inputSize, long hiddenSize, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_LSTMCell_ctor(inputSize, hiddenSize, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/RNN.cs
+++ b/src/TorchSharp/NN/Recurrent/RNN.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -25,9 +25,6 @@ namespace TorchSharp
             private bool _bidirectional;
             private bool _batch_first;
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
-
             /// <summary>
             /// Applies a multi-layer Elman RNN with \tanhtanh or \text{ReLU}ReLU non-linearity to an input sequence.
             /// </summary>
@@ -48,9 +45,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero || hN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return (new Tensor(res), new Tensor(hN));
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static torch.nn.utils.rnn.PackedSequence.HType THSNN_RNN_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
 
             /// <summary>
             /// Applies a multi-layer Elman RNN with \tanhtanh or \text{ReLU}ReLU non-linearity to an input sequence.
@@ -75,19 +69,11 @@ namespace TorchSharp
                 return (new torch.nn.utils.rnn.PackedSequence(res), new Tensor(hN));
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNN_flatten_parameters(torch.nn.Module.HType module);
-
             public void flatten_parameters()
             {
                 THSNN_RNN_flatten_parameters(handle);
                 torch.CheckForErrors();
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_bias_ih(torch.nn.Module.HType module, long idx);
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_bias_hh(torch.nn.Module.HType module, long idx);
 
             public Parameter? get_bias_ih(long idx)
             {
@@ -105,11 +91,6 @@ namespace TorchSharp
 
 #if false   // Disabled until we can figure out how to set the native code parameters.
 
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNN_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor, long idx);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNN_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor, long idx);
-
             public void set_bias_ih(Tensor? value, long idx)
             {
                 THSNN_RNN_set_bias_ih(handle, (value is null ? IntPtr.Zero : value.Handle), idx);
@@ -124,11 +105,6 @@ namespace TorchSharp
                 ConditionallyRegisterParameter($"bias_hh_l{idx}", value);
             }
 #endif
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_weight_ih(torch.nn.Module.HType module, long idx);
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNN_weight_hh(torch.nn.Module.HType module, long idx);
 
             public Parameter? get_weight_ih(long idx)
             {
@@ -145,10 +121,6 @@ namespace TorchSharp
             }
 
 #if false   // Disabled until we can figure out how to set the native code parameters.
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNN_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor, long idx);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNN_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor, long idx);
             public void set_weight_ih(Tensor? value, long idx)
             {
                 THSNN_RNN_set_weight_ih(handle, (value is null ? IntPtr.Zero : value.Handle), idx);
@@ -176,9 +148,6 @@ namespace TorchSharp
                 Tanh = 1
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_RNN_ctor(long input_size, long hidden_size, long num_layers, long nonlinearity, bool bias, bool batchFirst, double dropout, bool bidirectional, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Creates an Elman RNN module with tanh or ReLU non-linearity.
             /// </summary>
@@ -193,7 +162,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public RNN RNN(long inputSize, long hiddenSize, long numLayers = 1, NonLinearities nonLinearity = nn.NonLinearities.Tanh, bool bias = true, bool batchFirst = false, double dropout = 0.0, bool bidirectional = false, Device? device = null, ScalarType? dtype = null)
+            public static RNN RNN(long inputSize, long hiddenSize, long numLayers = 1, NonLinearities nonLinearity = nn.NonLinearities.Tanh, bool bias = true, bool batchFirst = false, double dropout = 0.0, bool bidirectional = false, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_RNN_ctor(inputSize, hiddenSize, numLayers, (long)nonLinearity, bias, batchFirst, dropout, bidirectional, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Recurrent/RNNCell.cs
+++ b/src/TorchSharp/NN/Recurrent/RNNCell.cs
@@ -1,9 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -18,14 +17,11 @@ namespace TorchSharp
             {
             }
 
-            public new static RNNCell Load(String modelPath)
+            public new static RNNCell Load(string modelPath)
             {
                 var res = Module<Tensor, Tensor>.Load(modelPath);
                 return new RNNCell(res.handle.DangerousGetHandle(), IntPtr.Zero);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0);
 
             /// <summary>
             /// Apply the RNN cell to an input tensor.
@@ -39,15 +35,6 @@ namespace TorchSharp
                 if (hN == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(hN);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_bias_ih(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNNCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_bias_hh(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNNCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? bias_ih {
                 get {
@@ -76,15 +63,6 @@ namespace TorchSharp
 
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_weight_ih(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNNCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_RNNCell_weight_hh(torch.nn.Module.HType module);
-            [DllImport("LibTorchSharp")]
-            extern static void THSNN_RNNCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
 
             public Parameter? weight_ih {
                 get {
@@ -118,9 +96,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_RNNCell_ctor(long input_size, long hidden_size, long nonlinearity, bool bias, out IntPtr pBoxedModule);
-
             /// <summary>
             /// An Elman RNN cell with tanh or ReLU non-linearity.
             /// </summary>
@@ -131,7 +106,7 @@ namespace TorchSharp
             /// <param name="device">The desired device of the parameters and buffers in this module</param>
             /// <param name="dtype">The desired floating point or complex dtype of the parameters and buffers in this module</param>
             /// <returns></returns>
-            static public RNNCell RNNCell(long inputSize, long hiddenSize, NonLinearities nonLinearity = nn.NonLinearities.Tanh, bool bias = true, Device? device = null, ScalarType? dtype = null)
+            public static RNNCell RNNCell(long inputSize, long hiddenSize, NonLinearities nonLinearity = nn.NonLinearities.Tanh, bool bias = true, Device? device = null, ScalarType? dtype = null)
             {
                 var res = THSNN_RNNCell_ctor(inputSize, hiddenSize, (long)nonLinearity, bias, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Sequential.cs
+++ b/src/TorchSharp/NN/Sequential.cs
@@ -1,9 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 using static TorchSharp.torch;
 
@@ -165,19 +164,19 @@ namespace TorchSharp
                 foreach (var m in _modules) { ((torch.nn.Module)m).eval(); }
             }
 
-            internal protected override nn.Module _to(ScalarType dtype)
+            protected internal override nn.Module _to(ScalarType dtype)
             {
                 foreach (var m in _modules) { ((torch.nn.Module)m)._to(dtype); }
                 return this;
             }
 
-            internal protected override nn.Module _to(Device device, ScalarType dtype)
+            protected internal override nn.Module _to(Device device, ScalarType dtype)
             {
                 foreach (var m in _modules) { ((torch.nn.Module)m)._to(device, dtype); }
                 return this;
             }
 
-            internal protected override nn.Module _to(DeviceType deviceType, int deviceIndex = -1)
+            protected internal override nn.Module _to(DeviceType deviceType, int deviceIndex = -1)
             {
                 foreach (var m in _modules) { ((torch.nn.Module)m)._to(deviceType, deviceIndex); }
                 return this;
@@ -195,17 +194,13 @@ namespace TorchSharp
 
     public static partial class torch
     {
-
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Sequential_ctor();
-
             /// <summary>
             /// Get empty sequential
             /// </summary>
             /// <returns></returns>
-            static public Sequential Sequential()
+            public static Sequential Sequential()
             {
                 var handle = THSNN_Sequential_ctor();
                 if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
@@ -223,7 +218,7 @@ namespace TorchSharp
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <returns></returns>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(params (string name, torch.nn.Module<Tensor, Tensor> submodule)[] modules)
+            public static Sequential Sequential(params (string name, torch.nn.Module<Tensor, Tensor> submodule)[] modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)
@@ -240,7 +235,7 @@ namespace TorchSharp
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <returns></returns>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(params torch.nn.Module<Tensor, Tensor>[] modules)
+            public static Sequential Sequential(params torch.nn.Module<Tensor, Tensor>[] modules)
             {
                 var res = Sequential();
                 foreach (var m in modules)
@@ -257,7 +252,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(params System.Tuple<string, torch.nn.Module<Tensor, Tensor>>[] modules)
+            public static Sequential Sequential(params System.Tuple<string, torch.nn.Module<Tensor, Tensor>>[] modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)
@@ -274,7 +269,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(IEnumerable<(string name, torch.nn.Module<Tensor, Tensor> submodule)> modules)
+            public static Sequential Sequential(IEnumerable<(string name, torch.nn.Module<Tensor, Tensor> submodule)> modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)
@@ -291,7 +286,7 @@ namespace TorchSharp
             /// </summary>
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(IEnumerable<System.Tuple<string, torch.nn.Module<Tensor, Tensor>>> modules)
+            public static Sequential Sequential(IEnumerable<System.Tuple<string, torch.nn.Module<Tensor, Tensor>>> modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)
@@ -308,7 +303,7 @@ namespace TorchSharp
             /// <param name="modules">An ordered list of the contained modules.</param>
             /// <returns></returns>
             /// <remarks>Sequential will take ownership of the modules and dispose of them when disposed.</remarks>
-            static public Sequential Sequential(IEnumerable<torch.nn.Module<Tensor, Tensor>> modules)
+            public static Sequential Sequential(IEnumerable<torch.nn.Module<Tensor, Tensor>> modules)
             {
                 var res = Sequential();
                 foreach (var module in modules)

--- a/src/TorchSharp/NN/Transformer.cs
+++ b/src/TorchSharp/NN/Transformer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -12,9 +12,6 @@ namespace TorchSharp
         public sealed class Transformer : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal Transformer(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Transformer_forward(torch.nn.Module.HType module, IntPtr src, IntPtr tgt, IntPtr src_mask, IntPtr tgt_mask, IntPtr memory_mask, IntPtr src_key_padding_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
 
             /// <summary>
             /// Take in and process masked source/target sequences.
@@ -75,9 +72,6 @@ namespace TorchSharp
                 GELU = 1
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Transformer_ctor(long d_model, long nhead, long num_encoder_layers, long num_decoder_layers, long dim_feedforward, double dropout, long activation, out IntPtr pBoxedModule);
-
             /// <summary>
             /// A transformer model. User is able to modify the attributes as needed. The architecture is based on the paper “Attention Is All You Need”.
             /// </summary>
@@ -89,7 +83,7 @@ namespace TorchSharp
             /// <param name="dropout">The dropout value (default=0.1).</param>
             /// <param name="activation">The activation function of encoder/decoder intermediate layer, relu or gelu (default=relu).</param>
             /// <returns></returns>
-            static public Transformer Transformer(long d_model = 512, long nhead = 8, long num_encoder_layers = 6, long num_decoder_layers = 6, long dim_feedforward = 2048, double dropout = 0.1, Activations activation = nn.Activations.ReLU)
+            public static Transformer Transformer(long d_model = 512, long nhead = 8, long num_encoder_layers = 6, long num_decoder_layers = 6, long dim_feedforward = 2048, double dropout = 0.1, Activations activation = nn.Activations.ReLU)
             {
                 var res = THSNN_Transformer_ctor(d_model, nhead, num_encoder_layers, num_decoder_layers, dim_feedforward, dropout, (long)activation, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/TransformerDecoder.cs
+++ b/src/TorchSharp/NN/TransformerDecoder.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -12,9 +12,6 @@ namespace TorchSharp
         public sealed class TransformerDecoder : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal TransformerDecoder(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerDecoder_forward(torch.nn.Module.HType module, IntPtr tgt, IntPtr memory, IntPtr tgt_mask, IntPtr memory_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
 
             /// <summary>
             /// Pass the inputs (and mask) through the decoder layers in turn.
@@ -63,16 +60,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerDecoder_ctor(torch.nn.Module.HType decoder_layer, long num_layers, out IntPtr pBoxedModule);
-
             /// <summary>
             /// TransformerDecoder is a stack of N decoder layers
             /// </summary>
             /// <param name="decoder_layer">An instance of the TransformerDecoderLayer class (required).</param>
             /// <param name="num_layers">The number of sub-decoder-layers in the decoder (required).</param>
             /// <returns></returns>
-            static public TransformerDecoder TransformerDecoder(TransformerDecoderLayer decoder_layer, long num_layers)
+            public static TransformerDecoder TransformerDecoder(TransformerDecoderLayer decoder_layer, long num_layers)
             {
                 var res = THSNN_TransformerDecoder_ctor(decoder_layer.handle, num_layers, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/TransformerDecoderLayer.cs
+++ b/src/TorchSharp/NN/TransformerDecoderLayer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -12,9 +12,6 @@ namespace TorchSharp
         public sealed class TransformerDecoderLayer : torch.nn.Module<Tensor, Tensor, Tensor>
         {
             internal TransformerDecoderLayer(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerDecoderLayer_forward(torch.nn.Module.HType module, IntPtr tgt, IntPtr memory, IntPtr tgt_mask, IntPtr memory_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
 
             /// <summary>
             /// Pass the inputs (and mask) through the decoder layer.
@@ -63,9 +60,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerDecoderLayer_ctor(long d_model, long nhead, long dim_feedforward, double dropout, long activation, out IntPtr pBoxedModule);
-
             /// <summary>
             /// TransformerDecoderLayer is made up of self-attn, multi-head-attn and feedforward network. This standard decoder layer is based on the paper “Attention Is All You Need”.
             /// </summary>
@@ -75,7 +69,7 @@ namespace TorchSharp
             /// <param name="dropout">The dropout value (default=0.1).</param>
             /// <param name="activation">The activation function of intermediate layer, relu or gelu (default=relu).</param>
             /// <returns></returns>
-            static public TransformerDecoderLayer TransformerDecoderLayer(long d_model = 512, long nhead = 8, long dim_feedforward = 2048, double dropout = 0.1, Activations activation = nn.Activations.ReLU)
+            public static TransformerDecoderLayer TransformerDecoderLayer(long d_model = 512, long nhead = 8, long dim_feedforward = 2048, double dropout = 0.1, Activations activation = nn.Activations.ReLU)
             {
                 var res = THSNN_TransformerDecoderLayer_ctor(d_model, nhead, dim_feedforward, dropout, (long)activation, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/TransformerEncoder.cs
+++ b/src/TorchSharp/NN/TransformerEncoder.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             }
 
             internal TransformerEncoder(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerEncoder_forward(torch.nn.Module.HType module, IntPtr src, IntPtr src_mask, IntPtr src_key_padding_mask);
 
             /// <summary>
             /// Pass the input through the encoder layers in turn.
@@ -76,16 +73,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerEncoder_ctor(torch.nn.Module.HType encoder_layer, long num_layers, out IntPtr pBoxedModule);
-
             /// <summary>
             /// TransformerEncoder is a stack of N encoder layers
             /// </summary>
             /// <param name="encoder_layer">An instance of the TransformerEncoderLayer class (required).</param>
             /// <param name="num_layers">The number of sub-encoder-layers in the encoder (required).</param>
             /// <returns></returns>
-            static public TransformerEncoder TransformerEncoder(TransformerEncoderLayer encoder_layer, long num_layers)
+            public static TransformerEncoder TransformerEncoder(TransformerEncoderLayer encoder_layer, long num_layers)
             {
                 var res = THSNN_TransformerEncoder_ctor(encoder_layer.handle, num_layers, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/TransformerEncoderLayer.cs
+++ b/src/TorchSharp/NN/TransformerEncoderLayer.cs
@@ -1,11 +1,10 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
-    using System.Dynamic;
     using Modules;
 
     namespace Modules
@@ -13,9 +12,6 @@ namespace TorchSharp
         public sealed class TransformerEncoderLayer : torch.nn.Module<Tensor, Tensor>, torch.nn.IModule<Tensor, Tensor, Tensor>, torch.nn.IModule<Tensor, Tensor, Tensor, Tensor>
         {
             internal TransformerEncoderLayer(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerEncoderLayer_forward(torch.nn.Module.HType module, IntPtr src, IntPtr src_mask, IntPtr src_key_padding_mask);
 
             /// <summary>
             /// Pass the input through the encoder layer.
@@ -69,11 +65,8 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_TransformerEncoderLayer_ctor(long d_model, long nhead, long dim_feedforward, double dropout, long activation, out IntPtr pBoxedModule);
-
             /// <summary>
-            /// TransformerEncoderLayer is made up of self-attn and feedforward network. This standard encoder layer is based on the paper “Attention Is All You Need”. 
+            /// TransformerEncoderLayer is made up of self-attn and feedforward network. This standard encoder layer is based on the paper “Attention Is All You Need”.
             /// </summary>
             /// <param name="d_model">The number of expected features in the input (required).</param>
             /// <param name="nhead">The number of heads in the multiheadattention models (required).</param>
@@ -81,7 +74,7 @@ namespace TorchSharp
             /// <param name="dropout">The dropout value (default=0.1).</param>
             /// <param name="activation">The activation function of intermediate layer, relu or gelu (default=relu).</param>
             /// <returns></returns>
-            static public TransformerEncoderLayer TransformerEncoderLayer(long d_model = 512, long nhead = 8, long dim_feedforward = 2048, double dropout = 0.1, Activations activation = nn.Activations.ReLU)
+            public static TransformerEncoderLayer TransformerEncoderLayer(long d_model = 512, long nhead = 8, long dim_feedforward = 2048, double dropout = 0.1, Activations activation = nn.Activations.ReLU)
             {
                 var res = THSNN_TransformerEncoderLayer_ctor(d_model, nhead, dim_feedforward, dropout, (long)activation, out var boxedHandle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }

--- a/src/TorchSharp/NN/Unflatten.cs
+++ b/src/TorchSharp/NN/Unflatten.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -18,9 +18,6 @@ namespace TorchSharp
             {
             }
 
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Unflatten_forward(torch.nn.Module.HType module, IntPtr tensor);
-
             public override Tensor forward(Tensor tensor)
             {
                 var res = THSNN_Unflatten_forward(handle, tensor.Handle);
@@ -34,16 +31,13 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSNN_Unflatten_ctor(long dim, IntPtr shape, long shape_len, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Unflattens a tensor dim expanding it to a desired shape. For use with Sequential.
             /// </summary>
             /// <param name="dim">Dimension to be unflattened</param>
             /// <param name="unflattenedSize">New shape of the unflattened dimension</param>
             /// <returns></returns>
-            static public Unflatten Unflatten(long dim, long[] unflattenedSize)
+            public static Unflatten Unflatten(long dim, long[] unflattenedSize)
             {
                 unsafe {
                     fixed (long* pUnflattenedSize = unflattenedSize) {

--- a/src/TorchSharp/NN/Upsample.cs
+++ b/src/TorchSharp/NN/Upsample.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
@@ -12,10 +12,6 @@ namespace TorchSharp
     {
         public static partial class nn
         {
-            [DllImport("LibTorchSharp")]
-            // align_corners -- 0=None, 1=true, 2=false
-            extern static IntPtr THSNN_Upsample_ctor(IntPtr size, int size_length, IntPtr scale_factor, int scale_factor_length, byte mode, byte align_corners, out IntPtr pBoxedModule);
-
             /// <summary>
             /// Upsamples a given multi-channel 1D (temporal), 2D (spatial) or 3D (volumetric) data.
             /// The input data is assumed to be of the form minibatch x channels x[optional depth] x[optional height] x width.
@@ -27,7 +23,7 @@ namespace TorchSharp
             /// <param name="alignCorners">If true, the corner pixels of the input and output tensors are aligned, and thus preserving the values at those pixels.
             /// This only has effect when mode is 'linear', 'bilinear', or 'trilinear'. Default: false</param>
             /// <returns></returns>
-            static public Upsample Upsample(long[]? size = null, double[]? scale_factor = null, UpsampleMode mode = UpsampleMode.Nearest, bool? alignCorners = null)
+            public static Upsample Upsample(long[]? size = null, double[]? scale_factor = null, UpsampleMode mode = UpsampleMode.Nearest, bool? alignCorners = null)
             {
                 unsafe {
                     fixed (long* psize = size) {
@@ -55,7 +51,7 @@ namespace TorchSharp
                 /// <param name="alignCorners">If true, the corner pixels of the input and output tensors are aligned, and thus preserving the values at those pixels.
                 /// This only has effect when mode is 'linear', 'bilinear', or 'trilinear'. Default: false</param>
                 /// <returns></returns>
-                static public Tensor upsample(Tensor x, long[]? size = null, double[]? scale_factor = null, UpsampleMode mode = UpsampleMode.Nearest, bool alignCorners = false)
+                public static Tensor upsample(Tensor x, long[]? size = null, double[]? scale_factor = null, UpsampleMode mode = UpsampleMode.Nearest, bool alignCorners = false)
                 {
                     using (var d = nn.Upsample(size, scale_factor, mode, alignCorners)) {
                         return d.forward(x);
@@ -73,9 +69,6 @@ namespace TorchSharp
         public sealed class Upsample : torch.nn.Module<Tensor, Tensor>
         {
             internal Upsample(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle) { }
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_Upsample_forward(torch.nn.Module.HType module, IntPtr tensor);
 
             /// <summary>
             /// Forward pass.

--- a/src/TorchSharp/NN/Utils/PackedSequence.cs
+++ b/src/TorchSharp/NN/Utils/PackedSequence.cs
@@ -1,8 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -36,9 +35,6 @@ namespace TorchSharp
                             internal HType() : base(IntPtr.Zero, true)
                             {
                             }
-
-                            [DllImport("LibTorchSharp")]
-                            private static extern void THSNN_PackedSequence_dispose(IntPtr handle);
 
                             protected override bool ReleaseHandle()
                             {
@@ -94,19 +90,7 @@ namespace TorchSharp
                                 handle.SetHandleAsInvalid();
                             }
                         }
-
-                        [DllImport("LibTorchSharp")]
-                        private static extern IntPtr THSNN_PackedSequence_data(HType handle);
-
-                        [DllImport("LibTorchSharp")]
-                        private static extern IntPtr THSNN_PackedSequence_batch_sizes(HType handle);
-
-                        [DllImport("LibTorchSharp")]
-                        private static extern IntPtr THSNN_PackedSequence_sorted_indices(HType handle);
-
-                        [DllImport("LibTorchSharp")]
-                        private static extern IntPtr THSNN_PackedSequence_unsorted_indices(HType handle);
-                    }
+}
                 }
             }
         }

--- a/src/TorchSharp/NN/Utils/RNNUtils.cs
+++ b/src/TorchSharp/NN/Utils/RNNUtils.cs
@@ -2,8 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,18 +14,6 @@ namespace TorchSharp
             {
                 public static partial class rnn
                 {
-                    [DllImport("LibTorchSharp")]
-                    private static extern PackedSequence.HType THSNN_pack_padded_sequence(IntPtr input, IntPtr lengths, bool batch_first, bool enforce_sorted);
-
-                    [DllImport("LibTorchSharp")]
-                    private static extern void THSNN_pad_packed_sequence(PackedSequence.HType sequence, bool batch_first, double padding_value, long total_length, out IntPtr res1, out IntPtr res2);
-
-                    [DllImport("LibTorchSharp")]
-                    private static extern IntPtr THSNN_pad_sequence(IntPtr[] sequences, int sequences_len, bool batch_first, double padding_value);
-
-                    [DllImport("LibTorchSharp")]
-                    private static extern PackedSequence.HType THSNN_pack_sequence(IntPtr[] sequences, int sequences_len, bool enforce_sorted);
-
                     /// <summary>
                     /// Pack a padded sequences.
                     /// </summary>

--- a/src/TorchSharp/NN/Vision.cs
+++ b/src/TorchSharp/NN/Vision.cs
@@ -1,13 +1,12 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
 {
     public static partial class torch
     {
-
         public enum UpsampleMode
         {
             Nearest = 0,
@@ -48,21 +47,6 @@ namespace TorchSharp
 
             public static partial class functional
             {
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_pad(IntPtr input, IntPtr pad, int pad_length, byte mode, double value);
-
-                [DllImport("LibTorchSharp")]
-                // align_corners -- 0=None, 1=true, 2=false
-                private static extern IntPtr THSNN_interpolate(IntPtr input, IntPtr size, int size_len, IntPtr scale_factor, int scale_factor_len, byte mode, byte align_corners, bool recompute_scale_factor);
-
-
-                [DllImport("LibTorchSharp")]
-                // align_corners -- 0=None, 1=true, 2=false
-                private static extern IntPtr THSNN_grid_sample(IntPtr input, IntPtr grid, byte mode, byte padding_mode, byte align_corners);
-
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_affine_grid(IntPtr theta, IntPtr size, int size_len, bool align_corners);
-
 
                 /// <summary>
                 /// Pads tensor.
@@ -72,7 +56,7 @@ namespace TorchSharp
                 /// <param name="mode">'constant', 'reflect', 'replicate' or 'circular'. Default: 'constant'</param>
                 /// <param name="value">Fill value for 'constant' padding. Default: 0</param>
                 /// <returns></returns>
-                static public Tensor pad(Tensor input, long[] pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
+                public static Tensor pad(Tensor input, long[] pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
                 {
                     unsafe {
                         fixed (long* psize = pad) {
@@ -91,7 +75,7 @@ namespace TorchSharp
                 /// <param name="mode">'constant', 'reflect', 'replicate' or 'circular'. Default: 'constant'</param>
                 /// <param name="value">Fill value for 'constant' padding. Default: 0</param>
                 /// <returns></returns>
-                static public Tensor pad(Tensor input, ReadOnlySpan<long> pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
+                public static Tensor pad(Tensor input, ReadOnlySpan<long> pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
                 {
                     unsafe {
                         fixed (long* psize = pad) {
@@ -110,7 +94,7 @@ namespace TorchSharp
                 /// <param name="mode">'constant', 'reflect', 'replicate' or 'circular'. Default: 'constant'</param>
                 /// <param name="value">Fill value for 'constant' padding. Default: 0</param>
                 /// <returns></returns>
-                static public Tensor pad(Tensor input, (long, long) pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
+                public static Tensor pad(Tensor input, (long, long) pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
                 {
                     unsafe {
                         var correctedPad = stackalloc long[] { pad.Item1, pad.Item2 };
@@ -129,7 +113,7 @@ namespace TorchSharp
                 /// <param name="mode">'constant', 'reflect', 'replicate' or 'circular'. Default: 'constant'</param>
                 /// <param name="value">Fill value for 'constant' padding. Default: 0</param>
                 /// <returns></returns>
-                static public Tensor pad(Tensor input, (long, long, long, long) pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
+                public static Tensor pad(Tensor input, (long, long, long, long) pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
                 {
                     unsafe {
                         var correctedPad = stackalloc long[] { pad.Item1, pad.Item2, pad.Item3, pad.Item4 };
@@ -147,7 +131,7 @@ namespace TorchSharp
                 /// <param name="mode">'constant', 'reflect', 'replicate' or 'circular'. Default: 'constant'</param>
                 /// <param name="value">Fill value for 'constant' padding. Default: 0</param>
                 /// <returns></returns>
-                static public Tensor pad(Tensor input, long pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
+                public static Tensor pad(Tensor input, long pad, PaddingModes mode = PaddingModes.Constant, double value = 0)
                 {
                     int length = (int)input.ndim * 2;
 
@@ -177,7 +161,7 @@ namespace TorchSharp
                 /// Currently, only spatial (4-D) and volumetric (5-D) input are supported.
                 /// Note: mode='bicubic' supports only 4-D input.
                 /// </remarks>
-                static public Tensor grid_sample(Tensor input, Tensor grid, GridSampleMode mode = GridSampleMode.Bilinear, GridSamplePaddingMode padding_mode = GridSamplePaddingMode.Zeros, bool? align_corners = null)
+                public static Tensor grid_sample(Tensor input, Tensor grid, GridSampleMode mode = GridSampleMode.Bilinear, GridSamplePaddingMode padding_mode = GridSamplePaddingMode.Zeros, bool? align_corners = null)
                 {
                     byte ac = (byte)((align_corners.HasValue) ? (align_corners.Value ? 1 : 2) : 0);
                     var res = THSNN_grid_sample(input.Handle, grid.Handle, (byte)mode, (byte)padding_mode, ac);
@@ -193,7 +177,7 @@ namespace TorchSharp
                 /// <param name="align_corners">if true, consider -1 and 1 to refer to the centers of the corner pixels rather than the image corners.
                 /// Refer to grid_sample() for a more complete description.</param>
                 /// <returns></returns>
-                static public Tensor affine_grid(Tensor theta, long[]? size = null, bool align_corners = false)
+                public static Tensor affine_grid(Tensor theta, long[]? size = null, bool align_corners = false)
                 {
                     unsafe {
                         fixed (long* psize = size) {
@@ -205,7 +189,7 @@ namespace TorchSharp
                 }
 
                 /// <summary>
-                /// 
+                ///
                 /// </summary>
                 /// <param name="x">The input tensor</param>
                 /// <param name="size">Output spatial size</param>
@@ -222,7 +206,7 @@ namespace TorchSharp
                 /// (i.e. the computation will be identical to if the computed output_size were passed-in explicitly).
                 /// </param>
                 /// <returns></returns>
-                static public Tensor interpolate(Tensor x, long[]? size = null, double[]? scale_factor = null, InterpolationMode mode = InterpolationMode.Nearest, bool? align_corners = null, bool recompute_scale_factor = false)
+                public static Tensor interpolate(Tensor x, long[]? size = null, double[]? scale_factor = null, InterpolationMode mode = InterpolationMode.Nearest, bool? align_corners = null, bool recompute_scale_factor = false)
                 {
                     unsafe {
                         fixed (long* psize = size) {
@@ -247,7 +231,7 @@ namespace TorchSharp
                 /// <param name="align_corners">If true, the corner pixels of the input and output tensors are aligned, and thus preserving the values at those pixels.
                 /// This only has effect when mode is 'linear', 'bilinear', or 'trilinear'. Default: false</param>
                 /// <returns></returns>
-                static public Tensor upsample_bilinear(Tensor x, long[]? size = null, double[]? scale_factor = null, bool align_corners = false)
+                public static Tensor upsample_bilinear(Tensor x, long[]? size = null, double[]? scale_factor = null, bool align_corners = false)
                 {
                     using (var d = torch.nn.Upsample(size, scale_factor, UpsampleMode.Bilinear, align_corners)) {
                         return d.forward(x);
@@ -265,7 +249,7 @@ namespace TorchSharp
                 /// <param name="align_corners">If true, the corner pixels of the input and output tensors are aligned, and thus preserving the values at those pixels.
                 /// This only has effect when mode is 'linear', 'bilinear', or 'trilinear'. Default: false</param>
                 /// <returns></returns>
-                static public Tensor upsample_nearest(Tensor x, long[]? size = null, double[]? scale_factor = null, bool align_corners = false)
+                public static Tensor upsample_nearest(Tensor x, long[]? size = null, double[]? scale_factor = null, bool align_corners = false)
                 {
                     using (var d = torch.nn.Upsample(size, scale_factor, UpsampleMode.Nearest, align_corners)) {
                         return d.forward(x);

--- a/src/TorchSharp/Optimizers/Adagrad.cs
+++ b/src/TorchSharp/Optimizers/Adagrad.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using static TorchSharp.torch;
-using static TorchSharp.torch.optim;
 
 namespace TorchSharp
 {

--- a/src/TorchSharp/Optimizers/LBFGS.cs
+++ b/src/TorchSharp/Optimizers/LBFGS.cs
@@ -2,8 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -13,10 +13,6 @@ namespace TorchSharp
     {
         public static partial class optim
         {
-
-            [DllImport("LibTorchSharp")]
-            private static extern IntPtr THSNN_LBFGS_ctor(IntPtr parameters, int len, double learningRate, long max_iter, long max_eval, double tolerange_grad, double tolerance_change, long history_size);
-
             /// <summary>
             /// Implements the L-BFGS algorithm, heavily inspired by `minFunc`
             ///
@@ -69,7 +65,7 @@ namespace TorchSharp
         {
             /// <summary>
             /// Implements L-BFGS algorithm, heavily inspired by `minFunc`
-            /// 
+            ///
             /// </summary>
             /// <param name="handle"></param>
             /// <param name="lr"></param>
@@ -79,9 +75,6 @@ namespace TorchSharp
                 InitialLearningRate = lr;
                 _paramGroups = new ParamGroup[] { new ParamGroup { Parameters = this.parameters(), Options = new() { LearningRate = lr, InitialLearningRate = lr } } };
             }
-
-            [DllImport("LibTorchSharp")]
-            private static extern void THSNN_LBFGS_set_lr(HType optimizer, double lr);
 
             public double LearningRate {
                 get { return _rate; }

--- a/src/TorchSharp/Optimizers/LRScheduler.cs
+++ b/src/TorchSharp/Optimizers/LRScheduler.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Transactions;
 
 // All LR schedulers in this file are directly based on the Pytorch implementation at:
 //

--- a/src/TorchSharp/Optimizers/Optimizer.cs
+++ b/src/TorchSharp/Optimizers/Optimizer.cs
@@ -4,11 +4,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using static TorchSharp.torch;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
     using System.IO;
-    using Google.Protobuf.WellKnownTypes;
     using Modules;
     using TorchSharp.Utils;
 
@@ -37,9 +37,6 @@ namespace TorchSharp
                     internal HType() : base(IntPtr.Zero, true)
                     {
                     }
-
-                    [DllImport("LibTorchSharp")]
-                    private static extern void THSNN_Optimizer_dispose(HType handle);
 
                     protected override bool ReleaseHandle()
                     {
@@ -93,9 +90,6 @@ namespace TorchSharp
                     }
                 }
 
-                [DllImport("LibTorchSharp")]
-                private static extern void THSNN_Optimizer_zero_grad(HType module);
-
                 /// <summary>
                 /// Sets the gradients of all parameters to zero.
                 /// </summary>
@@ -119,9 +113,6 @@ namespace TorchSharp
                 }
 
 
-                [DllImport("LibTorchSharp")]
-                private static extern IntPtr THSNN_Optimizer_step(HType module, LossClosure closure);
-
                 /// <summary>
                 /// Performs a single optimization step (parameter update).
                 /// </summary>
@@ -140,9 +131,6 @@ namespace TorchSharp
 
                     return (res == IntPtr.Zero) ? null : new Tensor(res);
                 }
-
-                [DllImport("LibTorchSharp")]
-                private static extern void THSNN_Optimizer_getParameters(HType module, AllocatePinnedArray allocator);
 
                 /// <summary>
                 /// Get the parameters that the optimizer is handling.

--- a/src/TorchSharp/Optimizers/SGD.cs
+++ b/src/TorchSharp/Optimizers/SGD.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using static TorchSharp.torch;
 
 namespace TorchSharp

--- a/src/TorchSharp/PInvoke/GCHandleDeleter.cs
+++ b/src/TorchSharp/PInvoke/GCHandleDeleter.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void GCHandleDeleter(IntPtr memory);
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSAutograd.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSAutograd.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSAutograd_isGradEnabled();
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSAutograd_setGrad(bool enabled);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSAutograd_grad(
+            IntPtr outputs, long oLength,
+            IntPtr inputs, long iLength,
+            IntPtr grad_outs, long gLength,
+            [MarshalAs(UnmanagedType.U1)] bool retain_graph,
+            [MarshalAs(UnmanagedType.U1)] bool create_graph,
+            [MarshalAs(UnmanagedType.U1)] bool allow_unused,
+            AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSAutograd_backward(
+            IntPtr tensors, long tLength,
+            IntPtr grad_tensors, long gtLength,
+            [MarshalAs(UnmanagedType.U1)] bool retain_graph,
+            [MarshalAs(UnmanagedType.U1)] bool create_graph,
+            IntPtr inputs, long iLength);
+
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSCuda.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSCuda.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSCuda_manual_seed(long seed);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSCuda_manual_seed_all(long seed);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSCuda_synchronize(long device_index);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSData.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSData_loaderMNIST(
+            [MarshalAs(UnmanagedType.LPStr)] string filename,
+            long batchSize,
+            bool isTrain);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSData_loaderCIFAR10(
+            [MarshalAs(UnmanagedType.LPStr)] string path,
+            long batchSize,
+            bool isTrain);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSData_current(IntPtr iterator, IntPtr data, IntPtr target);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSData_moveNext(IntPtr iterator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSData_size(IntPtr iterator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSData_reset(IntPtr iterator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSData_dispose(IntPtr iterator);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSGenerator.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSGenerator.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSGenerator_initial_seed(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSGenerator_get_rng_state(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSGenerator_set_rng_state(IntPtr handle, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSGenerator_gen_manual_seed(IntPtr handle, long seed);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSGenerator_new(ulong seed, long device_type, long device_index);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSGenerator_default_generator();
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSGenerator_dispose(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSGenerator_manual_seed(long seed);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSInit.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSInit.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern double THSInit_calculate_gain(long nonlinearity, double param);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_constant_(IntPtr tensor, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_dirac_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_eye_(IntPtr matrix);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_normal_(IntPtr tensor, double mean, double std);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_trunc_normal_(IntPtr tensor, double mean, double std, double a, double b);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_ones_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_orthogonal_(IntPtr tensor, double gain);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_sparse_(IntPtr tensor, double sparsity, double std);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_uniform_(IntPtr tensor, double low, double high);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_kaiming_normal_(IntPtr tensor, double a, long mode, long nonlinearity);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_kaiming_uniform_(IntPtr tensor, double a, long mode, long nonlinearity);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_xavier_normal_(IntPtr tensor, double gain);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_xavier_uniform_(IntPtr tensor, double gain);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSInit_zeros_(IntPtr tensor);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSJIT.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSJIT.cs
@@ -1,0 +1,103 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_CompilationUnit_Invoke(IntPtr module, string name, IntPtr tensors, int length, AllocatePinnedArray allocator, out sbyte typeCode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_CompilationUnit_dispose(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSJIT_compile(string script);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_dispose(torch.nn.Module.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_named_parameters(torch.nn.Module.HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_named_buffers(torch.nn.Module.HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_named_modules(torch.nn.Module.HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_named_children(torch.nn.Module.HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSJIT_getNumModules(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern int THSJIT_Module_num_inputs(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern int THSJIT_Module_num_outputs(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_train(torch.nn.Module.HType module, bool on);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_eval(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSJIT_Module_is_training(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_to_device(torch.nn.Module.HType module, long deviceType, long deviceIndex);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_to_device_dtype(torch.nn.Module.HType module, sbyte dtype, long deviceType, long deviceIndex);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_to_dtype(torch.nn.Module.HType module, sbyte dtype);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSJIT_Module_getInputType(torch.nn.Module.HType module, int index);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSJIT_getOutputType(torch.jit.Type.HType module, int index);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_forward(torch.nn.Module.HType module, IntPtr tensors, int length, AllocatePinnedArray allocator, out sbyte typeCode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Module_invoke(torch.nn.Module.HType module, string name, IntPtr tensors, int length, AllocatePinnedArray allocator, out sbyte typeCode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSJIT_load(string filename, long deviceType, long deviceIndex);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_save(torch.nn.Module.HType handle, string filename);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSJIT_TensorType_sizes(torch.jit.Type.HType handle, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern int THSJIT_getDimensionedTensorTypeDimensions(torch.jit.Type.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern string THSJIT_getDimensionedTensorDevice(torch.jit.Type.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern sbyte THSJIT_TensorType_dtype(torch.jit.Type.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_Type_dispose(torch.jit.Type.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSJIT_TensorType_dispose(torch.jit.Type.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern sbyte THSJIT_Type_kind(torch.jit.Type.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSJIT_Type_cast(torch.jit.Type.HType module);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSLinalg.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSLinalg.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_cholesky(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_cholesky_ex(IntPtr tensor, bool check_errors, out IntPtr pInfo);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_cond_int(IntPtr tensor, int p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_cond_float(IntPtr tensor, double p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_cond_str(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_cond_none(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_cross(IntPtr input, IntPtr other, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_det(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_slogdet(IntPtr tensor, out IntPtr pLogabsdet);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_eig(IntPtr tensor, out IntPtr pEigenvectors);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_eigh(IntPtr tensor, byte UPLO, out IntPtr pEigenvectors);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_eigvals(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_eigvalsh(IntPtr tensor, byte UPLO);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_inv(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_inv_ex(IntPtr tensor, bool check_errors, out IntPtr pInfo);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_lstsq_none(IntPtr tensor, IntPtr other, out IntPtr pResiduals, out IntPtr pRank, out IntPtr pSingularValues);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_lstsq_rcond(IntPtr tensor, IntPtr other, double rcond, out IntPtr pResiduals, out IntPtr pRank, out IntPtr pSingularValues);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_lu_factor(IntPtr tensor, bool pivot, out IntPtr pPivots);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_matrix_norm_fronuc(IntPtr tensor, byte fronuc, IntPtr dim, int dim_length, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_matrix_norm(IntPtr tensor, IntPtr ord, IntPtr dim, int dim_length, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_matrix_rank(IntPtr tensor, double atol, bool has_atol, double rtol, bool has_rtol, bool hermitian);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_matrix_rank_tensor(IntPtr tensor, IntPtr atol, IntPtr rtol, bool hermitian);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_multi_dot(IntPtr tensor, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_norm_str(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string p, IntPtr dim, int dim_length, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_norm_float(IntPtr tensor, double p, IntPtr dim, int dim_length, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_norm_int(IntPtr tensor, int p, IntPtr dim, int dim_length, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_norm_opt(IntPtr tensor, IntPtr dim, int dim_length, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_pinv(IntPtr tensor, double atol, bool has_atol, double rtol, bool has_rtol, bool hermitian);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_pinv_tensor(IntPtr tensor, IntPtr atol, IntPtr rtol, bool hermitian);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_qr(IntPtr tensor, byte mode, out IntPtr pR);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_solve(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_svd(IntPtr tensor, bool fullMatrices, out IntPtr pS, out IntPtr pVh);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_svdvals(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_tensorinv(IntPtr tensor, long ind);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_tensorsolve(IntPtr tensor, IntPtr other, IntPtr dim, int dim_length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_vector_norm(IntPtr tensor, IntPtr ord, IntPtr dim, int dim_length, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_matrix_power(IntPtr tensor, long n);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_pinverse(IntPtr tensor, double rcond, bool hermitian);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSNN.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSNN.cs
@@ -1,0 +1,1260 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {[DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_save(
+            torch.nn.Module.HType handle,
+            [MarshalAs(UnmanagedType.LPStr)] string location);
+
+        [DllImport("LibTorchSharp")]
+        [return: MarshalAs(UnmanagedType.LPStr)]
+        internal static extern string THSNN_Module_name(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_custom_module(
+            [MarshalAs(UnmanagedType.LPStr)] string name,
+            ForwardFunctionC forward,
+            out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern torch.nn.utils.rnn.PackedSequence.HType THSNN_RNN_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern torch.nn.utils.rnn.PackedSequence.HType THSNN_pack_padded_sequence(IntPtr input, IntPtr lengths, bool batch_first, bool enforce_sorted);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern torch.nn.utils.rnn.PackedSequence.HType THSNN_pack_sequence(IntPtr[] sequences, int sequences_len, bool enforce_sorted);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern torch.nn.utils.rnn.PackedSequence.HType THSNN_LSTM_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, IntPtr c_0, out IntPtr h_n, out IntPtr c_n);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern torch.nn.utils.rnn.PackedSequence.HType THSNN_GRU_forward_with_packed_input(torch.nn.Module.HType module, torch.nn.utils.rnn.PackedSequence.HType input, IntPtr h_0, out IntPtr h_n);
+
+        [DllImport("LibTorchSharp")]
+        // align_corners -- 0=None, 1=true, 2=false
+        internal static extern IntPtr THSNN_Upsample_ctor(IntPtr size, int size_length, IntPtr scale_factor, int scale_factor_length, byte mode, byte align_corners, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        // align_corners -- 0=None, 1=true, 2=false
+        internal static extern IntPtr THSNN_interpolate(IntPtr input, IntPtr size, int size_len, IntPtr scale_factor, int scale_factor_len, byte mode, byte align_corners, bool recompute_scale_factor);
+
+        [DllImport("LibTorchSharp")]
+        // align_corners -- 0=None, 1=true, 2=false
+        internal static extern IntPtr THSNN_grid_sample(IntPtr input, IntPtr grid, byte mode, byte padding_mode, byte align_corners);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AlphaDropout_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AlphaDropout_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_alpha_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Bilinear_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Bilinear_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Bilinear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Bilinear_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Bilinear_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Bilinear_ctor(long in1_features, long in2_features, long output_size, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_functional_bilinear(IntPtr input1, IntPtr input2, IntPtr weights, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_CosineSimilarity_ctor(long dim, double eps, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_CosineSimilarity_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Dropout_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Dropout_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Dropout2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Dropout2d_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_dropout2d(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Embedding_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Embedding_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Embedding_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Embedding_ctor(long num_embeddings, long embedding_dims, long padding_idx, bool hasPI, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, bool sparse, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Embedding_from_pretrained(IntPtr embeddings, bool freeze, long padding_idx, bool hasPI, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, bool sparse, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Dropout3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Dropout3d_ctor(double p, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_dropout3d(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_EmbeddingBag_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr offsets, IntPtr per_sample_weights);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_EmbeddingBag_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_EmbeddingBag_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_EmbeddingBag_ctor(long num_embeddings, long embedding_dims, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, long mode, bool sparse, bool include_last_offset, long padding_idx, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_EmbeddingBag_from_pretrained(IntPtr embeddings, bool freeze, double max_norm, bool hasMN, double norm_type, bool scale_grad_by_freq, long mode, bool sparse, bool include_last_offset, long padding_idx, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_FeatureAlphaDropout_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_FeatureAlphaDropout_ctor(double p, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_feature_alpha_dropout(IntPtr input, double p, [MarshalAs(UnmanagedType.U1)] bool training, [MarshalAs(UnmanagedType.U1)] bool inplace);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long ignore_index, bool hasII, long reduction, double smooting);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_binary_cross_entropy(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_binary_cross_entropy_with_logits(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction, IntPtr posWeights);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_cosine_embedding_loss(IntPtr input1, IntPtr input2, IntPtr trgt, double margin, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ctc_loss(IntPtr log_probs, IntPtr targets, IntPtr input_lengths, IntPtr target_lengths, long blank, bool zero_infinity, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_hinge_embedding_loss(IntPtr input, IntPtr trgt, double margin, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_huber_loss(IntPtr input, IntPtr trgt, double delta, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_margin_ranking_loss(IntPtr input1, IntPtr input2, IntPtr target, double margin, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_multilabel_margin_loss(IntPtr input, IntPtr target, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_multilabel_soft_margin_loss(IntPtr input, IntPtr target, IntPtr weight, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_multi_margin_loss(IntPtr input, IntPtr target, long p, double margin, IntPtr weight, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_mse_loss(IntPtr srct, IntPtr trgt, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_l1_loss(IntPtr srct, IntPtr trgt, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_nll_loss(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_poisson_loss(IntPtr srct, IntPtr trgt, bool logInput, bool full, float eps, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_kl_div_loss(IntPtr input, IntPtr target, long reduction, bool logTarget);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_smooth_l1_loss(IntPtr srct, IntPtr trgt, long reduction, double beta);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_soft_margin_loss(IntPtr srct, IntPtr trgt, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_triplet_margin_loss(IntPtr anchor, IntPtr positive, IntPtr negative, double margin, long p, double eps, bool swap, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_triplet_margin_with_distance_loss(IntPtr anchor, IntPtr positive, IntPtr negative, DistanceFunctionNative? distance_function, double margin, bool swap, long reduction);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Optimizer_dispose(torch.optim.Optimizer.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Optimizer_zero_grad(torch.optim.Optimizer.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Optimizer_step(torch.optim.Optimizer.HType module, torch.optim.Optimizer.LossClosure closure);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Optimizer_getParameters(torch.optim.Optimizer.HType module, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_dispose(torch.nn.Module.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_to_device_dtype(torch.nn.Module.HType module, sbyte dtype, long deviceType, long deviceIndex);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_to_device(torch.nn.Module.HType module, long deviceType, long deviceIndex);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_to_dtype(torch.nn.Module.HType module, sbyte dtype);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Module_load([MarshalAs(UnmanagedType.LPStr)] string location);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_train(torch.nn.Module.HType module, bool on);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_eval(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSNN_Module_is_training(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_zero_grad(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_get_named_parameters(torch.nn.Module.HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_get_named_buffers(torch.nn.Module.HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Module_get_parameters(torch.nn.Module.HType module, AllocatePinnedArray allocator, bool recurse);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_AnyModule_dispose(torch.nn.BoxedModule.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNN_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNN_flatten_parameters(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNN_bias_ih(torch.nn.Module.HType module, long idx);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNN_bias_hh(torch.nn.Module.HType module, long idx);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNN_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor, long idx);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNN_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor, long idx);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNN_weight_ih(torch.nn.Module.HType module, long idx);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNN_weight_hh(torch.nn.Module.HType module, long idx);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNN_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor, long idx);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNN_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor, long idx);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNN_ctor(long input_size, long hidden_size, long num_layers, long nonlinearity, bool bias, bool batchFirst, double dropout, bool bidirectional, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNNCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNNCell_bias_ih(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNNCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNNCell_bias_hh(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNNCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNNCell_weight_ih(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNNCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNNCell_weight_hh(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_RNNCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RNNCell_ctor(long input_size, long hidden_size, long nonlinearity, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Linear_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Linear_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Linear_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Linear_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Linear_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Linear_ctor(long input_size, long output_size, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_functional_linear(IntPtr input, IntPtr weights, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Flatten_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Flatten_ctor(long startDim, long endDim, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Identity_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Identity_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LSTMCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, IntPtr c_0, out IntPtr c_n);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LSTMCell_bias_ih(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_LSTMCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LSTMCell_bias_hh(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_LSTMCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LSTMCell_weight_ih(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_LSTMCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LSTMCell_weight_hh(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_LSTMCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LSTMCell_ctor(long input_size, long hidden_size, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_PackedSequence_dispose(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PackedSequence_data(torch.nn.utils.rnn.PackedSequence.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PackedSequence_batch_sizes(torch.nn.utils.rnn.PackedSequence.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PackedSequence_sorted_indices(torch.nn.utils.rnn.PackedSequence.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PackedSequence_unsorted_indices(torch.nn.utils.rnn.PackedSequence.HType handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_pad_packed_sequence(torch.nn.utils.rnn.PackedSequence.HType sequence, bool batch_first, double padding_value, long total_length, out IntPtr res1, out IntPtr res2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_pad_sequence(IntPtr[] sequences, int sequences_len, bool batch_first, double padding_value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_MultiheadAttention_forward(torch.nn.Module.HType module, IntPtr query, IntPtr key, IntPtr value, IntPtr key_padding_mask, bool need_weights, IntPtr attn_mask, out IntPtr res1, out IntPtr res2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MultiheadAttention_ctor(long embeded_dim, long num_heads, double dropout, bool bias, bool add_bias_kv, bool add_zero_attn, long kdim, long vdim, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_one_hot(IntPtr self, long num_classes);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PairwiseDistance_forward(torch.nn.Module.HType module, IntPtr input1, IntPtr input2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PairwiseDistance_ctor(double p, double eps, [MarshalAs(UnmanagedType.U1)] bool keep_dim, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PixelUnshuffle_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PixelUnshuffle_ctor(long downscaleFactor, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PixelShuffle_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_PixelShuffle_ctor(long upscaleFactor, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GRUCell_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GRUCell_bias_ih(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_GRUCell_set_bias_ih(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GRUCell_bias_hh(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_GRUCell_set_bias_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GRUCell_weight_ih(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_GRUCell_set_weight_ih(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GRUCell_weight_hh(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_GRUCell_set_weight_hh(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GRUCell_ctor(long input_size, long hidden_size, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LSTM_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, IntPtr c_0, out IntPtr h_n, out IntPtr c_n);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_LSTM_flatten_parameters(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LSTM_ctor(long input_size, long hidden_size, long num_layers, bool bias, bool batchFirst, double dropout, bool bidirectional, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_GRU_flatten_parameters(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GRU_ctor(long input_size, long hidden_size, long num_layers, bool bias, bool batchFirst, double dropout, bool bidirectional, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GRU_forward(torch.nn.Module.HType module, IntPtr input, IntPtr h_0, out IntPtr h_n);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LBFGS_ctor(IntPtr parameters, int len, double learningRate, long max_iter, long max_eval, double tolerange_grad, double tolerance_change, long history_size);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_LBFGS_set_lr(torch.optim.Optimizer.HType optimizer, double lr);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Sequential_ctor();
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Transformer_forward(torch.nn.Module.HType module, IntPtr src, IntPtr tgt, IntPtr src_mask, IntPtr tgt_mask, IntPtr memory_mask, IntPtr src_key_padding_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Transformer_ctor(long d_model, long nhead, long num_encoder_layers, long num_decoder_layers, long dim_feedforward, double dropout, long activation, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_TransformerDecoder_forward(torch.nn.Module.HType module, IntPtr tgt, IntPtr memory, IntPtr tgt_mask, IntPtr memory_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_TransformerDecoder_ctor(torch.nn.Module.HType decoder_layer, long num_layers, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_TransformerDecoderLayer_forward(torch.nn.Module.HType module, IntPtr tgt, IntPtr memory, IntPtr tgt_mask, IntPtr memory_mask, IntPtr tgt_key_padding_mask, IntPtr memory_key_padding_mask);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_TransformerDecoderLayer_ctor(long d_model, long nhead, long dim_feedforward, double dropout, long activation, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_TransformerEncoderLayer_forward(torch.nn.Module.HType module, IntPtr src, IntPtr src_mask, IntPtr src_key_padding_mask);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_TransformerEncoderLayer_ctor(long d_model, long nhead, long dim_feedforward, double dropout, long activation, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Upsample_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_TransformerEncoder_ctor(torch.nn.Module.HType encoder_layer, long num_layers, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_TransformerEncoder_forward(torch.nn.Module.HType module, IntPtr src, IntPtr src_mask, IntPtr src_key_padding_mask);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_pad(IntPtr input, IntPtr pad, int pad_length, byte mode, double value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_affine_grid(IntPtr theta, IntPtr size, int size_len, bool align_corners);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_CELU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_CELU_ctor(double alpha, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LeakyReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LeakyReLU_ctor(double negative_slope, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LogSoftmax_forward(torch.nn.Module.HType handle, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LogSoftmax_ctor(long dim, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm3d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm3d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm3d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm3d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm3d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm3d_reset_stats(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm3d_get_mean(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm3d_get_var(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm3d_get_batches(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm3d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm3d_set_var(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm3d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LayerNorm_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LayerNorm_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_LayerNorm_set_bias(torch.nn.Module.HType module, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LayerNorm_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_LayerNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LayerNorm_ctor(IntPtr norm_shape, long norm_shape_len, double eps, [MarshalAs(UnmanagedType.U1)] bool elementwise_affine, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm2d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm2d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm2d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm2d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm2d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm2d_reset_stats(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm2d_get_mean(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm2d_get_var(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm2d_get_batches(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm2d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm2d_set_var(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm2d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm1d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm1d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm1d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm1d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm1d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm1d_reset_stats(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm1d_get_mean(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm1d_get_var(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm1d_get_batches(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm1d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_InstanceNorm1d_set_var(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_InstanceNorm1d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv1d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Conv1d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv1d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Conv1d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv1d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv2d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Conv2d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv2d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Conv2d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv2d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv2d_ctor_1(long inputChannel, long outputChannel, long kernelSizeX, long kernelSizeY, long strideX, long strideY, long paddingX, long paddingY, long dilationX, long dilationY, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv3d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Conv3d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv3d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_Conv3d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Conv3d_ctor_1(long inputChannel, long outputChannel, long kernelSizeX, long kernelSizeY, long kernelSizeZ, long strideX, long strideY, long strideZ, long paddingX, long paddingY, long paddingZ, long dilationX, long dilationY, long dilationZ, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose1d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_ConvTranspose1d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose1d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_ConvTranspose1d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose1d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose3d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_ConvTranspose3d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose3d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_ConvTranspose3d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose3d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm1d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm1d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm1d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm1d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm1d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm1d_reset_stats(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm1d_get_mean(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm1d_get_var(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm1d_get_batches(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm1d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm1d_set_var(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm1d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GroupNorm_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GroupNorm_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_GroupNorm_set_bias(torch.nn.Module.HType module, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GroupNorm_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_GroupNorm_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GroupNorm_ctor(long num_groups, long num_channels, double eps, [MarshalAs(UnmanagedType.U1)] bool affine, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Unflatten_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Unflatten_ctor(long dim, IntPtr shape, long shape_len, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_batch_norm(IntPtr input, IntPtr running_mean, IntPtr running_var, IntPtr weight, IntPtr bias, bool training, double momentum, double eps);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_group_norm(IntPtr input, long num_groups, IntPtr weight, IntPtr bias, double eps);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_instance_norm(IntPtr input, IntPtr running_mean, IntPtr running_var, IntPtr weight, IntPtr bias, bool use_input_stats, double momentum, double eps);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern unsafe IntPtr THSNN_layer_norm(IntPtr input, long* normalized_shape, long normalized_shape_len, IntPtr weight, IntPtr bias, double eps);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_local_response_norm(IntPtr input, long size, double alpha, double beta, double k);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose2d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_ConvTranspose2d_set_bias(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose2d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_ConvTranspose2d_set_weight(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConvTranspose2d_ctor(long inputChannel, long outputChannel, long kernelSize, long stride, long padding, long outputPadding, long dilation, long paddingMode, long groups, bool bias, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm2d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm2d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm2d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm2d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm2d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm2d_reset_stats(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm2d_get_mean(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm2d_get_var(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm2d_get_batches(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm2d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm2d_set_var(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm2d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm3d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm3d_bias(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm3d_set_bias(torch.nn.Module.HType module, IntPtr bias);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm3d_weight(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm3d_set_weight(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm3d_reset_stats(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm3d_get_mean(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm3d_get_var(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm3d_get_batches(torch.nn.Module.HType module);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm3d_set_mean(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSNN_BatchNorm3d_set_var(torch.nn.Module.HType module, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_BatchNorm3d_ctor(long features, double eps, double momentum, [MarshalAs(UnmanagedType.U1)] bool affine, [MarshalAs(UnmanagedType.U1)] bool track_running_stats, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool1d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool1d_ctor(IntPtr pkernelSize, IntPtr pStrides, IntPtr pPadding, IntPtr pDilation, [MarshalAs(UnmanagedType.U1)] bool ceilMode, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxUnpool3d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize, int outputSizeLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxUnpool3d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, IntPtr pPadding, int paddingLength, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ELU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ELU_ctor(double alpha, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GELU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GELU_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_GLU_ctor(long dim, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Hardshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Hardshrink_ctor(double lambd, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Hardtanh_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Hardtanh_ctor(double min_val, double max_val, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Mish_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Mish_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReLU_ctor([MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReLU6_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReLU6_ctor([MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RReLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_RReLU_ctor(double lower, double upper, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_SELU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_SELU_ctor([MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Sigmoid_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Sigmoid_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_SiLU_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_SiLU_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softmax_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softmax_ctor(long dim, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softmax2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softmax2d_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softmin_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softmin_ctor(long dim, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softplus_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softplus_ctor(double beta, double threshold, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softshrink_ctor(double lambd, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softsign_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Softsign_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Tanh_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Tanh_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Tanhshrink_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Tanhshrink_ctor(out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Threshold_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_Threshold_ctor(double threshold, double value, [MarshalAs(UnmanagedType.U1)] bool inplace, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LocalResponseNorm_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LocalResponseNorm_ctor(long size, double alpha, double beta, double k, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConstantPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConstantPad1d_ctor(double value, long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConstantPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConstantPad2d_ctor(double value, long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConstantPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ConstantPad3d_ctor(double value, long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReflectionPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReflectionPad1d_ctor(long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReflectionPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReflectionPad2d_ctor(long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReflectionPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReflectionPad3d_ctor(long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReplicationPad1d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReplicationPad1d_ctor(long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReplicationPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReplicationPad2d_ctor(long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReplicationPad3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ReplicationPad3d_ctor(long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ZeroPad2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_ZeroPad2d_ctor(long padding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveAvgPool1d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveAvgPool1d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveAvgPool2d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveAvgPool2d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveAvgPool3d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveAvgPool3d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveMaxPool1d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveMaxPool1d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveMaxPool2d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveMaxPool2d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveMaxPool3d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AdaptiveMaxPool3d_ctor(IntPtr psizes, int length, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AvgPool1d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AvgPool1d_ctor(IntPtr pkernelSize, IntPtr pstrides, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AvgPool2d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AvgPool2d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AvgPool3d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_AvgPool3d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_FractionalMaxPool2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_FractionalMaxPool2d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_FractionalMaxPool2d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pOutputSize, int sizeLength, IntPtr pOutputRatio, int ratioLength, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_FractionalMaxPool3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_FractionalMaxPool3d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_FractionalMaxPool3d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pOutputSize, int sizeLength, IntPtr pOutputRatio, int ratioLength, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LPPool1d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LPPool1d_ctor(double norm_type, IntPtr pkernelSize, IntPtr pstrides, [MarshalAs(UnmanagedType.U1)] bool ceil_mode, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LPPool2d_forward(IntPtr module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_LPPool2d_ctor(double norm_type, IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, [MarshalAs(UnmanagedType.U1)] bool ceil_mode, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool2d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool2d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool2d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, IntPtr pPadding, int paddingLength, IntPtr pDilation, int dilationLength, [MarshalAs(UnmanagedType.U1)] bool ceilMode, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool3d_forward(torch.nn.Module.HType module, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool3d_forward_with_indices(torch.nn.Module.HType module, IntPtr tensor, out IntPtr indices);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxPool3d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, IntPtr pPadding, int paddingLength, IntPtr pDilation, int dilationLength, [MarshalAs(UnmanagedType.U1)] bool ceilMode, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxUnpool1d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxUnpool1d_ctor(IntPtr pkernelSize, IntPtr pStrides, IntPtr pPadding, out IntPtr pBoxedModule);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxUnpool2d_forward(torch.nn.Module.HType module, IntPtr tensor, IntPtr indices, IntPtr outSize, int outputSizeLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSNN_MaxUnpool2d_ctor(IntPtr pkernelSize, int kernelSizeLength, IntPtr pstrides, int stridesLength, IntPtr pPadding, int paddingLength, out IntPtr pBoxedModule);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSSpecial.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSSpecial.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_entr(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_erf(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_erfc(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_erfcx(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_erfinv(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_expit(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_expm1(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_exp2(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_gammaln(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_gammainc(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_gammaincc(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_polygamma(long n, IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_multigammaln(IntPtr tensor, long p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_digamma(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_i0(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_i0e(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_i1(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_i1e(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_logit(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_log_softmax(IntPtr tensor, long dim, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_ndtr(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_ndtri(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_sinc(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_xlog1py(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSSpecial_zeta(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern double THSSpecial_erf_scalar(double x);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern double THSSpecial_erfc_scalar(double x);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSStorage.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSStorage.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern ulong THSStorage_nbytes(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSStorage_set_nbytes(IntPtr tensor, ulong nbytes);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSStorage_data_ptr(IntPtr tensor);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSTensor.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSTensor.cs
@@ -1,0 +1,1973 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_where_list(IntPtr condition, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_squeeze_(IntPtr tensor, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_squeeze_no_dim_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conv1d(IntPtr input, IntPtr weight, IntPtr bias,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                long groups);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conv2d(IntPtr input, IntPtr weight, IntPtr bias,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                long groups);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conv3d(IntPtr input, IntPtr weight, IntPtr bias,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                long groups);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conv_transpose1d(IntPtr input, IntPtr weight, IntPtr bias,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr outputPadding, int outputPaddingLength,
+                IntPtr dilation, int dilationLength,
+                long groups);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conv_transpose2d(IntPtr input, IntPtr weight, IntPtr bias,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr outputPadding, int outputPaddingLength,
+                IntPtr dilation, int dilationLength,
+                long groups);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conv_transpose3d(IntPtr input, IntPtr weight, IntPtr bias,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr outputPadding, int outputPaddingLength,
+                IntPtr dilation, int dilationLength,
+                long groups);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_max_pool1d(IntPtr input,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                bool ceil_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_max_pool1d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                bool ceil_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_max_pool2d(IntPtr input,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                bool ceil_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_max_pool2d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+            IntPtr kernelSize, int kernelSizeLength,
+            IntPtr strides, int stridesLength,
+            IntPtr padding, int paddingLength,
+            IntPtr dilation, int dilationLength,
+            bool ceil_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_max_pool3d(IntPtr input,
+            IntPtr kernelSize, int kernelSizeLength,
+            IntPtr strides, int stridesLength,
+            IntPtr padding, int paddingLength,
+            IntPtr dilation, int dilationLength,
+            bool ceil_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_max_pool3d_with_indices(IntPtr input, AllocatePinnedArray allocator,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                IntPtr dilation, int dilationLength,
+                bool ceil_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_maxunpool3d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength, IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_avg_pool1d(IntPtr input,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                bool ceil_mode,
+                bool count_include_pad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_avg_pool2d(IntPtr input,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                bool ceil_mode,
+                bool count_include_pad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_avg_pool3d(IntPtr input,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                bool ceil_mode,
+                bool count_include_pad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_avg_pool2d_backward(IntPtr gradOutput, IntPtr originalInput,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                bool ceil_mode,
+                bool count_include_pad,
+                long divisorOverride);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_avg_pool3d_backward(IntPtr gradOutput, IntPtr originalInput,
+                IntPtr kernelSize, int kernelSizeLength,
+                IntPtr strides, int stridesLength,
+                IntPtr padding, int paddingLength,
+                bool ceil_mode,
+                bool count_include_pad,
+                long divisorOverride);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_adaptive_avg_pool1d(IntPtr input,
+                IntPtr outputSize, int outputSizeLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_adaptive_avg_pool2d(IntPtr input,
+                IntPtr outputSize, int outputSizeLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_upsample_nearest1d(IntPtr input,
+                IntPtr outputSize, int outputSizeLength,
+                IntPtr scaleFactors, int scaleFactorsLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_upsample_nearest1d_backward(IntPtr grad_output,
+                IntPtr outputSize, int outputSizeLength,
+                IntPtr inputSize, int inputSizeLength,
+                IntPtr scaleFactors, int scaleFactorsLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_upsample_nearest2d(IntPtr input,
+                IntPtr outputSize, int outputSizeLength,
+                IntPtr scaleFactors, int scaleFactorsLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_upsample_nearest2d_backward(IntPtr grad_output,
+                IntPtr outputSize, int outputSizeLength,
+                IntPtr inputSize, int inputSizeLength,
+                IntPtr scaleFactors, int scaleFactorsLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_upsample_nearest3d_backward(IntPtr grad_output,
+                IntPtr outputSize, int outputSizeLength,
+                IntPtr inputSize, int inputSizeLength,
+                IntPtr scaleFactors, int scaleFactorsLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_upsample_nearest3d(IntPtr input,
+            IntPtr outputSize, int outputSizeLength,
+            IntPtr scaleFactors, int scaleFactorsLength);
+
+        [DllImport("LibTorchSharp")]
+        [return: MarshalAs(UnmanagedType.LPStr)]
+        internal static extern string THSTensor_device_str(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_dispose(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_free(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_ndimension(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_element_size(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_numel(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_is_leaf(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_alias(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_storage_offset(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_data(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_real(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_imag(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern float THSTensor_data_idx_float16(IntPtr handle, long i);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern float THSTensor_data_idx_bfloat16(IntPtr handle, long i);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_item(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fill_(IntPtr handle, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern sbyte THSTensor_type(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern int THSTensor_device_index(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern int THSTensor_device_type(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSTensor_is_sparse(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_load([MarshalAs(UnmanagedType.LPStr)] string location);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_save(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string location);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSTensor_requires_grad(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_set_requires_grad(IntPtr handle, bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_retain_grad(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cpu(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cuda(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_to_device(IntPtr handle, int device_type, int device_index, bool copy);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_to_type(IntPtr handle, sbyte scalar_type, bool copy);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_to_type_and_device(IntPtr handle, sbyte scalar_type, int device_type, int device_index, bool copy);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_set_(IntPtr tensor, IntPtr source);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_size(IntPtr handle, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_sizes(IntPtr handle, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSTensor_has_names(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_names(IntPtr handle, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rename(IntPtr tensor, IntPtr names, long nLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rename_(IntPtr tensor, IntPtr names, long nLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_refine_names(IntPtr tensor, IntPtr names, long nLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_indices(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_values(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_vander(IntPtr handle, long N, bool increasing);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_stride(IntPtr handle, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_strides(IntPtr handle, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_as_strided(IntPtr input, IntPtr psizes, int sz_length, IntPtr pstrides, int str_length, long storageOffset);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_backward(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_to_dense(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clone(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_copy_(IntPtr handle, IntPtr source, [MarshalAs(UnmanagedType.U1)] bool non_blocking);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern int THSTensor_is_contiguous(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_contiguous(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_is_pinned(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_pin_memory(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_grad(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_put_scalar_(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_put_(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_get1(IntPtr handle, long i1);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_set1(IntPtr handle, long i1, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_get2(IntPtr handle, long i1, long i2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_set2(IntPtr handle, long i1, long i2, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_get3(IntPtr handle, long i1, long i2, long i3);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_set3(IntPtr handle, long i1, long i2, long i3, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_get4(IntPtr handle, long i1, long i2, long i3, long i4);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_set4(IntPtr handle, long i1, long i2, long i3, long i4, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_get5(IntPtr handle, long i1, long i2, long i3, long i4, long i5);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_set5(IntPtr handle, long i1, long i2, long i3, long i4, long i5, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_get6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_set6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_select(IntPtr tensor, long dim, IntPtr index);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_select(IntPtr tensor, long dim, long index);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_take(IntPtr tensor, IntPtr index);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_take_along_dim_dflt(IntPtr tensor, IntPtr indices);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_take_along_dim(IntPtr tensor, IntPtr indices, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_add(IntPtr tensor, long dim, IntPtr index, IntPtr source, IntPtr alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_add_(IntPtr tensor, long dim, IntPtr index, IntPtr source, IntPtr alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_copy(IntPtr tensor, long dim, IntPtr index, IntPtr source);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_copy_(IntPtr tensor, long dim, IntPtr index, IntPtr source);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_fill(IntPtr tensor, long dim, IntPtr index, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_index_fill_(IntPtr tensor, long dim, IntPtr index, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_reshape(IntPtr tensor, IntPtr shape, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_flatten(IntPtr tensor, long start, long end);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_flatten_names(IntPtr tensor, IntPtr names, long nLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unflatten(IntPtr tensor, long dim, IntPtr shape, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unflatten_names(IntPtr tensor, IntPtr names, IntPtr dims, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_align_to(IntPtr tensor, IntPtr names, long nLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unique(IntPtr tensor, bool sorted, bool return_inverse, bool return_counts, out IntPtr inverse_indices, out IntPtr counts);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unique_dim(IntPtr tensor, long dim, bool sorted, bool return_inverse, bool return_counts, out IntPtr inverse_indices, out IntPtr counts);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unique_consecutive(IntPtr tensor, bool return_inverse, bool return_counts, out IntPtr inverse_indices, out IntPtr counts);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unique_dim_consecutive(IntPtr tensor, long dim, bool return_inverse, bool return_counts, out IntPtr inverse_indices, out IntPtr counts);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_squeeze(IntPtr tensor, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_squeeze_no_dim(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_t(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_H(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mT(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mH(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_transpose(IntPtr tensor, long dim1, long dim2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_tril(IntPtr tensor, long diagonal);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_triu(IntPtr tensor, long diagonal);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_transpose_(IntPtr tensor, long dim1, long dim2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_view(IntPtr tensor, IntPtr shape, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_view_as_complex(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_view_as_real(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_all(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_all_along_dimension(IntPtr tensor, long dim, bool keep_dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_amax(IntPtr tensor, IntPtr dim, int dim_len, bool keep_dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_amax_out(IntPtr tensor, IntPtr dim, int dim_len, bool keep_dim, IntPtr _out);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_amin(IntPtr tensor, IntPtr dim, int dim_len, bool keep_dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_amin_out(IntPtr tensor, IntPtr dim, int dim_len, bool keep_dim, IntPtr _out);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_aminmax(IntPtr tensor, long dim, bool keep_dim, out IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_any(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_any_along_dimension(IntPtr tensor, long dim, bool keep_dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_argmax(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_argmax_along_dimension(IntPtr tensor, long dim, bool keep_dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_argmin(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_argmin_along_dimension(IntPtr tensor, long dim, bool keep_dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_argsort(IntPtr tensor, long dim, bool descending);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_deg2rad(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rad2deg(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_copysign(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_count_nonzero(IntPtr tensor, IntPtr dim, int dim_len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cov(IntPtr tensor, long correction, IntPtr fweights, IntPtr aweights);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_corrcoef(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_tile(IntPtr tensor, IntPtr reps, int reps_len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_digamma(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_digamma_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lgamma(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lgamma_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mvlgamma(IntPtr tensor, long p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mvlgamma_(IntPtr tensor, long p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_polygamma(IntPtr tensor, long p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_polygamma_(IntPtr tensor, long p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_positive(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_softplus(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ravel(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_relu(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_relu_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_relu6(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_relu6_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_celu(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_celu_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_elu(IntPtr tensor, IntPtr alpha, IntPtr scale, IntPtr input_scale);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_elu_(IntPtr tensor, IntPtr alpha, IntPtr scale, IntPtr input_scale);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_gelu(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hardsigmoid(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hardsigmoid_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hardswish(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hardswish_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hardtanh(IntPtr tensor, IntPtr min, IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hardtanh_(IntPtr tensor, IntPtr min, IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_heaviside(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_igamma(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_igammac(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_i0(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_isclose(IntPtr tensor, IntPtr other, double rtol, double atol, bool nanEqual);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_isin(IntPtr elements, IntPtr test_elements, bool assume_unique, bool invert);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_isinf(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_isfinite(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_isposinf(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_isneginf(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_isnan(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_isreal(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_leaky_relu(IntPtr tensor, IntPtr negative_slope);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_leaky_relu_(IntPtr tensor, IntPtr negative_slope);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_selu(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_selu_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_silu(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_silu_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log_sigmoid(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lerp(IntPtr tensor, IntPtr end, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lerp_(IntPtr tensor, IntPtr end, IntPtr weight);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_baddbmm(IntPtr batch1, IntPtr batch2, IntPtr mat, float beta, float alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bmm(IntPtr batch1, IntPtr batch2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bucketize(IntPtr input, IntPtr boundaries, bool out_int32, bool right);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bincount(IntPtr tensor, IntPtr weights, long minlength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_channel_shuffle(IntPtr input, long groups);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clamp(IntPtr input, IntPtr min, IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clamp_tensor(IntPtr input, IntPtr min, IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clamp_(IntPtr input, IntPtr min, IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clamp_tensor_(IntPtr input, IntPtr min, IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clamp_max(IntPtr input, IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clamp_max_(IntPtr input, IntPtr max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clamp_min(IntPtr input, IntPtr min);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_clamp_min_(IntPtr input, IntPtr min);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_diff(IntPtr tensor, long n, long dim, IntPtr prepend, IntPtr append);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_diag(IntPtr tensor, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_trace(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_diagflat(IntPtr tensor, long offset);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_diagonal(IntPtr tensor, long offset, long dim1, long dim2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_erf(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_erf_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_erfc(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_erfc_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_erfinv(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_erfinv_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_eq(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_eq_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_eq_scalar(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_eq_scalar_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSTensor_equal(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSTensor_allclose(IntPtr tensor, IntPtr trg, double rtol, double atol, bool equal_nan);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ge(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ge_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ge_scalar(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ge_scalar_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_gt(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_gt_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_gt_scalar(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_gt_scalar_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_kron(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lcm(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lcm_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ldexp(IntPtr right, IntPtr left);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ldexp_(IntPtr right, IntPtr left);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_le(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_le_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_le_scalar(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_le_scalar_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lt(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lt_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lt_scalar(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lt_scalar_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_masked_fill(IntPtr tensor, IntPtr mask, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_masked_scatter(IntPtr tensor, IntPtr mask, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_masked_scatter_(IntPtr tensor, IntPtr mask, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_masked_select(IntPtr tensor, IntPtr mask);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_topk(IntPtr tensor, AllocatePinnedArray allocator, int k, long dim, bool largest, bool sorted);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_unbind(IntPtr tensor, AllocatePinnedArray allocator, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unfold(IntPtr tensor, long dim, long size, long step);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_tensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_tensor_split_with_tensor_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr indices, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_vsplit_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_vsplit_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_hsplit_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_hsplit_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_dsplit_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_dsplit_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_chunk(IntPtr tensor, AllocatePinnedArray allocator, long chunks, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_kthvalue(IntPtr tensor, long k, long dim, bool keepdim, out IntPtr _out);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_max(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_max_elementwise(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_max_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dim, bool keep_dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mean(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_quantile(IntPtr tensor, IntPtr q, long dim, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_nanquantile(IntPtr tensor, IntPtr q, long dim, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mode(IntPtr tensor, AllocatePinnedArray allocator, long dim, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mean_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_var_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_median(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_min(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_min_elementwise(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_min_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dim, bool keep_dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_msort(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sort(IntPtr tensor, long dim, bool descending, bool stable, out IntPtr indices);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ne(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ne_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ne_scalar(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ne_scalar_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_dist(IntPtr tensor, IntPtr other, float p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_norm(IntPtr tensor, float p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_norm_along_dimension(IntPtr tensor, long dimension, bool keepdim, float p);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_outer(IntPtr input, IntPtr vec2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_inner(IntPtr input, IntPtr vec2);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_inverse(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_prelu(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fmax(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fmin(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_renorm(IntPtr tensor, float p, long dim, float maxnorm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sigmoid(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sigmoid_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_std(IntPtr tensor, bool unbiased);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_var(IntPtr tensor, bool unbiased);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_std_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool unbiased, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_var_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool unbiased, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_std_mean(IntPtr tensor, bool unbiased, out IntPtr mean);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_var_mean(IntPtr tensor, bool unbiased, out IntPtr mean);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_std_mean_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool unbiased, bool keepdim, out IntPtr mean);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_var_mean_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool unbiased, bool keepdim, out IntPtr mean);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sum(IntPtr tensor, bool has_type, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sum_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_expand(IntPtr tensor, IntPtr psizes, int length, [MarshalAs(UnmanagedType.U1)] bool isImplicit);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_repeat(IntPtr tensor, IntPtr psizes, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_repeat_interleave(IntPtr tensor, IntPtr repeats, long dim, long output_size);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_repeat_interleave_int64(IntPtr tensor, long repeats, long dim, long output_size);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_broadcast_to(IntPtr tensor, IntPtr psizes, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_movedim(IntPtr tensor, IntPtr src, int src_len, IntPtr dst, int dst_len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randn_out(IntPtr psizes, int length, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rand_out(IntPtr psizes, int length, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randint_out(long high, IntPtr psizes, int length, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rand_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_tensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randn_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randint_like(IntPtr input, long low, long high, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randperm_out(long n, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bernoulli(IntPtr tensor, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_multinomial(IntPtr tensor, long num_samples, bool replacement, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_poisson(IntPtr tensor, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bernoulli_0(IntPtr tensor, double p, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bernoulli_1(IntPtr tensor, IntPtr p_tensor, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_binomial(IntPtr count, IntPtr prob, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cauchy_(IntPtr tensor, double median, double sigma, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_exponential_(IntPtr tensor, double lambda, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_geometric_(IntPtr tensor, double p, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_normal_(IntPtr tensor, double mean, double std, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log_normal_(IntPtr tensor, double mean, double std, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_random_(IntPtr tensor, double low, double high, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_uniform_(IntPtr tensor, double low, double high, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_arange_out(IntPtr start, IntPtr strp, IntPtr step, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_permute(IntPtr tensor, IntPtr psizes, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ones_out(IntPtr psizes, int length, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_zeros_out(IntPtr psizes, int length, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_zeros_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ones_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_empty_out(IntPtr psizes, int length, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_empty_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_full_out(IntPtr psizes, int length, IntPtr value, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_full_like(IntPtr input, IntPtr value, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_detach(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_detach_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_eye_out(long rows, long columns, IntPtr tensorOut);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_scatter(IntPtr tensor, long dim, IntPtr index, IntPtr source);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_scatter_(IntPtr tensor, long dim, IntPtr index, IntPtr source);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_scatter_add(IntPtr tensor, long dim, IntPtr index, IntPtr source);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_scatter_add_(IntPtr tensor, long dim, IntPtr index, IntPtr source);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_gather(IntPtr tensor, long dim, IntPtr index);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_flip(IntPtr tensor, IntPtr psizes, int length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fliplr(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_flipud(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_nanmean(IntPtr tensor, long dim, bool keepdim, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_nanmedian(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_nansum(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_nan_to_num(IntPtr tensor, IntPtr nan, IntPtr posinf, IntPtr neginf);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_nextafter(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_narrow(IntPtr tensor, long dim, long start, long length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_nonzero(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_roll(IntPtr tensor, IntPtr shifts, int shLength, IntPtr dims, long dimLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_slice(IntPtr tensor, long dim, long start, long length, long step);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unsqueeze(IntPtr tensor, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_unsqueeze_(IntPtr tensor, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_where(IntPtr condition, IntPtr x, IntPtr y);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_atleast_1d(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_atleast_2d(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_atleast_3d(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_stft(IntPtr x, long n_fft, long hop_length, long win_length, IntPtr window, [MarshalAs(UnmanagedType.U1)] bool normalized, long onesided, [MarshalAs(UnmanagedType.U1)] bool return_complex);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_istft(IntPtr x, long n_fft, long hop_length, long win_length, IntPtr window, [MarshalAs(UnmanagedType.U1)] bool center, [MarshalAs(UnmanagedType.U1)] bool normalized, long onesided, long length, [MarshalAs(UnmanagedType.U1)] bool return_complex);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_to_type(IntPtr handle, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_arange(IntPtr start, IntPtr stop, IntPtr step, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requireGrad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newComplexFloat32Scalar(float real, float imaginary, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randint(long max, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randint(IntPtr generator, long low, long high, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_linspace(double start, double end, long steps, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logspace(double start, double end, long steps, double @base, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bartlett_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_blackman_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hamming_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, double alpha, double beta, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hann_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_kaiser_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, double beta, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newBoolScalar([MarshalAs(UnmanagedType.U1)] bool scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newByteScalar(byte scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newInt8Scalar(sbyte scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newInt16Scalar(short scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newInt32Scalar(int scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newInt64Scalar(long scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newFloat16Scalar(float scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newFloat32Scalar(float scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newFloat64Scalar(double scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newComplexFloat64Scalar(double real, double imaginary, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_frombuffer(IntPtr rawArray, GCHandleDeleter deleter, long count, long offset, sbyte type, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, sbyte type, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_newInt64(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rand(IntPtr generator, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randn(IntPtr generator, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_complex(IntPtr real, IntPtr imag);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_polar(IntPtr abs, IntPtr angle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ifft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ifft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ifftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_irfft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rfft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_irfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_irfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hfft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ihfft(IntPtr tensor, long n, long dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fftshift(IntPtr tensor, IntPtr dim, int dim_length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ifftshift(IntPtr tensor, IntPtr dim, int dim_length);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rfftfreq(long n, double d, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ihfft2(IntPtr tensor, IntPtr s, IntPtr dim, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ihfftn(IntPtr tensor, IntPtr s, int s_length, IntPtr dim, int dim_length, sbyte norm);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_angle(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_asin(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_asin_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_acos(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_acos_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_atan(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_atan_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_atan2_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cos(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_atan2(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cos_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sin(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sin_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_tan(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_tan_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sinc(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sinc_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sinh(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sinh_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cosh(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cosh_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_tanh(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_tanh_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_arcsinh(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_arcsinh_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_arccosh(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_arccosh_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_arctanh(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_arctanh_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_block_diag(IntPtr tensor, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_broadcast_tensors(IntPtr tensor, long length, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cat(IntPtr tensor, int len, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_stack(IntPtr tensor, int len, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hstack(IntPtr tensor, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_vstack(IntPtr tensor, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_column_stack(IntPtr tensors, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_row_stack(IntPtr tensor, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_dstack(IntPtr tensor, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_meshgrid(IntPtr tensor, long len, [MarshalAs(UnmanagedType.LPStr)] string indexing, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_standard_gamma_(IntPtr tensor, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sample_dirichlet_(IntPtr tensor, IntPtr gen);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_abs(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_abs_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_add(IntPtr tensor, IntPtr trg, IntPtr alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_add_scalar(IntPtr tensor, IntPtr trg, IntPtr alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_add_(IntPtr tensor, IntPtr trg, IntPtr alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addmm_(IntPtr mat, IntPtr mat1, IntPtr mat2, float beta, float alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addmv(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta = 1, float alpha = 1);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addmv_(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addr(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addr_(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_and(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addmm(IntPtr mat, IntPtr mat1, IntPtr mat2, float beta, float alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_add_scalar_(IntPtr tensor, IntPtr trg, IntPtr alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addcdiv(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addbmm(IntPtr mat, IntPtr batch1, IntPtr batch2, float beta, float alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addbmm_(IntPtr mat, IntPtr batch1, IntPtr batch2, float beta, float alpha);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addcmul(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addcmul_(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_xor(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_xor_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_addcdiv_(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_not(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_not_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_and_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_or(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_or_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_left_shift_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_right_shift(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ceil(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ceil_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTensor_is_conj(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_resolve_conj(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_left_shift(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_cummin(IntPtr tensor, AllocatePinnedArray allocator, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cumsum(IntPtr tensor, long dim, bool has_type, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_bitwise_right_shift_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conj(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conj_physical(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_div_scalar(IntPtr tensor, IntPtr trg, [MarshalAs(UnmanagedType.LPStr)] string rounding_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_div_(IntPtr tensor, IntPtr trg, [MarshalAs(UnmanagedType.LPStr)] string rounding_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_conj_physical_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_cummax(IntPtr tensor, AllocatePinnedArray allocator, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_exp(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_exp_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_exp2(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_expm1(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_floor(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_floor_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_frexp(IntPtr tensor, out IntPtr exponent);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_gcd(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_div(IntPtr tensor, IntPtr trg, [MarshalAs(UnmanagedType.LPStr)] string rounding_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fmod_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fmod_scalar(IntPtr tensor, IntPtr scalar);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_remainder_scalar_(IntPtr tensor, IntPtr scalar);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_round(IntPtr tensor, long decimals);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cumprod(IntPtr tensor, long dim, bool has_type, sbyte scalar_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_div_scalar_(IntPtr tensor, IntPtr trg, [MarshalAs(UnmanagedType.LPStr)] string rounding_mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_histc(IntPtr tensor, long bins, long min, long max);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_hypot(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log10(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log10_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logcumsumexp(IntPtr tensor, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logsumexp(IntPtr tensor, long dim, bool keepdim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logical_or(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logical_or_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logical_not(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logical_not_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mul_scalar_(IntPtr tensor, IntPtr target);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_neg(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_reciprocal_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_remainder(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logical_and(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logical_and_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_pow_scalar(IntPtr tensor, IntPtr scalar);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_pow_scalar_(IntPtr tensor, IntPtr scalar);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_remainder_scalar(IntPtr tensor, IntPtr scalar);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_reciprocal(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_remainder_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cumulative_trapezoid_x(IntPtr y, IntPtr x, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cumulative_trapezoid_dx(IntPtr y, double dx, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rsqrt_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sqrt(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_float_power(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fmod_scalar_(IntPtr tensor, IntPtr scalar);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_frac(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logit(IntPtr tensor, IntPtr eps);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mul(IntPtr tensor, IntPtr target);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_expm1_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_fmod(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_frac_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_gcd_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logaddexp(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logaddexp2(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log2(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log2_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log1p_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_log1p(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logical_xor(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_logical_xor_(IntPtr tensor, IntPtr other);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mul_(IntPtr tensor, IntPtr target);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_pow(IntPtr tensor, IntPtr exponent);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_pow_(IntPtr tensor, IntPtr exponent);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mul_scalar(IntPtr tensor, IntPtr scalar);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_neg_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_round_(IntPtr tensor, long decimals);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_rsqrt(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sqrt_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sign(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_signbit(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sub(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sub_scalar(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sub_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sub_scalar_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_trapezoid_x(IntPtr y, IntPtr x, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_trapezoid_dx(IntPtr y, double dx, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_sign_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_trunc_(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_xlogy(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_xlogy_scalar(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_xlogy_scalar_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_xlogy_(IntPtr tensor, IntPtr trg);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_trunc(IntPtr tensor);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_einsum([MarshalAs(UnmanagedType.LPStr)] string location, IntPtr tensors, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern double THSTensor_clip_grad_norm_(IntPtr tensors, int len, double max_norm, double norm_type);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_clip_grad_value_(IntPtr tensors, int len, double clip_value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_parameters_to_vector(IntPtr tensors, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_vector_to_parameters(IntPtr vec, IntPtr tensors, int len);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cholesky(IntPtr input, bool upper);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cholesky_inverse(IntPtr input, bool upper);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cholesky_solve(IntPtr input, IntPtr input2, bool upper);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_cross(IntPtr input, IntPtr other, long dim);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_eig(IntPtr tensor, bool eigenvectors, out IntPtr pEigenvectors);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_matmul(IntPtr tensor, IntPtr target);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mm(IntPtr tensor, IntPtr target);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_mv(IntPtr tensor, IntPtr target);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_matrix_exp(IntPtr input);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_vdot(IntPtr tensor, IntPtr target);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lu(IntPtr tensor, bool pivot, bool get_infos, out IntPtr infos, out IntPtr pivots);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lu_solve(IntPtr tensor, IntPtr LU_data, IntPtr LU_pivots);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_lu_unpack(IntPtr LU_data, IntPtr LU_pivots, bool unpack_data, bool unpack_pivots, out IntPtr L, out IntPtr U);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_zeros(IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requireGrad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_randperm(IntPtr generator, long n, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requireGrad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_ones(IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_empty_strided(IntPtr psizes, int sz_length, IntPtr pstrides, int str_length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_empty(IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_full(IntPtr psizes, int length, IntPtr value, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_eye(long rows, long columns, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_maxunpool2d(IntPtr input, IntPtr indices, IntPtr outputSize, int outputSizeLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_adaptive_avg_pool3d(IntPtr input, IntPtr outputSize, int outputSizeLength);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTensor_adaptive_avg_pool3d_backward_out(IntPtr gradInput, IntPtr gradOutput, IntPtr originalInput);
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSTorch.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSTorch.cs
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static extern bool THSTorch_scalar_to_bool(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_lstsq(IntPtr input, IntPtr A, out IntPtr pQR);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTorch_dispose_scalar(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern byte THSTorch_scalar_type(IntPtr value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_uint8_to_scalar(byte value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_int8_to_scalar(sbyte value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_int16_to_scalar(short value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_int32_to_scalar(int value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_int64_to_scalar(long value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_float32_to_scalar(float value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_float64_to_scalar(double value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_complex32_to_scalar(float real, float imaginary);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_complex64_to_scalar(double real, double imaginary);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_bool_to_scalar([MarshalAs(UnmanagedType.U1)] bool value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_float16_to_scalar(float value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_bfloat16_to_scalar(float value);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern float THSTorch_scalar_to_float32(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern double THSTorch_scalar_to_float64(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern sbyte THSTorch_scalar_to_int8(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern byte THSTorch_scalar_to_uint8(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern short THSTorch_scalar_to_int16(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern int THSTorch_scalar_to_int32(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern long THSTorch_scalar_to_int64(IntPtr handle);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTorch_scalar_to_complex32(IntPtr handle, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTorch_scalar_to_complex64(IntPtr handle, AllocatePinnedArray allocator);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSTorch_get_and_reset_last_err();
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSTorchCuda.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSTorchCuda.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSTorchCuda_is_available();
+
+        [DllImport("LibTorchSharp")]
+        internal static extern bool THSTorchCuda_cudnn_is_available();
+
+        [DllImport("LibTorchSharp")]
+        internal static extern int THSTorchCuda_device_count();
+    }
+}

--- a/src/TorchSharp/PInvoke/LibTorchSharp.crc32c.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.crc32c.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    internal static partial class LibTorchSharp
+    {
+        [DllImport("LibTorchSharp")]
+        internal static extern uint crc32c_append(uint crc, IntPtr value, ulong length);
+    }
+}

--- a/src/TorchSharp/PInvoke/TensorOrScalar.cs
+++ b/src/TorchSharp/PInvoke/TensorOrScalar.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp.PInvoke
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TensorOrScalar
+    {
+        public long TypeCode;
+        public IntPtr Handle;
+    }
+}

--- a/src/TorchSharp/Scalar.cs
+++ b/src/TorchSharp/Scalar.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -114,9 +114,6 @@ namespace TorchSharp
             return value.ToScalar();
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static byte THSTorch_scalar_type(IntPtr value);
-
         /// <summary>
         /// Gets the actual type of the Scalar value
         /// </summary>
@@ -130,15 +127,12 @@ namespace TorchSharp
         ///   Finalize the tensor. Releases the tensor and its associated data.
         /// </summary>
         ~Scalar() => Dispose(false);
- 
+
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static void THSTorch_dispose_scalar(IntPtr handle);
 
         /// <summary>
         ///   Implements the .NET Dispose pattern.
@@ -154,10 +148,6 @@ namespace TorchSharp
 
     public static class ScalarExtensionMethods
     {
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_uint8_to_scalar(byte value);
-
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
         /// </summary>
@@ -167,9 +157,6 @@ namespace TorchSharp
             torch.InitializeDeviceType(DeviceType.CPU);
             return new Scalar(THSTorch_uint8_to_scalar(value));
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_int8_to_scalar(sbyte value);
 
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
@@ -181,9 +168,6 @@ namespace TorchSharp
             return new Scalar(THSTorch_int8_to_scalar(value));
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_int16_to_scalar(short value);
-
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
         /// </summary>
@@ -193,9 +177,6 @@ namespace TorchSharp
             torch.InitializeDeviceType(DeviceType.CPU);
             return new Scalar(THSTorch_int16_to_scalar(value));
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_int32_to_scalar(int value);
 
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
@@ -207,9 +188,6 @@ namespace TorchSharp
             return new Scalar(THSTorch_int32_to_scalar(value));
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_int64_to_scalar(long value);
-
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
         /// </summary>
@@ -219,9 +197,6 @@ namespace TorchSharp
             torch.InitializeDeviceType(DeviceType.CPU);
             return new Scalar(THSTorch_int64_to_scalar(value));
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_float32_to_scalar(float value);
 
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
@@ -233,9 +208,6 @@ namespace TorchSharp
             return new Scalar(THSTorch_float32_to_scalar(value));
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_float64_to_scalar(double value);
-
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
         /// </summary>
@@ -245,9 +217,6 @@ namespace TorchSharp
             torch.InitializeDeviceType(DeviceType.CPU);
             return new Scalar(THSTorch_float64_to_scalar(value));
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_complex32_to_scalar(float real, float imaginary);
 
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
@@ -259,9 +228,6 @@ namespace TorchSharp
             return new Scalar(THSTorch_complex32_to_scalar(value.Item1, value.Item2));
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_complex64_to_scalar(double real, double imaginary);
-
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
         /// </summary>
@@ -271,9 +237,6 @@ namespace TorchSharp
             torch.InitializeDeviceType(DeviceType.CPU);
             return new Scalar(THSTorch_complex64_to_scalar(value.Real, value.Imaginary));
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_bool_to_scalar([MarshalAs(UnmanagedType.U1)] bool value);
 
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
@@ -285,9 +248,6 @@ namespace TorchSharp
             return new Scalar(THSTorch_bool_to_scalar(value));
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_float16_to_scalar(float value);
-
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
         /// </summary>
@@ -297,9 +257,6 @@ namespace TorchSharp
             torch.InitializeDeviceType(DeviceType.CPU);
             return new Scalar(THSTorch_float16_to_scalar(value));
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_bfloat16_to_scalar(float value);
 
         /// <summary>
         /// Explcitly construct a Scalar from a .NET scalar.
@@ -311,9 +268,6 @@ namespace TorchSharp
             return new Scalar(THSTorch_bfloat16_to_scalar(value));
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static float THSTorch_scalar_to_float32(IntPtr handle);
-
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
         /// </summary>
@@ -322,9 +276,6 @@ namespace TorchSharp
         {
             return THSTorch_scalar_to_float32(value.Handle);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static double THSTorch_scalar_to_float64(IntPtr handle);
 
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
@@ -335,9 +286,6 @@ namespace TorchSharp
             return THSTorch_scalar_to_float64(value.Handle);
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static sbyte THSTorch_scalar_to_int8(IntPtr handle);
-
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
         /// </summary>
@@ -346,9 +294,6 @@ namespace TorchSharp
         {
             return THSTorch_scalar_to_int8(value.Handle);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static byte THSTorch_scalar_to_uint8(IntPtr handle);
 
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
@@ -359,9 +304,6 @@ namespace TorchSharp
             return THSTorch_scalar_to_uint8(value.Handle);
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static short THSTorch_scalar_to_int16(IntPtr handle);
-
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
         /// </summary>
@@ -370,9 +312,6 @@ namespace TorchSharp
         {
             return THSTorch_scalar_to_int16(value.Handle);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static int THSTorch_scalar_to_int32(IntPtr handle);
 
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
@@ -383,9 +322,6 @@ namespace TorchSharp
             return THSTorch_scalar_to_int32(value.Handle);
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static long THSTorch_scalar_to_int64(IntPtr handle);
-
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
         /// </summary>
@@ -395,10 +331,6 @@ namespace TorchSharp
             return THSTorch_scalar_to_int64(value.Handle);
         }
 
-        [DllImport("LibTorchSharp")]
-        [return: MarshalAs(UnmanagedType.U1)]
-        extern static bool THSTorch_scalar_to_bool(IntPtr handle);
-
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
         /// </summary>
@@ -407,9 +339,6 @@ namespace TorchSharp
         {
             return THSTorch_scalar_to_bool(value.Handle);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static void THSTorch_scalar_to_complex32(IntPtr handle, AllocatePinnedArray allocator);
 
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar
@@ -427,9 +356,6 @@ namespace TorchSharp
 
             return (floatArray[0], floatArray[1]);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static void THSTorch_scalar_to_complex64(IntPtr handle, AllocatePinnedArray allocator);
 
         /// <summary>
         /// Explicitly convert a Scalar value to a .NET scalar

--- a/src/TorchSharp/Special.cs
+++ b/src/TorchSharp/Special.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -8,9 +8,6 @@ namespace TorchSharp
     {
         public static class special
         {
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_entr(IntPtr tensor);
-
             /// <summary>
             /// Computes the entropy on input, elementwise.
             /// </summary>
@@ -23,9 +20,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_erf(IntPtr tensor);
 
             /// <summary>
             /// Computes the error function of input.
@@ -40,9 +34,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_erfc(IntPtr tensor);
-
             /// <summary>
             /// Computes the complementary error function of input.
             /// </summary>
@@ -55,9 +46,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_erfcx(IntPtr tensor);
 
             /// <summary>
             /// Computes the scaled complementary error function of input.
@@ -72,9 +60,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_erfinv(IntPtr tensor);
-
             /// <summary>
             /// Computes the inverse error function of input.
             /// </summary>
@@ -87,9 +72,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_expit(IntPtr tensor);
 
             /// <summary>
             /// Computes the expit (also known as the logistic sigmoid function) of the elements of input.
@@ -104,9 +86,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_expm1(IntPtr tensor);
-
             /// <summary>
             /// Computes the exponential of the elements minus 1 of input.
             /// </summary>
@@ -119,9 +98,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_exp2(IntPtr tensor);
 
             /// <summary>
             /// Computes the base two exponential function of input.
@@ -136,9 +112,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_gammaln(IntPtr tensor);
-
             /// <summary>
             /// Computes the natural logarithm of the absolute value of the gamma function on input.
             /// </summary>
@@ -151,9 +124,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_gammainc(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Computes the regularized lower incomplete gamma function.
@@ -169,9 +139,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_gammaincc(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Computes the regularized upper incomplete gamma function.
             /// </summary>
@@ -185,9 +152,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_polygamma(long n, IntPtr tensor);
 
             /// <summary>
             /// Computes the n-th derivative of the digamma function on input.
@@ -203,9 +167,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_multigammaln(IntPtr tensor, long p);
-
             /// <summary>
             /// Computes the multivariate log-gamma function with dimension pp element-wise.
             /// </summary>
@@ -219,9 +180,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_digamma(IntPtr tensor);
 
             /// <summary>
             /// Computes the logarithmic derivative of the gamma function on input.
@@ -242,9 +200,6 @@ namespace TorchSharp
             /// <param name="input">The second non-negative input tensor</param>
             public static Tensor psi(Tensor input) => digamma(input);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_i0(IntPtr tensor);
-
             /// <summary>
             /// Computes the zeroth order modified Bessel function of the first kind for each element of input.
             /// </summary>
@@ -257,9 +212,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_i0e(IntPtr tensor);
 
             /// <summary>
             /// Computes the exponentially scaled zeroth order modified Bessel function of the first kind (as defined below) for each element of input.
@@ -274,9 +226,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_i1(IntPtr tensor);
-
             /// <summary>
             /// Computes the first order modified Bessel function of the first kind for each element of input.
             /// </summary>
@@ -289,9 +238,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_i1e(IntPtr tensor);
 
             /// <summary>
             /// Computes the exponentially scaled first order modified Bessel function of the first kind (as defined below) for each element of input.
@@ -306,9 +252,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_logit(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the logit of the elements of input.
             /// </summary>
@@ -321,9 +264,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_log_softmax(IntPtr tensor, long dim, sbyte scalar_type);
 
             /// <summary>
             /// Returns a new tensor with the logit of the elements of input.
@@ -341,9 +281,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_ndtr(IntPtr tensor);
-
             /// <summary>
             /// Computes the area under the standard Gaussian probability density function, integrated from minus infinity to input, elementwise.
             /// </summary>
@@ -357,9 +294,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_ndtri(IntPtr tensor);
-
             /// <summary>
             /// Computes the argument, x, for which the area under the Gaussian probability density function (integrated from minus infinity to x) is equal to input, elementwise.
             /// </summary>
@@ -372,9 +306,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_sinc(IntPtr tensor);
 
             /// <summary>
             /// Computes the normalized sinc of input.
@@ -401,9 +332,6 @@ namespace TorchSharp
             /// <returns></returns>
             public static Tensor sigmoid_(Tensor input) => input.sigmoid_();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_xlog1py(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Computes input * log1p(other). Similar to SciPy’s scipy.special.xlog1py.
             /// </summary>
@@ -417,9 +345,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSSpecial_zeta(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Computes the Hurwitz zeta function, elementwise.

--- a/src/TorchSharp/Tensor/Size.cs
+++ b/src/TorchSharp/Tensor/Size.cs
@@ -3,7 +3,6 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections;
-using System.Net;
 
 #nullable enable
 namespace TorchSharp

--- a/src/TorchSharp/Tensor/Storage.cs
+++ b/src/TorchSharp/Tensor/Storage.cs
@@ -2,10 +2,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
-using System.Linq;
-using System.Runtime.CompilerServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -156,19 +154,12 @@ namespace TorchSharp
             /// The number of bytes allocated to the storage.
             /// </summary>
             /// <returns></returns>
-            public UInt64 nbytes()
+            public ulong nbytes()
             {
                 var res = THSStorage_nbytes(_tensor.Handle);
                 CheckForErrors();
                 return res;
             }
-
-            [DllImport("LibTorchSharp")]
-            protected static extern UInt64 THSStorage_nbytes(IntPtr tensor);
-            [DllImport("LibTorchSharp")]
-            protected static extern void THSStorage_set_nbytes(IntPtr tensor, UInt64 nbytes);
-            [DllImport("LibTorchSharp")]
-            protected static extern IntPtr THSStorage_data_ptr(IntPtr tensor);
         }
 
         /// <summary>

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -5,6 +5,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using TorchSharp.PInvoke;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -25,10 +27,6 @@ namespace TorchSharp
         /// </summary>
         /// <param name="dtype"></param>
         public static void set_default_dtype(ScalarType dtype) { default_dtype = dtype; }
-
-        // arange()
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_arange(IntPtr start, IntPtr stop, IntPtr step, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requireGrad);
 
         /// <summary>
         /// Creates 1-D tensor of size [(stop - start) / step] with values from interval [start, stop) and
@@ -155,11 +153,6 @@ namespace TorchSharp
             return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
-        // randperm()
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_randperm(IntPtr generator, long n, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requireGrad);
-
         /// <summary>
         /// Creates 1-D tensor of size [n] with a random permutation of [0, n).
         /// </summary>
@@ -180,13 +173,7 @@ namespace TorchSharp
             return new Tensor(handle);
         }
 
-
-        // zeros()
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_zeros(IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requireGrad);
-
-        static private Tensor _zeros(ReadOnlySpan<long> size, torch.ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, string[]? names = null)
+        private static Tensor _zeros(ReadOnlySpan<long> size, torch.ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, string[]? names = null)
         {
             device = torch.InitializeDevice(device);
             if (!dtype.HasValue) {
@@ -307,16 +294,10 @@ namespace TorchSharp
         /// </summary>
         public static Tensor zeros_like(Tensor input, ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, string[]? names = null) => input.zeros_like(dtype, device, requires_grad);
 
-
-        // ones()
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_ones(IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
         /// <summary>
         ///  Create a new tensor filled with ones
         /// </summary>
-        static private Tensor _ones(ReadOnlySpan<long> size, torch.ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, string[]? names = null)
+        private static Tensor _ones(ReadOnlySpan<long> size, torch.ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, string[]? names = null)
         {
             device = torch.InitializeDevice(device);
             if (!dtype.HasValue) {
@@ -429,12 +410,6 @@ namespace TorchSharp
         /// Returns a tensor filled with the scalar value 1, with the same size as input.
         /// </summary>
         public static Tensor ones_like(Tensor input, ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, string[]? names = null) => input.ones_like(dtype, device, requires_grad);
-
-
-        // empty()
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_empty(IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         /// <summary>
         ///  Create a new tensor filled with empty
@@ -553,10 +528,6 @@ namespace TorchSharp
         /// </summary>
         public static Tensor empty_like(Tensor input, ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, string[]? names = null) => input.empty_like(dtype, device, requires_grad);
 
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_empty_strided(IntPtr psizes, int sz_length, IntPtr pstrides, int str_length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
         /// <summary>
         ///  Returns a tensor filled with uninitialized data. The shape and strides of the tensor is defined by the variable argument size and stride respectively.
         /// </summary>
@@ -588,9 +559,6 @@ namespace TorchSharp
                 }
             }
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_full(IntPtr psizes, int length, IntPtr value, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         /// <summary>
         ///  Create a new tensor filled with a given value
@@ -713,10 +681,6 @@ namespace TorchSharp
         /// </summary>
         public static Tensor full_like(Tensor input, Scalar value, ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, string[]? names = null) => input.full_like(value, dtype, device, requires_grad);
 
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_eye(long rows, long columns, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
         /// <summary>
         ///  Create a 2-D tensor with ones on the diagonal and zeros elsewhere.
         /// </summary>
@@ -746,10 +710,6 @@ namespace TorchSharp
 
             return result;
         }
-
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_randint(IntPtr generator, long low, long high, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         /// <summary>
         ///  Create a new tensor filled with random integer values taken from a uniform distribution in [low, max).
@@ -901,7 +861,7 @@ namespace TorchSharp
         /// <param name="device">The desired device of returned tensor.</param>
         /// <param name="requires_grad">If autograd should record operations on the returned tensor.</param>
         /// <param name="names">Names of the dimensions of the tensor.</param>
-        static private Tensor randint_c32(IntPtr genHandle, long low, long high, long[] size, torch.Device device, bool requires_grad, string[]? names)
+        private static Tensor randint_c32(IntPtr genHandle, long low, long high, long[] size, torch.Device device, bool requires_grad, string[]? names)
         {
             var sz = new List<long>();
             sz.AddRange(size);
@@ -963,7 +923,7 @@ namespace TorchSharp
         /// <param name="device">The desired device of returned tensor.</param>
         /// <param name="requires_grad">If autograd should record operations on the returned tensor.</param>
         /// <param name="names">Names of the dimensions of the tensor.</param>
-        static private Tensor randint_c64(IntPtr genHandle, long low, long high, long[] size, torch.Device device, bool requires_grad, string[]? names)
+        private static Tensor randint_c64(IntPtr genHandle, long low, long high, long[] size, torch.Device device, bool requires_grad, string[]? names)
         {
             var sz = new List<long>();
             sz.AddRange(size);
@@ -1160,7 +1120,7 @@ namespace TorchSharp
 
         /// <summary>
         ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
-        /// </summary>        
+        /// </summary>
         private static Tensor _randn(ReadOnlySpan<long> size, torch.ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, torch.Generator? generator = null, string[]? names = null)
         {
             if (dtype.HasValue && torch.is_integral(dtype.Value))
@@ -1194,7 +1154,7 @@ namespace TorchSharp
 
         /// <summary>
         ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
-        /// </summary>        
+        /// </summary>
         public static Tensor randn(long[] size, torch.ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, torch.Generator? generator = null, string[]? names = null)
         {
             return _randn(size, dtype, device, requires_grad, generator, names);
@@ -1202,7 +1162,7 @@ namespace TorchSharp
 
         /// <summary>
         ///  Create a new tensor filled with random values taken from a normal distribution with mean 0 and variance 1.
-        /// </summary>        
+        /// </summary>
         public static Tensor randn(ReadOnlySpan<long> size, torch.ScalarType? dtype = null, torch.Device? device = null, bool requires_grad = false, torch.Generator? generator = null, string[]? names = null)
         {
             return _randn(size, dtype, device, requires_grad, generator, names);
@@ -2640,7 +2600,7 @@ namespace TorchSharp
 
         /// <summary>
         /// Creates a 1-dimensional Tensor from an array of n dimensions.
-        /// 
+        ///
         /// Skips the first offset bytes in the buffer, and interprets the rest of the raw bytes as a 1-dimensional tensor of type dtype with count elements.
         /// </summary>
         /// <param name="rawArray">The input array</param>
@@ -2726,9 +2686,6 @@ namespace TorchSharp
             }
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_sparse(IntPtr indices, IntPtr values, IntPtr sizes, int length, sbyte type, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
         /// <summary>
         /// Create a sparse tensor by indexing into an existing dense tensor.
         /// </summary>
@@ -2780,9 +2737,6 @@ namespace TorchSharp
             return new Tensor(res);
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_linspace(double start, double end, long steps, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
         /// <summary>
         ///  Create a one-dimensional tensor of size steps whose values are evenly spaced from start to end, inclusive.
         /// </summary>
@@ -2804,9 +2758,6 @@ namespace TorchSharp
             return new Tensor(handle);
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_logspace(double start, double end, long steps, double @base, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
         /// <summary>
         ///  Creates a one-dimensional tensor of size steps whose values are evenly spaced from base^start to base^end, inclusive, on a logarithmic scale with base 'base.'
         /// </summary>
@@ -2827,9 +2778,6 @@ namespace TorchSharp
             if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
             return new Tensor(handle);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_bartlett_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         /// <summary>
         /// Bartlett window function.
@@ -2853,9 +2801,6 @@ namespace TorchSharp
             return new Tensor(handle);
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_blackman_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
         /// <summary>
         /// Blackman window function.
         /// </summary>
@@ -2877,9 +2822,6 @@ namespace TorchSharp
             if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
             return new Tensor(handle);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_hamming_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, double alpha, double beta, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         /// <summary>
         /// Hamming window function.
@@ -2903,9 +2845,6 @@ namespace TorchSharp
             return new Tensor(handle);
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_hann_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
         /// <summary>
         /// Hann window function.
         /// </summary>
@@ -2927,9 +2866,6 @@ namespace TorchSharp
             if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
             return new Tensor(handle);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_kaiser_window(long len, [MarshalAs(UnmanagedType.U1)] bool periodic, double beta, sbyte scalar_type, int device_type, int device_index, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         /// <summary>
         /// Computes the Kaiser window with window length window_length and shape parameter beta.
@@ -2977,71 +2913,8 @@ namespace TorchSharp
             }
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newBoolScalar([MarshalAs(UnmanagedType.U1)] bool scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newByteScalar(byte scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newInt8Scalar(sbyte scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newInt16Scalar(short scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newInt32Scalar(int scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newInt64Scalar(long scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newFloat16Scalar(float scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newFloat32Scalar(float scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newFloat64Scalar(double scalar, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newComplexFloat32Scalar(float real, float imaginary, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newComplexFloat64Scalar(double real, double imaginary, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_frombuffer(IntPtr rawArray, GCHandleDeleter deleter, long count, long offset, sbyte type, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, sbyte type, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_newInt64(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_view_as_complex(IntPtr tensor);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_copy_(IntPtr handle, IntPtr source, [MarshalAs(UnmanagedType.U1)] bool non_blocking);
-
-        [DllImport("LibTorchSharp")]
-        extern static void THSTensor_dispose(IntPtr handle);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_rand(IntPtr generator, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_randn(IntPtr generator, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_complex(IntPtr real, IntPtr imag);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_polar(IntPtr abs, IntPtr angle);
-
-        static private ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
-        static private ScalarType default_dtype = ScalarType.Float32;
+        private static ConcurrentDictionary<GCHandleDeleter, GCHandleDeleter> deleters;
+        private static ScalarType default_dtype = ScalarType.Float32;
 
         static torch()
         {

--- a/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
+++ b/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
@@ -1,19 +1,13 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
-using System.Transactions;
-using ICSharpCode.SharpZipLib.BZip2;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
     public static partial class torch
     {
-
         public partial class Tensor
         {
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cholesky(IntPtr input, bool upper);
-
             /// <summary>
             /// Computes the Cholesky decomposition of a symmetric positive-definite matrix AA or for batches of symmetric positive-definite matrices.
             /// </summary>
@@ -25,9 +19,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cholesky_inverse(IntPtr input, bool upper);
 
             /// <summary>
             /// Computes the inverse of a symmetric positive-definite matrix AA using its Cholesky factor uu : returns matrix inv
@@ -41,9 +32,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cholesky_solve(IntPtr input, IntPtr input2, bool upper);
-
             /// <summary>
             /// Solves a linear system of equations with a positive semidefinite matrix to be inverted given its Cholesky factor matrix u.
             /// </summary>
@@ -56,9 +44,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cross(IntPtr input, IntPtr other, long dim);
 
             /// <summary>
             /// Computes the cross product of two 3-dimensional vectors.
@@ -83,12 +68,6 @@ namespace TorchSharp
                 return torch.linalg.det(this);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_eig(IntPtr tensor, bool eigenvectors, out IntPtr pEigenvectors);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_matmul(IntPtr tensor, IntPtr target);
-
             /// <summary>
             /// Matrix product of two tensors.
             /// </summary>
@@ -109,9 +88,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mm(IntPtr tensor, IntPtr target);
-
             /// <summary>
             /// Performs a matrix multiplication of the matrices input and mat2.
             /// </summary>
@@ -123,9 +99,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mv(IntPtr tensor, IntPtr target);
 
             /// <summary>
             /// Performs a matrix-vector product of the matrix input and the vector vec.
@@ -139,9 +112,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_matrix_exp(IntPtr input);
-
             /// <summary>
             /// Computes the matrix exponential of a square matrix or of each square matrix in a batch.
             /// </summary>
@@ -151,9 +121,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSLinalg_matrix_power(IntPtr tensor, long n);
 
             /// <summary>
             /// Computes the n-th power of a square matrix for an integer n.
@@ -168,11 +135,8 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_vdot(IntPtr tensor, IntPtr target);
-
             /// <summary>
-            /// Computes the dot product of two 1D tensors. 
+            /// Computes the dot product of two 1D tensors.
             /// </summary>
             /// <param name="target"></param>
             /// <returns></returns>
@@ -187,9 +151,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSLinalg_pinverse(IntPtr tensor, double rcond, bool hermitian);
 
             /// <summary>
             /// Computes the pseudoinverse (Moore-Penrose inverse) of a matrix.
@@ -207,7 +168,6 @@ namespace TorchSharp
             }
         }
 
-
         /// <summary>
         /// Computes the pseudoinverse (Moore-Penrose inverse) of a matrix.
         /// </summary>
@@ -216,7 +176,6 @@ namespace TorchSharp
         /// <param name="hermitian">Indicates whether A is Hermitian if complex or symmetric if real. </param>
         /// <remarks>Input should be tensor of shape (*, m, n) where * is zero or more batch dimensions.</remarks>
         public static Tensor pinverse(Tensor input, double rcond = 1e-15, bool hermitian = false) => input.pinverse(rcond, hermitian);
-
 
         /// <summary>
         /// Computes the Cholesky decomposition of a symmetric positive-definite matrix 'input' or for batches of symmetric positive-definite matrices.
@@ -322,7 +281,7 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The input tensor</param>
         /// <returns></returns>
-        public static Tensor trace(Tensor input) => input.trace(); 
+        public static Tensor trace(Tensor input) => input.trace();
 
         /// <summary>
         /// Returns a partial view of input with the its diagonal elements with respect to dim1 and dim2 appended as a dimension at the end of the shape.
@@ -341,16 +300,6 @@ namespace TorchSharp
         /// However, torch.diag_embed() has different default dimensions, so those need to be explicitly specified.
         /// </remarks>
         public static Tensor diagonal(Tensor input, long offset = 0, long dim1 = 0, long dim2 = 0) => input.diagonal(offset, dim1, dim2);
-
-        [DllImport("LibTorchSharp")]
-        static extern IntPtr THSTensor_lu(IntPtr tensor, bool pivot, bool get_infos, out IntPtr infos, out IntPtr pivots);
-
-        [DllImport("LibTorchSharp")]
-        static extern IntPtr THSTensor_lu_solve(IntPtr tensor, IntPtr LU_data, IntPtr LU_pivots);
-
-        [DllImport("LibTorchSharp")]
-        static extern IntPtr THSTensor_lu_unpack(IntPtr LU_data, IntPtr LU_pivots, bool unpack_data, bool unpack_pivots, out IntPtr L, out IntPtr U);
-
 
         /// <summary>
         /// Computes the LU factorization of a matrix or batches of matrices A. Returns a tuple containing the LU factorization and pivots of A. Pivoting is done if pivot is set to true.
@@ -399,7 +348,6 @@ namespace TorchSharp
                 torch.CheckForErrors();
             return (new Tensor(solution), L == IntPtr.Zero ? null : new Tensor(L), U == IntPtr.Zero ? null : new Tensor(U));
         }
-
 
         /// <summary>
         /// Matrix product of two tensors.
@@ -455,7 +403,7 @@ namespace TorchSharp
         public static Tensor norm(Tensor input) => input.norm();
 
         /// <summary>
-        /// Computes the dot product of two 1D tensors. 
+        /// Computes the dot product of two 1D tensors.
         /// </summary>
         /// <param name="input"></param>
         /// <param name="target"></param>

--- a/src/TorchSharp/Tensor/Tensor.Math.cs
+++ b/src/TorchSharp/Tensor/Tensor.Math.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -20,8 +20,6 @@ namespace TorchSharp
 
         public partial class Tensor
         {
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_abs(IntPtr tensor);
 
             /// <summary>
             /// Compute the absolute value of each element in the tensor
@@ -39,9 +37,6 @@ namespace TorchSharp
             /// </summary>
             public Tensor absolute() => abs();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_abs_(IntPtr tensor);
-
             /// <summary>
             /// Compute the absolute value of each element in the tensor, in-place.
             /// </summary>
@@ -57,9 +52,6 @@ namespace TorchSharp
             /// Compute the absolute value of each element in the tensor, in-place
             /// </summary>
             public Tensor absolute_() => abs_();
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_add(IntPtr tensor, IntPtr trg, IntPtr alpha);
 
             /// <summary>
             /// Add two tensors, element-wise
@@ -85,9 +77,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_add_scalar(IntPtr tensor, IntPtr trg, IntPtr alpha);
-
             /// <summary>
             /// Add a scalar value to each element in the target tensor.
             /// </summary>
@@ -111,9 +100,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_add_(IntPtr tensor, IntPtr trg, IntPtr alpha);
 
             /// <summary>
             /// In-place element-wise addition.
@@ -139,9 +125,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_add_scalar_(IntPtr tensor, IntPtr trg, IntPtr alpha);
-
             /// <summary>
             /// In-place scalar addition.
             /// </summary>
@@ -166,9 +149,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addbmm(IntPtr mat, IntPtr batch1, IntPtr batch2, float beta, float alpha);
-
             /// <summary>
             /// Performs a batch matrix-matrix product of matrices stored in batch1 and batch2, with a reduced
             /// add step (all matrix multiplications get accumulated along the first dimension).
@@ -187,9 +167,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addbmm_(IntPtr mat, IntPtr batch1, IntPtr batch2, float beta, float alpha);
-
             /// <summary>
             /// Performs an in-place batch matrix-matrix product of matrices stored in batch1 and batch2, with a reduced
             /// add step (all matrix multiplications get accumulated along the first dimension).
@@ -207,9 +184,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addcdiv(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
 
             /// <summary>
             /// Performs the element-wise division of tensor1 by tensor2, multiply the result by the scalar value and add it to input.
@@ -237,9 +211,6 @@ namespace TorchSharp
                 return addcdiv(tensor1, tensor2, 1);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addcdiv_(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
-
             /// <summary>
             /// Performs the in-place element-wise division of tensor1 by tensor2, multiply the result by the scalar value and add it to input.
             /// </summary>
@@ -266,9 +237,6 @@ namespace TorchSharp
                 return addcdiv_(tensor1, tensor2, 1);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addcmul(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
-
             /// <summary>
             /// Performs the element-wise multiplication of tensor1 by tensor2, multiply the result by the scalar value and add it to input.
             /// </summary>
@@ -284,9 +252,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addcmul_(IntPtr tensor, IntPtr tensor1, IntPtr tensor2, IntPtr value);
-
             /// <summary>
             /// Performs the in-place element-wise multiplication of tensor1 by tensor2, multiply the result by the scalar value and add it to input.
             /// </summary>
@@ -301,10 +266,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addmm(IntPtr mat, IntPtr mat1, IntPtr mat2, float beta, float alpha);
 
             /// <summary>
             /// Performs a matrix multiplication of the matrices mat1 and mat2. The matrix input is added to the final result.
@@ -322,9 +283,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addmm_(IntPtr mat, IntPtr mat1, IntPtr mat2, float beta, float alpha);
-
             /// <summary>
             /// Performs an in-place matrix multiplication of the matrices mat1 and mat2. The matrix input is added to the final result.
             /// </summary>
@@ -340,9 +298,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addmv(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta = 1, float alpha = 1);
 
             /// <summary>
             /// Performs a matrix-vector product of the matrix mat and the vector vec. The vector input is added to the final result.
@@ -360,9 +315,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addmv_(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
-
             /// <summary>
             /// Performs a matrix-vector product of the matrix mat and the vector vec. The vector input is added to the final result.
             /// </summary>
@@ -379,9 +331,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addr(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
-
             /// <summary>
             /// Performs the outer-product of vectors vec1 and vec2 and adds it to the input tensor.
             /// </summary>
@@ -397,9 +346,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_addr_(IntPtr mat, IntPtr mat1, IntPtr vec2, float beta, float alpha);
 
             /// <summary>
             /// Performs the outer-product of vectors vec1 and vec2 and adds it to the input tensor.
@@ -419,9 +365,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_and(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Element-wise bitwise AND
             /// </summary>
@@ -433,9 +376,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_and_(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Element-wise bitwise AND, in-place
@@ -449,9 +389,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_not(IntPtr tensor);
-
             /// <summary>
             /// Element-wise bitwise NOT
             /// </summary>
@@ -463,9 +400,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_not_(IntPtr tensor);
-
             /// <summary>
             /// Element-wise bitwise NOT, in-place
             /// </summary>
@@ -476,9 +410,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_or(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Element-wise bitwise OR
@@ -492,9 +423,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_or_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Element-wise bitwise OR, in-place
             /// </summary>
@@ -506,9 +434,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_xor(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Element-wise bitwise XOR
@@ -522,9 +447,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_xor_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Element-wise bitwise XOR, in-place.
             /// </summary>
@@ -536,9 +458,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_left_shift(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Element-wise bitwise left_shift
@@ -552,9 +471,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_left_shift_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Element-wise bitwise left_shift, in-place.
             /// </summary>
@@ -566,9 +482,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_right_shift(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Element-wise bitwise right_shift
@@ -582,9 +495,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bitwise_right_shift_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Element-wise bitwise right_shift, in-place.
             /// </summary>
@@ -596,9 +506,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ceil(IntPtr tensor);
 
             /// <summary>
             /// Returns a new tensor with the ceil of the elements of input, the smallest integer greater than or equal to each element.
@@ -612,9 +519,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ceil_(IntPtr tensor);
-
             /// <summary>
             /// Replaces each element of the input with the smallest integer greater than or equal to the element.
             /// </summary>
@@ -626,9 +530,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_conj(IntPtr tensor);
 
             /// <summary>
             /// Returns a view of input with a flipped conjugate bit. If input has a non-complex dtype, this function just returns input.
@@ -642,9 +543,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_conj_physical(IntPtr tensor);
-
             /// <summary>
             /// Computes the element-wise conjugate of the given input tensor. If input has a non-complex dtype, this function just returns input.
             /// </summary>
@@ -656,9 +554,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_conj_physical_(IntPtr tensor);
 
             /// <summary>
             /// In-place version of conj_physical
@@ -672,9 +567,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern long THSTensor_is_conj(IntPtr tensor);
-
             /// <summary>
             /// Returns true if the input is a conjugated tensor, i.e. its conjugate bit is set to True.
             /// </summary>
@@ -685,9 +577,6 @@ namespace TorchSharp
                 torch.CheckForErrors();
                 return res != 0;
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_resolve_conj(IntPtr tensor);
 
             /// <summary>
             /// Returns a new tensor with materialized conjugation if input’s conjugate bit is set to True, else returns input.
@@ -701,9 +590,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_cummax(IntPtr tensor, AllocatePinnedArray allocator, long dim);
 
             /// <summary>
             /// Returns a tuple (values, indices) where values is the cumulative maximum of elements of input in the dimension dim.
@@ -723,9 +609,6 @@ namespace TorchSharp
                 return (new Tensor(ptrArray[0]), new Tensor(ptrArray[1]));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_cummin(IntPtr tensor, AllocatePinnedArray allocator, long dim);
-
             /// <summary>
             /// Returns a tuple (values, indices) where values is the cumulative minimum of elements of input in the dimension dim.
             /// Indices is the index location of each minimum value found in the dimension dim.
@@ -744,9 +627,6 @@ namespace TorchSharp
                 return (new Tensor(ptrArray[0]), new Tensor(ptrArray[1]));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cumsum(IntPtr tensor, long dim, bool has_type, sbyte scalar_type);
-
             /// <summary>
             /// Returns the cumulative sum of elements of input in the dimension dim.
             /// </summary>
@@ -761,9 +641,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cumprod(IntPtr tensor, long dim, bool has_type, sbyte scalar_type);
-
             /// <summary>
             /// Returns the cumulative product of elements of input in the dimension dim.
             /// </summary>
@@ -777,9 +654,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_div(IntPtr tensor, IntPtr trg, [MarshalAs(UnmanagedType.LPStr)] string rounding_mode);
 
             /// <summary>
             /// Divides each element of the input by the corresponding element of other.
@@ -802,9 +676,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor divide(Tensor target, RoundingMode rounding_mode = RoundingMode.None) => div(target, rounding_mode);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_div_scalar(IntPtr tensor, IntPtr trg, [MarshalAs(UnmanagedType.LPStr)] string rounding_mode);
-
             /// <summary>
             /// Scalar division
             /// </summary>
@@ -825,9 +696,6 @@ namespace TorchSharp
             /// <param name="rounding_mode">Rounding mode.</param>
             /// <returns></returns>
             public Tensor divide(Scalar target, RoundingMode rounding_mode = RoundingMode.None) => div(target, rounding_mode);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_div_(IntPtr tensor, IntPtr trg, [MarshalAs(UnmanagedType.LPStr)] string rounding_mode);
 
             /// <summary>
             /// In-place division
@@ -850,9 +718,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor divide_(Tensor target, RoundingMode rounding_mode = RoundingMode.None) => div_(target, rounding_mode);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_div_scalar_(IntPtr tensor, IntPtr trg, [MarshalAs(UnmanagedType.LPStr)] string rounding_mode);
-
             /// <summary>
             /// In-place scalar division
             /// </summary>
@@ -874,9 +739,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor divide_(Scalar target, RoundingMode rounding_mode = RoundingMode.None) => div_(target, rounding_mode);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_exp(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the exponential of the elements of the input tensor.
             /// </summary>
@@ -887,9 +749,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_exp_(IntPtr tensor);
-
             /// <summary>
             /// Replaces the tensor with the exponential of the elements of the input tensor.
             /// </summary>
@@ -899,9 +758,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_exp2(IntPtr tensor);
 
             /// <summary>
             /// Computes the base 2 exponential function of input.
@@ -914,9 +770,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_expm1(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the exponential of the elements minus 1 of input.
             /// </summary>
@@ -928,9 +781,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_expm1_(IntPtr tensor);
-
             /// <summary>
             /// Replaces each element with the exponential of the element minus 1 of input, in-place.
             /// </summary>
@@ -941,9 +791,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_float_power(IntPtr tensor, IntPtr trg);
 
             /// <summary>
             /// Raises input to the power of exponent, elementwise, in double precision.
@@ -958,9 +805,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_floor(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the floor of the elements of input, the largest integer less than or equal to each element.
             /// </summary>
@@ -972,9 +816,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_floor_(IntPtr tensor);
 
             /// <summary>
             /// Replaces each element with the floor of the input, the largest integer less than or equal to each element.
@@ -988,9 +829,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fmod(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Computes the element-wise remainder of division.
             /// </summary>
@@ -1002,9 +840,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fmod_(IntPtr tensor, IntPtr trg);
 
             /// <summary>
             /// Computes the element-wise remainder of division, in-place.
@@ -1018,9 +853,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fmod_scalar(IntPtr tensor, IntPtr scalar);
-
             /// <summary>
             /// Computes the element-wise remainder of division.
             /// </summary>
@@ -1032,9 +864,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fmod_scalar_(IntPtr tensor, IntPtr scalar);
 
             /// <summary>
             /// Computes the element-wise remainder of division, in-place
@@ -1048,9 +877,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_frac(IntPtr tensor);
-
             /// <summary>
             /// Computes the fractional portion of each element in input.
             /// </summary>
@@ -1061,9 +887,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_frac_(IntPtr tensor);
 
             /// <summary>
             /// Computes the fractional portion of each element in input, in-place.
@@ -1076,11 +899,8 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_frexp(IntPtr tensor, out IntPtr exponent);
-
             /// <summary>
-            /// Decomposes input into mantissa and exponent tensors 
+            /// Decomposes input into mantissa and exponent tensors
             /// </summary>
             /// <returns></returns>
             public (Tensor Mantissa, Tensor Exponent) frexp()
@@ -1090,9 +910,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return (new Tensor(mantissa), new Tensor(exponent));
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_gcd(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Computes the element-wise greatest common divisor (GCD) of input and other.
@@ -1105,9 +922,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_gcd_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Computes the element-wise greatest common divisor (GCD) of input and other.
             /// </summary>
@@ -1119,9 +933,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_histc(IntPtr tensor, long bins, long min, long max);
 
             /// <summary>
             /// Computes the histogram of a tensor.
@@ -1140,9 +951,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_hypot(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Element-wise: given the legs of a right triangle, return its hypotenuse.
             /// </summary>
@@ -1156,9 +964,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the natural logarithm of the input elements.
             /// </summary>
@@ -1170,9 +975,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log_(IntPtr tensor);
-
             /// <summary>
             /// Replaces each elements with the natural logarithm of the input.
             /// </summary>
@@ -1182,9 +984,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logaddexp(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Logarithm of the sum of exponentiations of the inputs.
@@ -1199,9 +998,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logaddexp2(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Logarithm of the sum of exponentiations of the inputs in base-2.
             /// </summary>
@@ -1214,9 +1010,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logcumsumexp(IntPtr tensor, long dim);
 
             /// <summary>
             /// Returns the logarithm of the cumulative summation of the exponentiation of elements of input in the dimension dim.
@@ -1231,17 +1024,14 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logsumexp(IntPtr tensor, long dim, bool keepdim);
-
             /// <summary>
-            /// Returns the log of summed exponentials of each row of the input tensor in the given dimension dim. 
+            /// Returns the log of summed exponentials of each row of the input tensor in the given dimension dim.
             /// </summary>
             /// <param name="dim">The dimension to do the operation over</param>
             /// <param name="keepdim">Thether the output tensor has dim retained or not.</param>
             /// <returns></returns>
             /// <remarks>The computation is numerically stabilized.</remarks>
-            public Tensor logsumexp(long dim, Boolean keepdim = false)
+            public Tensor logsumexp(long dim, bool keepdim = false)
             {
                 var res = THSTensor_logsumexp(Handle, dim, keepdim);
                 if (res == IntPtr.Zero)
@@ -1256,9 +1046,6 @@ namespace TorchSharp
             /// <param name="dtype">The desired data type of returned tensor.</param>
             public Tensor log_softmax(long dim, ScalarType? dtype = null) => torch.special.log_softmax(this, dim, dtype);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log10(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the logarithm to the base 10 of the elements of input.
             /// </summary>
@@ -1270,9 +1057,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log10_(IntPtr tensor);
 
             /// <summary>
             /// Replaces elements with the logarithm to the base 10 of the elements of input.
@@ -1286,9 +1070,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log1p(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the natural logarithm of (1 + input).
             /// </summary>
@@ -1301,9 +1082,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log1p_(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the natural logarithm of (1 + input), inplace.
             /// </summary>
@@ -1314,9 +1092,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log2(IntPtr tensor);
 
             /// <summary>
             /// Returns a new tensor with the logarithm to the base 2 of the elements of input.
@@ -1330,9 +1105,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log2_(IntPtr tensor);
-
             /// <summary>
             /// Replaces each element with the logarithm to the base 2 of the input.
             /// </summary>
@@ -1343,9 +1115,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logical_and(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Logical AND
@@ -1359,9 +1128,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logical_and_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Logical AND, in place
             /// </summary>
@@ -1374,9 +1140,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logical_not(IntPtr tensor);
-
             /// <summary>
             /// Logical NOT
             /// </summary>
@@ -1388,9 +1151,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logical_not_(IntPtr tensor);
-
             /// <summary>
             /// Logical NOT, in place
             /// </summary>
@@ -1401,9 +1161,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logical_or(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Logical OR
@@ -1417,9 +1174,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logical_or_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Logical OR, in place
             /// </summary>
@@ -1431,9 +1185,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logical_xor(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Logical XOR
@@ -1447,9 +1198,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logical_xor_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Logical XOR, in place
             /// </summary>
@@ -1461,9 +1209,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_logit(IntPtr tensor, IntPtr eps);
 
             /// <summary>
             /// Returns a new tensor with the logit of the elements of input.
@@ -1484,9 +1229,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mul(IntPtr tensor, IntPtr target);
-
             /// <summary>
             /// Element-wise multiplication
             /// </summary>
@@ -1505,9 +1247,6 @@ namespace TorchSharp
             /// <param name="target">Right-hand operand</param>
             /// <returns></returns>
             public Tensor multiply(Tensor target) => mul(target);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mul_scalar(IntPtr tensor, IntPtr scalar);
 
             /// <summary>
             /// Element-wise multiplication
@@ -1528,9 +1267,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor multiply(Scalar target) => mul(target);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mul_(IntPtr tensor, IntPtr target);
-
             /// <summary>
             /// Element-wise multiplication, in place
             /// </summary>
@@ -1542,9 +1278,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mul_scalar_(IntPtr tensor, IntPtr target);
 
             /// <summary>
             /// Element-wise multiplication, in place
@@ -1563,9 +1296,6 @@ namespace TorchSharp
                 return tensor.neg();
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_neg(IntPtr tensor);
-
             /// <summary>
             /// Negation
             /// </summary>
@@ -1583,9 +1313,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor negative() => neg();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_neg_(IntPtr tensor);
-
             /// <summary>
             /// In-place negation
             /// </summary>
@@ -1596,9 +1323,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_pow(IntPtr tensor, IntPtr exponent);
 
             /// <summary>
             /// Takes the power of each element in input with exponent and returns a tensor with the result.
@@ -1612,9 +1336,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_pow_(IntPtr tensor, IntPtr exponent);
-
             /// <summary>
             /// Replaces each element in input with the power of the element and the exponent.
             /// </summary>
@@ -1626,9 +1347,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_pow_scalar(IntPtr tensor, IntPtr scalar);
 
             /// <summary>
             /// Takes the power of each element in input with exponent and returns a tensor with the result.
@@ -1642,9 +1360,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_pow_scalar_(IntPtr tensor, IntPtr scalar);
-
             /// <summary>
             /// Replaces each element in input with the power of the element and the exponent.
             /// </summary>
@@ -1656,9 +1371,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_reciprocal(IntPtr tensor);
 
             /// <summary>
             /// Returns a new tensor with the reciprocal of the elements of input
@@ -1672,9 +1384,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_reciprocal_(IntPtr tensor);
-
             /// <summary>
             /// Replaces each element with the reciprocal of the input
             /// </summary>
@@ -1686,9 +1395,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_remainder(IntPtr tensor, IntPtr trg);
 
             /// <summary>
             /// Computes the element-wise remainder of division.
@@ -1702,9 +1408,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_remainder_(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Computes the element-wise remainder of division, in place
             /// </summary>
@@ -1716,9 +1419,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_remainder_scalar(IntPtr tensor, IntPtr scalar);
 
             /// <summary>
             /// Computes the element-wise remainder of division.
@@ -1733,9 +1433,6 @@ namespace TorchSharp
             }
 
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_remainder_scalar_(IntPtr tensor, IntPtr scalar);
-
             /// <summary>
             /// Computes the element-wise remainder of division.
             /// </summary>
@@ -1747,9 +1444,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_round(IntPtr tensor, long decimals);
 
             /// <summary>
             /// Returns a new tensor with each of the elements of input rounded to the closest value with the given number of decimals.
@@ -1764,9 +1458,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_round_(IntPtr tensor, long decimals);
-
             /// <summary>
             /// Replaces each of the elements of input with the element rounded to the closest value with the given number of decimals.
             /// </summary>
@@ -1780,9 +1471,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_rsqrt(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the reciprocal of the square-root of each of the elements of input.
             /// </summary>
@@ -1793,9 +1481,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_rsqrt_(IntPtr tensor);
 
             /// <summary>
             /// Replaces each of the elements of input with  the reciprocal of the square-root of each of the elements of input.
@@ -1814,9 +1499,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor square() => pow(2);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sqrt(IntPtr tensor);
-
             /// <summary>
             /// Computes the element-wise square root
             /// </summary>
@@ -1828,9 +1510,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sqrt_(IntPtr tensor);
-
             /// <summary>
             /// Computes the element-wise square root, in place
             /// </summary>
@@ -1841,9 +1520,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sign(IntPtr tensor);
 
             /// <summary>
             /// Returns a new tensor with the signs (-1, 0, 1) of the elements of input.
@@ -1857,9 +1533,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sign_(IntPtr tensor);
-
             /// <summary>
             /// Replaces each element with the signs (-1, 0, 1) of the elements of input.
             /// </summary>
@@ -1871,9 +1544,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_signbit(IntPtr tensor);
 
             /// <summary>
             /// Tests if each element of input has its sign bit set (is less than zero) or not.
@@ -1887,9 +1557,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sub(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Element-wise subtraction
             /// </summary>
@@ -1901,9 +1568,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sub_scalar(IntPtr tensor, IntPtr trg);
 
             /// <summary>
             /// Element-wise subtraction
@@ -1917,9 +1581,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sub_(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Element-wise subtraction, in place
             /// </summary>
@@ -1932,9 +1593,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sub_scalar_(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Element-wise subtraction, in-place
             /// </summary>
@@ -1946,12 +1604,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cumulative_trapezoid_x(IntPtr y, IntPtr x, long dim);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cumulative_trapezoid_dx(IntPtr y, double dx, long dim);
 
             /// <summary>
             /// Cumulatively computes the trapezoidal rule along dim. By default the spacing between elements is assumed to be 1,
@@ -1981,12 +1633,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_trapezoid_x(IntPtr y, IntPtr x, long dim);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_trapezoid_dx(IntPtr y, double dx, long dim);
-
             /// <summary>
             /// Computes the trapezoidal rule along dim. By default the spacing between elements is assumed to be 1,
             /// but dx can be used to specify a different constant spacing.
@@ -2015,9 +1661,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_trunc(IntPtr tensor);
-
             /// <summary>
             /// Returns a new tensor with the truncated integer values of the elements of input.
             /// </summary>
@@ -2034,9 +1677,6 @@ namespace TorchSharp
             /// </summary>
             /// <returns></returns>
             public Tensor fix() => trunc();
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_trunc_(IntPtr tensor);
 
             /// <summary>
             /// Replaces each element with the truncated integer values of the elements of input.
@@ -2055,9 +1695,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor fix_() => trunc_();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_xlogy(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Computes x * log(y)
             /// </summary>
@@ -2070,10 +1707,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_xlogy_(IntPtr tensor, IntPtr trg);
 
             /// <summary>
             /// Computes x * log(y) in place
@@ -2088,9 +1721,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_xlogy_scalar(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Computes x * log(y)
             /// </summary>
@@ -2103,10 +1733,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_xlogy_scalar_(IntPtr tensor, IntPtr trg);
 
             /// <summary>
             /// Computes x * log(y) in place
@@ -2638,9 +2264,6 @@ namespace TorchSharp
         /// <param name="right">Denominator</param>
         public static Tensor divide_(Tensor left, Scalar right) => left.div_(right);
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_einsum([MarshalAs(UnmanagedType.LPStr)] string location, IntPtr tensors, int len);
-
         /// <summary>
         /// Sums the product of the elements of the input operands along dimensions specified using a notation based on the Einstein summation convention.
         /// </summary>
@@ -2755,7 +2378,7 @@ namespace TorchSharp
 
         /// <summary>
         /// Computes the element-wise maximum of input and other.
-        /// 
+        ///
         /// This is like torch.maximum() except it handles NaNs differently: if exactly one of the two elements being compared is a NaN
         /// then the non-NaN element is taken as the maximum.
         /// Only if both elements are NaN is NaN propagated.
@@ -2766,7 +2389,7 @@ namespace TorchSharp
 
         /// <summary>
         /// Computes the element-wise minimum of input and other.
-        /// 
+        ///
         /// This is like torch.minimum() except it handles NaNs differently: if exactly one of the two elements being compared is a NaN
         /// then the non-NaN element is taken as the minimum.
         /// Only if both elements are NaN is NaN propagated.
@@ -2814,7 +2437,7 @@ namespace TorchSharp
         public static Tensor frac_(Tensor input) => input.frac_();
 
         /// <summary>
-        /// Decomposes input into mantissa and exponent tensors 
+        /// Decomposes input into mantissa and exponent tensors
         /// </summary>
         /// <param name="input">The input tensor.</param>
         public static (Tensor Mantissa, Tensor Exponent) frexp(Tensor input) => input.frexp();
@@ -2866,7 +2489,7 @@ namespace TorchSharp
         public static Tensor hypot(Tensor left, Tensor right) => left.hypot(right);
 
         /// <summary>
-        /// Outer product of input and vec2. 
+        /// Outer product of input and vec2.
         /// </summary>
         /// <param name="input">1-D input vector.</param>
         /// <param name="vec2">1-D input vector.</param>
@@ -3040,12 +2663,12 @@ namespace TorchSharp
         public static Tensor logcumsumexp(Tensor input, long dim) => input.logcumsumexp(dim);
 
         /// <summary>
-        /// Returns the log of summed exponentials of each row of the input tensor in the given dimension dim. 
+        /// Returns the log of summed exponentials of each row of the input tensor in the given dimension dim.
         /// </summary>
         /// <param name="input">The input tensor.</param>
         /// <param name="dim">The dimension to do the operation over</param>
         /// <param name="keepdim">Thether the output tensor has dim retained or not.</param>
-        public static Tensor logsumexp(Tensor input, long dim, Boolean keepdim = false) => input.logsumexp(dim, keepdim);
+        public static Tensor logsumexp(Tensor input, long dim, bool keepdim = false) => input.logsumexp(dim, keepdim);
 
         /// <summary>
         /// Returns a new tensor with the logarithm to the base 10 of the elements of input.
@@ -3131,7 +2754,7 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The first input tensor</param>
         /// <param name="other">The second input tensor</param>
-        static public Tensor maximum(Tensor input, Tensor other) => input.maximum(other);
+        public static Tensor maximum(Tensor input, Tensor other) => input.maximum(other);
 
         /// <summary>
         /// Returns a named tuple (values, indexes) where values is the maximum value of each row of the input tensor in the given dimension dim.
@@ -3143,7 +2766,7 @@ namespace TorchSharp
         /// <remarks>If keepdim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
         /// Otherwise, dim is squeezed(see torch.squeeze()), resulting in the output tensors having 1 fewer dimension than input.</remarks>
 
-        static public (Tensor values, Tensor indexes) max(Tensor input, long dim, bool keepdim = false) => input.max(dim, keepdim);
+        public static (Tensor values, Tensor indexes) max(Tensor input, long dim, bool keepdim = false) => input.max(dim, keepdim);
 
         /// <summary>
         /// Returns the mean value of all elements in the input tensor.
@@ -3174,7 +2797,7 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The first input tensor</param>
         /// <param name="other">The second input tensor</param>
-        static public Tensor minimum(Tensor input, Tensor other) => input.minimum(other);
+        public static Tensor minimum(Tensor input, Tensor other) => input.minimum(other);
 
         /// <summary>
         /// Returns a named tuple (values, indexes) where values is the minimum value of each row of the input tensor in the given dimension dim.
@@ -3185,7 +2808,7 @@ namespace TorchSharp
         /// <param name="keepdim">whether the output tensor has dim retained or not. Default: false.</param>
         /// <remarks>If keepdim is true, the output tensors are of the same size as input except in the dimension dim where they are of size 1.
         /// Otherwise, dim is squeezed(see torch.squeeze()), resulting in the output tensors having 1 fewer dimension than input.</remarks>
-        static public (Tensor values, Tensor indexes) min(Tensor input, long dim, bool keepdim = false) => input.min(dim, keepdim);
+        public static (Tensor values, Tensor indexes) min(Tensor input, long dim, bool keepdim = false) => input.min(dim, keepdim);
 
         /// <summary>
         /// Multiplies each element of the input by the corresponding element of other.
@@ -3841,7 +3464,7 @@ namespace TorchSharp
         public static Tensor rand_like(Tensor input, ScalarType? dtype = null, torch.Device device = null, bool requires_grad = false) => input.rand_like(dtype, device, requires_grad);
 
         /// <summary>
-        /// Returns a tensor with the same size as input that is filled with random numbers from a normal distribution with mean 0 and variance 1. 
+        /// Returns a tensor with the same size as input that is filled with random numbers from a normal distribution with mean 0 and variance 1.
         /// </summary>
         public static Tensor randn_like(Tensor input, ScalarType? dtype = null, torch.Device device = null, bool requires_grad = false) => input.randn_like(dtype, device, requires_grad);
 
@@ -3864,7 +3487,7 @@ namespace TorchSharp
         public static Tensor bernoulli(Tensor input, torch.Generator generator = null) => input.bernoulli(generator);
 
         /// <summary>
-        /// Returns a new tensor with boolean elements representing if each element of input is <value>NaN</value> or not. 
+        /// Returns a new tensor with boolean elements representing if each element of input is <value>NaN</value> or not.
         /// Complex values are considered <value>NaN</value> when either their real and/or imaginary part is <value>NaN</value>.
         /// </summary>
         /// <param name="input">the input tensor</param>

--- a/src/TorchSharp/Tensor/Tensor.Trig.cs
+++ b/src/TorchSharp/Tensor/Tensor.Trig.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -15,9 +15,6 @@ namespace TorchSharp
 
         public partial class Tensor
         {
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_angle(IntPtr tensor);
-
             /// <summary>
             /// Computes the element-wise angle (in radians) of the given input tensor.
             /// </summary>
@@ -33,9 +30,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_asin(IntPtr tensor);
 
             /// <summary>
             /// Computes the arcsine of the elements of input.
@@ -55,9 +49,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arcsin() => asin();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_asin_(IntPtr tensor);
-
             /// <summary>
             /// Computes the arcsine of the elements of input.
             /// </summary>
@@ -71,9 +62,6 @@ namespace TorchSharp
             }
 
             public Tensor arcsin_() => asin_();
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_acos(IntPtr tensor);
 
             /// <summary>
             /// Computes the arccosine of the elements of input.
@@ -93,9 +81,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arccos() => acos();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_acos_(IntPtr tensor);
-
             /// <summary>
             /// Computes the arccosine of the elements of input.
             /// </summary>
@@ -113,9 +98,6 @@ namespace TorchSharp
             /// </summary>
             /// <returns></returns>
             public Tensor arccos_() => acos_();
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_atan(IntPtr tensor);
 
             /// <summary>
             /// Computes the arctangent of the elements of input.
@@ -135,9 +117,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arctan() => atan();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_atan_(IntPtr tensor);
-
             /// <summary>
             /// Computes the arctangent of the elements of input.
             /// </summary>
@@ -156,9 +135,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor arctan_() => atan_();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_atan2(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Element-wise arctangent of input / other with consideration of the quadrant.
             /// </summary>
@@ -170,9 +146,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_atan2_(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Element-wise arctangent of input / other with consideration of the quadrant.
@@ -187,9 +160,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cos(IntPtr tensor);
-
             /// <summary>
             /// Computes the cosine of the elements of input.
             /// </summary>
@@ -201,9 +171,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cos_(IntPtr tensor);
 
             /// <summary>
             /// Computes the cosine of the elements of input.
@@ -217,9 +184,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sin(IntPtr tensor);
-
             /// <summary>
             /// Computes the sine of the elements of input.
             /// </summary>
@@ -231,9 +195,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sin_(IntPtr tensor);
 
             /// <summary>
             /// Computes the sine of the elements of input.
@@ -247,9 +208,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_tan(IntPtr tensor);
-
             /// <summary>
             /// Computes the tangent of the elements of input.
             /// </summary>
@@ -261,9 +219,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_tan_(IntPtr tensor);
 
             /// <summary>
             /// Computes the tangent of the elements of input.
@@ -277,9 +232,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sinc(IntPtr tensor);
-
             /// <summary>
             /// Computes the normalized sinc of input.
             /// </summary>
@@ -291,9 +243,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sinc_(IntPtr tensor);
 
             /// <summary>
             /// Computes the normalized sinc of input, in place.
@@ -307,9 +256,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sinh(IntPtr tensor);
-
             /// <summary>
             /// Computes the hyperbolic sine of the elements of input.
             /// </summary>
@@ -321,9 +267,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sinh_(IntPtr tensor);
 
             /// <summary>
             /// Computes the hyperbolic sine of the elements of input.
@@ -337,9 +280,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cosh(IntPtr tensor);
-
             /// <summary>
             /// Computes the hyperbolic cosine of the elements of input.
             /// </summary>
@@ -352,9 +292,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cosh_(IntPtr tensor);
-
             /// <summary>
             /// Computes the hyperbolic cosine of the elements of input.
             /// </summary>
@@ -366,8 +303,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_tanh(IntPtr tensor);
 
             /// <summary>
             /// Computes the hyperbolic tangent of the elements of input.
@@ -381,9 +316,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_tanh_(IntPtr tensor);
-
             /// <summary>
             /// Computes the hyperbolic tangent of the elements of input.
             /// </summary>
@@ -395,9 +327,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_arcsinh(IntPtr tensor);
 
             /// <summary>
             /// Computes the hyperbolic arcsine of the elements of input.
@@ -417,9 +346,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor asinh() => arcsinh();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_arcsinh_(IntPtr tensor);
-
             /// <summary>
             /// Computes the hyperbolic arcsine of the elements of input.
             /// </summary>
@@ -437,9 +363,6 @@ namespace TorchSharp
             /// </summary>
             /// <returns></returns>
             public Tensor asinh_() => arcsinh_();
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_arccosh(IntPtr tensor);
 
             /// <summary>
             /// Computes the hyperbolic arccosine of the elements of input.
@@ -459,10 +382,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor acosh() => arccosh();
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_arccosh_(IntPtr tensor);
-
             /// <summary>
             /// Computes the hyperbolic arccosine of the elements of input.
             /// </summary>
@@ -481,9 +400,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor acosh_() => arccosh_();
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_arctanh(IntPtr tensor);
-
             /// <summary>
             /// Computes the hyperbolic arctangent of the elements of input.
             /// </summary>
@@ -501,9 +417,6 @@ namespace TorchSharp
             /// </summary>
             /// <returns></returns>
             public Tensor atanh() => arctanh();
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_arctanh_(IntPtr tensor);
 
             /// <summary>
             /// Computes the hyperbolic arctangent of the elements of input.

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -8,15 +8,13 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Diagnostics.Contracts;
-using Google.Protobuf;
-using static Tensorboard.TensorShapeProto.Types;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 #nullable enable
 namespace TorchSharp
 {
     public static partial class torch
     {
-
         /// <summary>
         /// Represents a TorchSharp tensor.
         /// </summary>
@@ -57,8 +55,8 @@ namespace TorchSharp
             public override bool Equals(object? obj)
             {
                 return (obj is Tensor) && this.Equals((obj as Tensor)!);
-
             }
+
             /// <summary>
             ///  TBD
             /// </summary>
@@ -83,9 +81,6 @@ namespace TorchSharp
                 Dispose(true);
                 GC.SuppressFinalize(this);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSTensor_dispose(IntPtr handle);
 
             /// <summary>
             ///   Implements the .NET Dispose pattern.
@@ -124,9 +119,6 @@ namespace TorchSharp
                 OwningDisposeScope?.Detach(this);
                 return this;
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSTensor_free(IntPtr handle);
 
             /// <summary>
             /// Decouple the managed tensor from its underlying native tensor.
@@ -201,9 +193,6 @@ namespace TorchSharp
                 return h;
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern long THSTensor_ndimension(IntPtr handle);
-
             /// <summary>
             ///  Returns the number of dimensions for this tensor
             /// </summary>
@@ -218,12 +207,6 @@ namespace TorchSharp
             ///  Returns the number of dimensions for this tensor
             /// </summary>
             public long ndim => Dimensions;
-
-            [DllImport("LibTorchSharp")]
-            static extern long THSTensor_element_size(IntPtr handle);
-
-            [DllImport("LibTorchSharp")]
-            static extern long THSTensor_numel(IntPtr handle);
 
             /// <summary>
             ///  Get the number of elements in the tensor.
@@ -250,20 +233,12 @@ namespace TorchSharp
 
             public bool is_meta => device.type == DeviceType.META;
 
-
-            [DllImport("LibTorchSharp")]
-            internal static extern long THSTensor_is_leaf(IntPtr handle);
-
             /// <summary>
             /// All Tensors that have requires_grad which is true will be leaf Tensors by convention.
             /// For Tensors that have requires_grad which is true, they will be leaf Tensors if they were created by the user.This means that they are not the result of an operation and so grad_fn is None.
             /// Only leaf Tensors will have their grad populated during a call to backward(). To get grad populated for non-leaf Tensors, you can use retain_grad().
             /// </summary>
             public bool is_leaf { get => THSTensor_is_leaf(Handle) != 0; }
-
-
-            [DllImport("LibTorchSharp")]
-            internal static extern IntPtr THSTensor_alias(IntPtr handle);
 
             /// <summary>
             /// Create a new reference to the same underlying native tensor.
@@ -291,9 +266,6 @@ namespace TorchSharp
                 return Storage.Create<T>(this);
             }
 
-            [DllImport("LibTorchSharp")]
-            internal static extern long THSTensor_storage_offset(IntPtr tensor);
-
             /// <summary>
             /// Returns the tensor’s offset in the underlying storage in terms of number of storage elements (not bytes).
             /// </summary>
@@ -304,9 +276,6 @@ namespace TorchSharp
                 torch.CheckForErrors();
                 return res;
             }
-
-            [DllImport("LibTorchSharp")]
-            internal static extern IntPtr THSTensor_data(IntPtr handle);
 
             /// <summary>
             ///  Returns a pointer to the unmanaged data managed by this tensor.
@@ -424,9 +393,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_real(IntPtr handle);
-
             public Tensor real {
                 get {
                     var res = THSTensor_real(Handle);
@@ -435,9 +401,6 @@ namespace TorchSharp
 
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_imag(IntPtr handle);
 
             public Tensor imag {
                 get {
@@ -502,9 +465,6 @@ namespace TorchSharp
             /// <param name="i">The index.</param>
             public T ReadCpuValue<T>(long i) where T : unmanaged => Utils.TensorAccessor<T>.ReadItemAt(this, i);
 
-            [DllImport("LibTorchSharp")]
-            static extern float THSTensor_data_idx_float16(IntPtr handle, long i);
-
             /// <summary>
             /// Read the Float16 value at the given index.
             /// </summary>
@@ -516,9 +476,6 @@ namespace TorchSharp
                 }
                 return THSTensor_data_idx_float16(handle, i);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern float THSTensor_data_idx_bfloat16(IntPtr handle, long i);
 
             /// <summary>
             /// Read the BFloat16 value at the given index.
@@ -532,9 +489,6 @@ namespace TorchSharp
                 return THSTensor_data_idx_bfloat16(handle, i);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_item(IntPtr handle);
-
             /// <summary>
             /// Convert to a scalar.
             /// </summary>
@@ -544,9 +498,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Scalar(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fill_(IntPtr handle, IntPtr value);
 
             /// <summary>
             /// Fill the tensor with the provided scalar value.
@@ -559,17 +510,10 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern sbyte THSTensor_type(IntPtr handle);
-
             /// <summary>
             /// Gets the type of the tensor elements.
             /// </summary>
             public ScalarType dtype => (ScalarType)THSTensor_type(Handle);
-
-            [DllImport("LibTorchSharp")]
-            [return: MarshalAs(UnmanagedType.LPStr)]
-            static extern string THSTensor_device_str(IntPtr handle);
 
             /// <summary>
             /// Gets a string representing the device where the tensor is stored.
@@ -585,10 +529,6 @@ namespace TorchSharp
                 }
             }
 
-
-            [DllImport("LibTorchSharp")]
-            static extern int THSTensor_device_index(IntPtr handle);
-
             /// <summary>
             /// Gets a index of the device where the tensor is stored.
             /// </summary>
@@ -600,10 +540,6 @@ namespace TorchSharp
                 }
             }
 
-
-            [DllImport("LibTorchSharp")]
-            static extern int THSTensor_device_type(IntPtr handle);
-
             /// <summary>
             /// Gets the type ('CPU', 'CUDA', etc.) of the device where the tensor is stored.
             /// </summary>
@@ -614,9 +550,6 @@ namespace TorchSharp
                     return (DeviceType)res;
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern bool THSTensor_is_sparse(IntPtr handle);
 
             /// <summary>
             /// Is the tensor a sparse tensor?
@@ -632,9 +565,6 @@ namespace TorchSharp
             public void backward(IList<Tensor>? grad_tensors = null, bool create_graph = false, bool retain_graph = false, IList<Tensor>? inputs = null) =>
                 torch.autograd.backward(new[] { this }, grad_tensors, create_graph, retain_graph, inputs);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_load([MarshalAs(UnmanagedType.LPStr)] string location);
-
             /// <summary>
             /// Creates a tensor by loading it from a file.
             /// </summary>
@@ -647,9 +577,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_save(IntPtr tensor, [MarshalAs(UnmanagedType.LPStr)] string location);
-
             /// <summary>
             /// Save the contents of a tensor to a file.
             /// </summary>
@@ -659,12 +586,6 @@ namespace TorchSharp
                 THSTensor_save(Handle, location);
                 torch.CheckForErrors();
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern bool THSTensor_requires_grad(IntPtr handle);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_set_requires_grad(IntPtr handle, bool requires_grad);
 
             /// <summary>
             /// Is the tensor tracking gradients?
@@ -685,9 +606,6 @@ namespace TorchSharp
                 return this;
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_retain_grad(IntPtr handle);
-
             /// <summary>
             /// Enables this Tensor to have their grad populated during backward(). This is a no-op for leaf tensors.
             /// </summary>
@@ -706,9 +624,6 @@ namespace TorchSharp
                 return this;
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cpu(IntPtr handle);
-
             /// <summary>
             /// Moves the tensor data to the CPU device
             /// </summary>
@@ -719,9 +634,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cuda(IntPtr handle);
 
             /// <summary>
             /// Returns a copy of this object in CUDA memory.
@@ -743,15 +655,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_to_device(IntPtr handle, int device_type, int device_index, bool copy);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_to_type(IntPtr handle, sbyte scalar_type, bool copy);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_to_type_and_device(IntPtr handle, sbyte scalar_type, int device_type, int device_index, bool copy);
-
             /// <summary>
             /// Cast the tensor to the given element type.
             /// </summary>
@@ -769,9 +672,6 @@ namespace TorchSharp
             /// Returns this tensor cast to the type of the given tensor.
             /// </summary>
             public Tensor type_as(Tensor tensor) => to_type(tensor.dtype);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_set_(IntPtr tensor, IntPtr source);
 
             /// <summary>
             /// Overwrite an existing tensor with the contents of another tensor.
@@ -841,9 +741,6 @@ namespace TorchSharp
 
             public Tensor to(Tensor other) => to(other.dtype, other.device);
 
-            [DllImport("LibTorchSharp")]
-            static extern long THSTensor_size(IntPtr handle, long dim);
-
             /// <summary>
             ///  Retrieves the size of the specified dimension in the tensor.
             /// </summary>
@@ -854,9 +751,6 @@ namespace TorchSharp
                 torch.CheckForErrors();
                 return res;
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern long THSTensor_sizes(IntPtr handle, AllocatePinnedArray allocator);
 
             /// <summary>
             ///  Retrieves the sizes of all dimensions of the tensor.
@@ -874,7 +768,6 @@ namespace TorchSharp
                 return ptrArray;
             }
 
-
             /// <summary>
             /// Returns the tensor shape, this is an array whose size determines the number of dimensions on the tensor,
             /// and each element is the size of the dimension
@@ -890,28 +783,12 @@ namespace TorchSharp
                 }
             }
 
-
-            [DllImport("LibTorchSharp")]
-            static extern bool THSTensor_has_names(IntPtr handle);
-
             public bool has_names()
             {
                 var res = THSTensor_has_names(Handle);
                 CheckForErrors();
                 return res;
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_names(IntPtr handle, AllocatePinnedArray allocator);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_rename(IntPtr tensor, IntPtr names, long nLength);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_rename_(IntPtr tensor, IntPtr names, long nLength);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_refine_names(IntPtr tensor, IntPtr names, long nLength);
 
             /// <summary>
             /// Stores names for each of this tensor’s dimensions.
@@ -1021,7 +898,7 @@ namespace TorchSharp
 
             /// <summary>
             /// Refines the dimension names of the input tensor according to names.
-            /// 
+            ///
             /// Refining is a special case of renaming that “lifts” unnamed dimensions.A None dim can be refined to have any name; a named dim can only be refined to have the same name.
             /// Because named tensors can coexist with unnamed tensors, refining names gives a nice way to write named-tensor-aware code that works with both named and unnamed tensors.
             /// names may contain up to one ellipsis argument, passed as "...". The ellipsis is expanded greedily; it is expanded in-place to fill names to the same length as
@@ -1107,7 +984,7 @@ namespace TorchSharp
 
             /// <summary>
             /// Refines the dimension names of the input tensor according to names.
-            /// 
+            ///
             /// Refining is a special case of renaming that “lifts” unnamed dimensions.A None dim can be refined to have any name; a named dim can only be refined to have the same name.
             /// Because named tensors can coexist with unnamed tensors, refining names gives a nice way to write named-tensor-aware code that works with both named and unnamed tensors.
             /// names may contain up to one ellipsis argument, passed as "...". The ellipsis is expanded greedily; it is expanded in-place to fill names to the same length as
@@ -1116,9 +993,6 @@ namespace TorchSharp
             /// <param name="names">A list of names, one for each dimension in the tensor.</param>
             /// <remarks>The named tensor API is experimental and subject to change.</remarks>
             public Tensor refine_names(params string[] names) => refine_names((IEnumerable<string>)names);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_indices(IntPtr handle);
 
             /// <summary>
             /// Return the indices tensor of a sparse COO tensor.
@@ -1132,9 +1006,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_values(IntPtr handle);
-
             /// <summary>
             /// Return the values tensor of a sparse COO tensor.
             /// </summary>
@@ -1146,9 +1017,6 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_vander(IntPtr handle, long N, bool increasing);
 
             /// <summary>
             ///
@@ -1162,12 +1030,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern long THSTensor_stride(IntPtr handle, long dim);
-
-            [DllImport("LibTorchSharp")]
-            static extern long THSTensor_strides(IntPtr handle, AllocatePinnedArray allocator);
 
             /// <summary>
             ///  Retrieves the stride of all dimensions of the tensor.
@@ -1195,11 +1057,6 @@ namespace TorchSharp
                 return res;
             }
 
-
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_as_strided(IntPtr input, IntPtr psizes, int sz_length, IntPtr pstrides, int str_length, long storageOffset);
-
             /// <summary>
             ///  Create a view of an existing torch.Tensor input with specified size, stride and storage offset.
             /// </summary>
@@ -1214,9 +1071,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_backward(IntPtr handle);
-
             /// <summary>
             /// Computes the gradient of current tensor w.r.t. graph leaves.
             /// </summary>
@@ -1225,9 +1079,6 @@ namespace TorchSharp
                 THSTensor_backward(Handle);
                 torch.CheckForErrors();
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_to_dense(IntPtr handle);
 
             /// <summary>
             /// Creates a strided copy of the input tensor.
@@ -1241,9 +1092,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_clone(IntPtr handle);
-
             /// <summary>
             /// Returns a copy of the tensor input.
             /// </summary>
@@ -1255,9 +1103,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_copy_(IntPtr handle, IntPtr source, [MarshalAs(UnmanagedType.U1)] bool non_blocking);
 
             /// <summary>
             /// Copies the elements from source into the tensor and returns it.
@@ -1272,9 +1117,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static int THSTensor_is_contiguous(IntPtr handle);
-
             /// <summary>
             /// Returns true if the tensor is contiguous.
             /// </summary>
@@ -1284,9 +1126,6 @@ namespace TorchSharp
                 torch.CheckForErrors();
                 return res != 0;
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_contiguous(IntPtr handle);
 
             /// <summary>
             /// Returns a contiguous in memory tensor containing the same data as the input tensor.
@@ -1300,9 +1139,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static long THSTensor_is_pinned(IntPtr handle);
-
             /// <summary>
             /// Returns true if the tensor is contiguous.
             /// </summary>
@@ -1312,9 +1148,6 @@ namespace TorchSharp
                 torch.CheckForErrors();
                 return res != 0;
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_pin_memory(IntPtr handle);
 
             /// <summary>
             /// Returns a contiguous in memory tensor containing the same data as the input tensor.
@@ -1327,9 +1160,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_grad(IntPtr handle);
 
             /// <summary>
             /// This attribute is null by default and becomes a Tensor the first time a call to backward() computes gradients for the tensor.
@@ -1346,14 +1176,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_put_scalar_(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength, IntPtr value);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_put_(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength, IntPtr value);
             internal void EncodeIndices(TensorIndex[] indices,
                 out long[] arrKindAndStarts,
                 out long[]? arrStops,
@@ -1414,12 +1236,6 @@ namespace TorchSharp
                 set { index_put_(value, indices); }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_get1(IntPtr handle, long i1);
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_set1(IntPtr handle, long i1, IntPtr value);
-
             /// <summary>
             /// Tensor indexer.
             /// </summary>
@@ -1437,12 +1253,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_get2(IntPtr handle, long i1, long i2);
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_set2(IntPtr handle, long i1, long i2, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1462,12 +1272,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_get3(IntPtr handle, long i1, long i2, long i3);
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_set3(IntPtr handle, long i1, long i2, long i3, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1490,12 +1294,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_get4(IntPtr handle, long i1, long i2, long i3, long i4);
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_set4(IntPtr handle, long i1, long i2, long i3, long i4, IntPtr value);
-
             /// <summary>
             /// Tensor indexer.
             /// </summary>
@@ -1517,12 +1315,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_get5(IntPtr handle, long i1, long i2, long i3, long i4, long i5);
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_set5(IntPtr handle, long i1, long i2, long i3, long i4, long i5, IntPtr value);
 
             /// <summary>
             /// Tensor indexer.
@@ -1547,13 +1339,6 @@ namespace TorchSharp
                 }
             }
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_get6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6);
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_set6(IntPtr handle, long i1, long i2, long i3, long i4, long i5, long i6, IntPtr value);
-
             /// <summary>
             /// Tensor indexer.
             /// </summary>
@@ -1563,7 +1348,6 @@ namespace TorchSharp
             /// <param name="i4">The fourth-dimension index</param>
             /// <param name="i5">The fifth-dimension index</param>
             /// <param name="i6">The sixth-dimension index</param>
-
             [IndexerName("TensorItems")]
             public Tensor this[long i1, long i2, long i3, long i4, long i5, long i6] {
                 get {
@@ -1581,7 +1365,6 @@ namespace TorchSharp
             /// <summary>
             /// Index into the tensor using Python-like indexing expressions.
             /// </summary>
-
             public Tensor index(params TensorIndex[] indices)
             {
                 EncodeIndices(indices, out var arrKindAndStarts, out var arrStops, out var arrSteps, out var arrTensors);
@@ -1602,7 +1385,6 @@ namespace TorchSharp
             /// <summary>
             /// Index into the tensor using Python-like indexing expressions.
             /// </summary>
-
             public Tensor index(params Tensor[] indices)
             {
                 return index(indices.Select(t => TensorIndex.Tensor(t)).ToArray());
@@ -1611,7 +1393,6 @@ namespace TorchSharp
             /// <summary>
             /// Index into the tensor using Python-like indexing expressions and place a tensor at the index.
             /// </summary>
-
             public Tensor index_put_(Tensor value, params TensorIndex[] indices)
             {
                 EncodeIndices(indices, out var arrKindAndStarts, out var arrStops, out var arrSteps, out var arrTensors);
@@ -1632,17 +1413,14 @@ namespace TorchSharp
             /// <summary>
             /// Index into the tensor using Python-like indexing expressions and place a tensor at the index.
             /// </summary>
-
             public Tensor index_put_(Tensor value, params Tensor[] indices)
             {
                 return index_put_(value, indices.Select(t => TensorIndex.Tensor(t)).ToArray());
             }
 
-
             /// <summary>
             /// Index into the tensor using Python-like indexing expressions and place a scalar tensor at the index.
             /// </summary>
-
             public Tensor index_put_(Scalar value, params TensorIndex[] indices)
             {
                 EncodeIndices(indices, out var arrKindAndStarts, out var arrStops, out var arrSteps, out var arrTensors);
@@ -1663,21 +1441,16 @@ namespace TorchSharp
             /// <summary>
             /// Index into the tensor using Python-like indexing expressions and place a scalar tensor at the index.
             /// </summary>
-
             public Tensor index_put_(Scalar value, params Tensor[] indices)
             {
                 return index_put_(value, indices.Select(t => TensorIndex.Tensor(t)).ToArray());
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_select(IntPtr tensor, long dim, IntPtr index);
 
             /// <summary>
             /// Returns a new tensor which indexes the input tensor along dimension dim using the entries in index which is a LongTensor.
             /// </summary>
             /// <param name="dim">The dimension in which we index</param>
             /// <param name="index">The 1-D tensor containing the indices to index</param>
-
             public Tensor index_select(long dim, Tensor index)
             {
                 var res = THSTensor_index_select(Handle, dim, index.Handle);
@@ -1686,16 +1459,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_select(IntPtr tensor, long dim, long index);
-
             /// <summary>
             /// Slices the input tensor along the selected dimension at the given index.
             /// This function returns a view of the original tensor with the given dimension removed.
             /// </summary>
             /// <param name="dim">The dimension to slice</param>
             /// <param name="index">The index to select with</param>
-
             public Tensor select(long dim, long index)
             {
                 var res = THSTensor_select(Handle, dim, index);
@@ -1703,9 +1472,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_take(IntPtr tensor, IntPtr index);
 
             /// <summary>
             /// Returns a new tensor with the elements of input at the given indices. The input tensor is treated as if it were viewed as a 1-D tensor.
@@ -1720,12 +1486,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_take_along_dim_dflt(IntPtr tensor, IntPtr indices);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_take_along_dim(IntPtr tensor, IntPtr indices, long dim);
 
             /// <summary>
             /// Selects values from input at the 1-dimensional indices from indices along the given dim.
@@ -1773,12 +1533,9 @@ namespace TorchSharp
             /// <remarks>Functions that return indices along a dimension, like torch.argmax() and torch.argsort(), are designed to work with this function.</remarks>
             public Tensor take_along_dim(IEnumerable<long> indices, long dim) => take_along_dim(torch.tensor(indices.ToArray()), dim);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_add(IntPtr tensor, long dim, IntPtr index, IntPtr source, IntPtr alpha);
-
             /// <summary>
             /// Accumulate the elements of alpha times source into the input tensor by adding to the indices in the order given in index.
-            /// 
+            ///
             /// For example, if dim == 0, index[i] == j, and alpha=-1, then the ith row of source is subtracted from the jth row of the input tensor.
             /// The dimth dimension of source must have the same size as the length of index(which must be a vector), and all other dimensions must match the input tensor, or an error will be raised.
             /// </summary>
@@ -1797,12 +1554,9 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_add_(IntPtr tensor, long dim, IntPtr index, IntPtr source, IntPtr alpha);
-
             /// <summary>
             /// Accumulate, in place, the elements of alpha times source into the input tensor by adding to the indices in the order given in index.
-            /// 
+            ///
             /// For example, if dim == 0, index[i] == j, and alpha=-1, then the ith row of source is subtracted from the jth row of the input tensor.
             /// The dimth dimension of source must have the same size as the length of index(which must be a vector), and all other dimensions must match the input tensor, or an error will be raised.
             /// </summary>
@@ -1820,11 +1574,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_copy(IntPtr tensor, long dim, IntPtr index, IntPtr source);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_copy_(IntPtr tensor, long dim, IntPtr index, IntPtr source);
 
             /// <summary>
             /// Copies the elements of the source tensor into the input tensor by selecting the indices in the order given in index.
@@ -1866,14 +1615,9 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_fill(IntPtr tensor, long dim, IntPtr index, IntPtr value);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_index_fill_(IntPtr tensor, long dim, IntPtr index, IntPtr value);
-
             /// <summary>
             /// Fills the elements of the input tensor with value value by selecting the indices in the order given in index.
-            /// 
+            ///
             /// For example, if dim == 0, index[i] == j, and alpha=-1, then the ith row of source is subtracted from the jth row of the input tensor.
             /// The dimth dimension of source must have the same size as the length of index(which must be a vector), and all other dimensions must match the input tensor, or an error will be raised.
             /// </summary>
@@ -1893,7 +1637,7 @@ namespace TorchSharp
 
             /// <summary>
             /// Fills, in place, the elements of the input tensor with value value by selecting the indices in the order given in index.
-            /// 
+            ///
             /// For example, if dim == 0, index[i] == j, and alpha=-1, then the ith row of source is subtracted from the jth row of the input tensor.
             /// The dimth dimension of source must have the same size as the length of index(which must be a vector), and all other dimensions must match the input tensor, or an error will be raised.
             /// </summary>
@@ -1911,9 +1655,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_reshape(IntPtr tensor, IntPtr shape, int length);
-
             /// <summary>
             /// Returns a tensor with the same data and number of elements as the input tensor but with the specified shape.
             /// </summary>
@@ -1929,12 +1670,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_flatten(IntPtr tensor, long start, long end);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_flatten_names(IntPtr tensor, IntPtr names, long nLength);
 
             /// <summary>
             /// Flattens input by reshaping it into a one-dimensional tensor.
@@ -1973,12 +1708,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unflatten(IntPtr tensor, long dim, IntPtr shape, int length);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unflatten_names(IntPtr tensor, IntPtr names, IntPtr dims, int length);
 
             /// <summary>
             /// Expands the dimension dim of the input tensor over multiple dimensions of sizes given by sizes.
@@ -2032,13 +1761,9 @@ namespace TorchSharp
                 }
             }
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_align_to(IntPtr tensor, IntPtr names, long nLength);
-
             /// <summary>
             /// Permutes the dimensions of the input tensor to match the order specified in names, adding size-one dims for any new names.
-            /// 
+            ///
             /// All of the dims of the input tensor must be named in order to use this method.The resulting tensor is a view on the original tensor.
             /// All dimension names of the input tensor must be present in names.names may contain additional names that are not in this.names; the output tensor has a size-one dimension for each of those new names.
             /// names may contain up to one ellipsis "...". The ellipsis is expanded to be equal to all dimension names of the input tensor that are not mentioned in names, in the order that they appear in the input tensor.
@@ -2057,7 +1782,7 @@ namespace TorchSharp
 
             /// <summary>
             /// Permutes the dimensions of the input tensor to match the order specified in names, adding size-one dims for any new names.
-            /// 
+            ///
             /// All of the dims of the input tensor must be named in order to use this method.The resulting tensor is a view on the original tensor.
             /// All dimension names of the input tensor must be present in names.names may contain additional names that are not in this.names; the output tensor has a size-one dimension for each of those new names.
             /// names may contain up to one ellipsis "...". The ellipsis is expanded to be equal to all dimension names of the input tensor that are not mentioned in names, in the order that they appear in the input tensor.
@@ -2066,10 +1791,9 @@ namespace TorchSharp
             /// <remarks>The named tensor API is experimental and subject to change.</remarks>
             public Tensor align_to(params string[] names) => align_to((IEnumerable<string>)names);
 
-
             /// <summary>
             /// Permutes the dimensions of the input tensor to match the dimension order in the other tensor, adding size-one dims for any new names.
-            /// 
+            ///
             /// This operation is useful for explicit broadcasting by names.
             /// All of the dims of the input tensor must be named in order to use this method.The resulting tensor is a view on the original tensor.
             /// All dimension names of the input tensor must be present in other.names.other may contain named dimensions that are not in this.names; the output tensor has a size-one dimension for each of those new names.
@@ -2079,15 +1803,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor align_as(Tensor other) => align_to(other.names!);
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unique(IntPtr tensor, bool sorted, bool return_inverse, bool return_counts, out IntPtr inverse_indices, out IntPtr counts);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unique_dim(IntPtr tensor, long dim, bool sorted, bool return_inverse, bool return_counts, out IntPtr inverse_indices, out IntPtr counts);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unique_consecutive(IntPtr tensor, bool return_inverse, bool return_counts, out IntPtr inverse_indices, out IntPtr counts);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unique_dim_consecutive(IntPtr tensor, long dim, bool return_inverse, bool return_counts, out IntPtr inverse_indices, out IntPtr counts);
 
             /// <summary>
             /// Returns the unique elements of the input tensor.
@@ -2145,15 +1860,6 @@ namespace TorchSharp
                 return unflatten(dim, sizes.Shape);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_squeeze(IntPtr tensor, long dim);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_squeeze_no_dim(IntPtr tensor);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_squeeze_(IntPtr tensor, long dim);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_squeeze_no_dim_(IntPtr tensor);
-
             /// <summary>
             /// Returns a tensor with all the dimensions of input of size 1 removed. When dim is given, a squeeze operation is done only in the given dimension.
             /// </summary>
@@ -2178,9 +1884,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_t(IntPtr tensor);
 
             /// <summary>
             /// Expects input to be 1- or 2-D tensor and transposes dimensions 0 and 1.
@@ -2207,9 +1910,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_H(IntPtr tensor);
-
             /// <summary>
             /// Is this Tensor with its dimensions reversed.
             /// </summary>
@@ -2218,9 +1918,6 @@ namespace TorchSharp
                     return is_complex() ? transpose(0, 1).conj() : transpose(0, 1);
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_mT(IntPtr tensor);
 
             /// <summary>
             /// Returns a view of this tensor with the last two dimensions transposed.
@@ -2234,9 +1931,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_mH(IntPtr tensor);
-
             /// <summary>
             /// Accessing this property is equivalent to calling adjoint().
             /// </summary>
@@ -2248,9 +1942,6 @@ namespace TorchSharp
                     return new Tensor(res);
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_transpose(IntPtr tensor, long dim1, long dim2);
 
             /// <summary>
             /// Returns a tensor that is a transposed version of input. The given dimensions dim0 and dim1 are swapped.
@@ -2266,9 +1957,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_tril(IntPtr tensor, long diagonal);
-
             /// <summary>
             /// Returns the lower triangular part of the matrix (2-D tensor) or batch of matrices input, the other elements of the result tensor out are set to 0.
             /// The lower triangular part of the matrix is defined as the elements on and below the diagonal.
@@ -2282,9 +1970,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_triu(IntPtr tensor, long diagonal);
 
             /// <summary>
             /// Returns the upper triangular part of a matrix (2-D tensor) or batch of matrices input, the other elements of the result tensor out are set to 0.
@@ -2300,7 +1985,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-
             /// <summary>
             /// Returns a tensor that is a transposed version of input. The given dimensions dim0 and dim1 are swapped.
             /// </summary>
@@ -2310,9 +1994,6 @@ namespace TorchSharp
             /// Returns a tensor that is a transposed version of input. The given dimensions dim0 and dim1 are swapped.
             /// </summary>
             public Tensor swapaxes(long dim0, long dim1) => transpose(dim0, dim1);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_transpose_(IntPtr tensor, long dim1, long dim2);
 
             /// <summary>
             /// Returns a tensor that is a transposed version of input. The given dimensions dim0 and dim1 are swapped.
@@ -2328,9 +2009,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_view(IntPtr tensor, IntPtr shape, int length);
 
             /// <summary>
             /// Returns a new tensor with the same data as the input tensor but of a different shape.
@@ -2362,9 +2040,6 @@ namespace TorchSharp
                 return view(other.shape);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_view_as_complex(IntPtr tensor);
-
             /// <summary>
             /// Returns a view of input as a complex tensor.
             /// </summary>
@@ -2375,9 +2050,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(result);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_view_as_real(IntPtr tensor);
 
             /// <summary>
             /// Returns a view of input as a real tensor.
@@ -2390,9 +2062,6 @@ namespace TorchSharp
                 return new Tensor(result);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_all(IntPtr tensor);
-
             /// <summary>
             /// Tests if all elements in input evaluate to true.
             /// </summary>
@@ -2404,9 +2073,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_all_along_dimension(IntPtr tensor, long dim, bool keep_dim);
 
             /// <summary>
             /// Tests if all elements in input evaluate to true.
@@ -2421,12 +2087,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_amax(IntPtr tensor, IntPtr dim, int dim_len, bool keep_dim);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_amax_out(IntPtr tensor, IntPtr dim, int dim_len, bool keep_dim, IntPtr _out);
 
             /// <summary>
             /// Returns the maximum value of each slice of the input tensor in the given dimension(s) dim.
@@ -2468,11 +2128,6 @@ namespace TorchSharp
                 return amax((ReadOnlySpan<long>)dims, false, null);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_amin(IntPtr tensor, IntPtr dim, int dim_len, bool keep_dim);
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_amin_out(IntPtr tensor, IntPtr dim, int dim_len, bool keep_dim, IntPtr _out);
-
             /// <summary>
             /// Returns the minimum value of each slice of the input tensor in the given dimension(s) dim.
             /// </summary>
@@ -2513,10 +2168,6 @@ namespace TorchSharp
                 return amin((ReadOnlySpan<long>)dims, false, null);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_aminmax(IntPtr tensor, long dim, bool keep_dim, out IntPtr max);
-
-
             /// <summary>
             /// Computes the minimum and maximum values of the input tensor.
             /// </summary>
@@ -2530,9 +2181,6 @@ namespace TorchSharp
                 return (new Tensor(res), new Tensor(maxHandle));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_any(IntPtr tensor);
-
             /// <summary>
             /// Tests if any element in input evaluate to true.
             /// </summary>
@@ -2544,9 +2192,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_any_along_dimension(IntPtr tensor, long dim, bool keep_dim);
 
             /// <summary>
             /// Tests if any element in input evaluate to true.
@@ -2562,9 +2207,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_argmax(IntPtr tensor);
-
             /// <summary>
             /// Returns the indices of the maximum value of all elements in the input tensor.
             /// </summary>
@@ -2576,9 +2218,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_argmax_along_dimension(IntPtr tensor, long dim, bool keep_dim);
 
             /// <summary>
             /// Returns the indices of the maximum value of all elements in the input tensor.
@@ -2594,9 +2233,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_argmin(IntPtr tensor);
-
             /// <summary>
             /// Returns the indices of the minimum value of all elements in the input tensor.
             /// </summary>
@@ -2608,9 +2244,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_argmin_along_dimension(IntPtr tensor, long dim, bool keep_dim);
 
             /// <summary>
             /// Returns the indices of the minimum value of all elements in the input tensor.
@@ -2626,9 +2259,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_argsort(IntPtr tensor, long dim, bool descending);
-
             /// <summary>
             /// Returns the indices that sort a tensor along a given dimension in ascending order by value.
             /// </summary>
@@ -2643,9 +2273,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_deg2rad(IntPtr tensor);
-
             /// <summary>
             /// Convert each element from degrees to radians.
             /// </summary>
@@ -2657,9 +2284,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_rad2deg(IntPtr tensor);
 
             /// <summary>
             /// Convert each element from radians to degrees.
@@ -2673,9 +2297,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_copysign(IntPtr tensor, IntPtr other);
-
             /// <summary>
             ///
             /// </summary>
@@ -2688,9 +2309,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_count_nonzero(IntPtr tensor, IntPtr dim, int dim_len);
-
             public Tensor count_nonzero(long[]? dims = null)
             {
                 unsafe {
@@ -2701,9 +2319,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_cov(IntPtr tensor, long correction, IntPtr fweights, IntPtr aweights);
 
             /// <summary>
             /// Estimates the covariance matrix of the variables given by the input matrix, where rows are the variables and columns are the observations.
@@ -2732,9 +2347,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_corrcoef(IntPtr tensor);
-
             /// <summary>
             /// Estimates the Pearson product-moment correlation coefficient matrix of the variables given by the input matrix, where rows are the variables and columns are the observations.
             /// </summary>
@@ -2748,9 +2360,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_tile(IntPtr tensor, IntPtr reps, int reps_len);
 
             /// <summary>
             /// Constructs a tensor by repeating the elements of input. The reps argument specifies the number of repetitions in each dimension.
@@ -2768,9 +2377,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_digamma(IntPtr tensor);
-
             /// <summary>
             /// Computes the logarithmic derivative of the gamma function on input.
             /// </summary>
@@ -2782,9 +2388,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_digamma_(IntPtr tensor);
 
             /// <summary>
             /// Computes the logarithmic derivative of the gamma function on input, in place.
@@ -2798,9 +2401,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lgamma(IntPtr tensor);
-
             /// <summary>
             /// Computes the logarithm of the gamma function on input.
             /// </summary>
@@ -2813,9 +2413,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lgamma_(IntPtr tensor);
-
             /// <summary>
             /// Computes the logarithm of the gamma function on input, in place.
             /// </summary>
@@ -2827,9 +2424,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mvlgamma(IntPtr tensor, long p);
 
             /// <summary>
             /// Computes the multivariate log-gamma function) with dimension pp element-wise
@@ -2844,9 +2438,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mvlgamma_(IntPtr tensor, long p);
-
             /// <summary>
             /// Computes the multivariate log-gamma function) with dimension pp element-wise, in place.
             /// </summary>
@@ -2860,9 +2451,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_polygamma(IntPtr tensor, long p);
-
             public Tensor polygamma(long p)
             {
                 var res = THSTensor_polygamma(Handle, p);
@@ -2871,9 +2459,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_polygamma_(IntPtr tensor, long p);
-
             public Tensor polygamma_(long p)
             {
                 var res = THSTensor_polygamma_(Handle, p);
@@ -2881,9 +2466,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_positive(IntPtr tensor);
 
             /// <summary>
             /// Returns input. Throws a runtime error if input is a bool tensor.
@@ -2898,9 +2480,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_softplus(IntPtr tensor);
-
             public Tensor softplus()
             {
                 var res = THSTensor_softplus(Handle);
@@ -2908,9 +2487,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ravel(IntPtr tensor);
 
             public Tensor ravel()
             {
@@ -2920,9 +2496,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_relu(IntPtr tensor);
-
             public Tensor relu()
             {
                 var res = THSTensor_relu(Handle);
@@ -2930,9 +2503,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_relu_(IntPtr tensor);
 
             public Tensor relu_()
             {
@@ -2942,9 +2512,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_relu6(IntPtr tensor);
-
             public Tensor relu6()
             {
                 var res = THSTensor_relu6(Handle);
@@ -2952,9 +2519,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_relu6_(IntPtr tensor);
 
             public Tensor relu6_()
             {
@@ -2964,9 +2528,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_celu(IntPtr tensor);
-
             public Tensor celu()
             {
                 var res = THSTensor_celu(Handle);
@@ -2974,9 +2535,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_celu_(IntPtr tensor);
 
             public Tensor celu_()
             {
@@ -2986,9 +2544,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_elu(IntPtr tensor, IntPtr alpha, IntPtr scale, IntPtr input_scale);
-
             public Tensor elu(Scalar alpha, Scalar scale, Scalar input_scale)
             {
                 var res = THSTensor_elu(Handle, alpha.Handle, scale.Handle, input_scale.Handle);
@@ -2996,9 +2551,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_elu_(IntPtr tensor, IntPtr alpha, IntPtr scale, IntPtr input_scale);
 
             public Tensor elu_(Scalar alpha, Scalar scale, Scalar input_scale)
             {
@@ -3008,9 +2560,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_gelu(IntPtr tensor);
-
             public Tensor gelu()
             {
                 var res = THSTensor_gelu(Handle);
@@ -3018,9 +2567,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_hardsigmoid(IntPtr tensor);
 
             public Tensor hardsigmoid()
             {
@@ -3030,9 +2576,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_hardsigmoid_(IntPtr tensor);
-
             public Tensor hardsigmoid_()
             {
                 var res = THSTensor_hardsigmoid_(Handle);
@@ -3040,9 +2583,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_hardswish(IntPtr tensor);
 
             public Tensor hardswish()
             {
@@ -3052,9 +2592,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_hardswish_(IntPtr tensor);
-
             public Tensor hardswish_()
             {
                 var res = THSTensor_hardswish_(Handle);
@@ -3062,9 +2599,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_hardtanh(IntPtr tensor, IntPtr min, IntPtr max);
 
             public Tensor hardtanh(Scalar min, Scalar max)
             {
@@ -3074,9 +2608,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_hardtanh_(IntPtr tensor, IntPtr min, IntPtr max);
-
             public Tensor hardtanh_(Scalar min, Scalar max)
             {
                 var res = THSTensor_hardtanh_(Handle, min.Handle, max.Handle);
@@ -3085,9 +2616,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_heaviside(IntPtr tensor, IntPtr other);
-
             public Tensor heaviside(Tensor other)
             {
                 var res = THSTensor_heaviside(Handle, other.Handle);
@@ -3095,9 +2623,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_igamma(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Computes the regularized lower incomplete gamma function
@@ -3112,9 +2637,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_igammac(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Computes the regularized upper incomplete gamma function.
             /// </summary>
@@ -3128,9 +2650,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_i0(IntPtr tensor);
-
             /// <summary>
             /// Computes the zeroth order modified Bessel function of the first kind for each element of input.
             /// </summary>
@@ -3142,9 +2661,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_isclose(IntPtr tensor, IntPtr other, double rtol, double atol, bool nanEqual);
 
             /// <summary>
             /// Returns a new tensor with boolean elements representing if each element of input is “close” to the corresponding element of other.
@@ -3161,9 +2677,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_isin(IntPtr elements, IntPtr test_elements, bool assume_unique, bool invert);
-
             /// <summary>
             /// Tests if each element of elements is in test_elements.
             /// Returns a boolean tensor of the same shape as elements that is true for elements in test_elements and false otherwise.
@@ -3179,9 +2692,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_isinf(IntPtr tensor);
-
             public Tensor isinf()
             {
                 var res = THSTensor_isinf(Handle);
@@ -3189,9 +2699,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_isfinite(IntPtr tensor);
 
             public Tensor isfinite()
             {
@@ -3201,9 +2708,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_isposinf(IntPtr tensor);
-
             public Tensor isposinf()
             {
                 var res = THSTensor_isposinf(Handle);
@@ -3211,9 +2715,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_isneginf(IntPtr tensor);
 
             public Tensor isneginf()
             {
@@ -3223,11 +2724,8 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_isnan(IntPtr tensor);
-
             /// <summary>
-            /// Returns a new tensor with boolean elements representing if each element of input is <value>NaN</value> or not. 
+            /// Returns a new tensor with boolean elements representing if each element of input is <value>NaN</value> or not.
             /// Complex values are considered <value>NaN</value> when either their real and/or imaginary part is <value>NaN</value>.
             /// </summary>
             /// <returns>A boolean tensor that is <value>True</value> where tensor is <value>NaN</value> and <value>False</value> elsewhere</returns>
@@ -3240,9 +2738,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_isreal(IntPtr tensor);
-
             public Tensor isreal()
             {
                 var res = THSTensor_isreal(Handle);
@@ -3250,9 +2745,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_leaky_relu(IntPtr tensor, IntPtr negative_slope);
 
             public Tensor leaky_relu(Scalar negative_slope)
             {
@@ -3262,9 +2754,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_leaky_relu_(IntPtr tensor, IntPtr negative_slope);
-
             public Tensor leaky_relu_(Scalar negative_slope)
             {
                 var res = THSTensor_leaky_relu_(Handle, negative_slope.Handle);
@@ -3272,9 +2761,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_selu(IntPtr tensor);
 
             public Tensor selu()
             {
@@ -3284,9 +2770,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_selu_(IntPtr tensor);
-
             public Tensor selu_()
             {
                 var res = THSTensor_selu_(Handle);
@@ -3294,10 +2777,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_silu(IntPtr tensor);
 
             public Tensor silu()
             {
@@ -3307,9 +2786,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_silu_(IntPtr tensor);
-
             public Tensor silu_()
             {
                 var res = THSTensor_silu_(Handle);
@@ -3317,9 +2793,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_log_sigmoid(IntPtr tensor);
 
             public Tensor log_sigmoid()
             {
@@ -3329,9 +2802,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lerp(IntPtr tensor, IntPtr end, IntPtr weight);
-
             public Tensor lerp(Tensor end, Tensor weight)
             {
                 var res = THSTensor_lerp(Handle, end.Handle, weight.Handle);
@@ -3340,9 +2810,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lerp_(IntPtr tensor, IntPtr end, IntPtr weight);
-
             public Tensor lerp_(Tensor end, Tensor weight)
             {
                 var res = THSTensor_lerp_(Handle, end.Handle, weight.Handle);
@@ -3350,11 +2817,6 @@ namespace TorchSharp
                     torch.CheckForErrors();
                 return new Tensor(res);
             }
-
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_baddbmm(IntPtr batch1, IntPtr batch2, IntPtr mat, float beta,
-                float alpha);
 
             /// <summary>
             /// Performs a batch matrix-matrix product of matrices in batch1 and batch2. input is added to the final result.
@@ -3371,9 +2833,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bmm(IntPtr batch1, IntPtr batch2);
-
             /// <summary>
             /// Performs a batch matrix-matrix product of matrices stored in input and mat2.
             /// </summary>
@@ -3385,9 +2844,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bucketize(IntPtr input, IntPtr boundaries, bool out_int32, bool right);
 
             /// <summary>
             /// Returns the indices of the buckets to which each value in the input belongs, where the boundaries of the buckets are set by boundaries.
@@ -3408,9 +2864,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bincount(IntPtr tensor, IntPtr weights, long minlength);
-
             /// <summary>
             /// Count the frequency of each value in an array of non-negative ints.
             /// </summary>
@@ -3421,7 +2874,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
 
             public Tensor @bool() => this.to_type(ScalarType.Bool);
 
@@ -3437,10 +2889,6 @@ namespace TorchSharp
 
             public Tensor @double() => this.to_type(ScalarType.Float64);
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_channel_shuffle(IntPtr input, long groups);
-
             /// <summary>
             /// Divide the channels in a tensor into g groups and rearrange them.
             ///
@@ -3453,12 +2901,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_clamp(IntPtr input, IntPtr min, IntPtr max);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_clamp_tensor(IntPtr input, IntPtr min, IntPtr max);
 
             /// <summary>
             /// Clamps all elements in input into the range [ min, max ].
@@ -3492,12 +2934,6 @@ namespace TorchSharp
             /// <returns></returns>
             public Tensor clip(Scalar? min = null, Scalar? max = null) => clamp(min, max);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_clamp_(IntPtr input, IntPtr min, IntPtr max);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_clamp_tensor_(IntPtr input, IntPtr min, IntPtr max);
-
             /// <summary>
             /// Clamps all elements in input into the range [ min, max ] in place.
             /// </summary>
@@ -3522,18 +2958,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_clamp_max(IntPtr input, IntPtr max);
-
             public Tensor clamp_max(Scalar max)
             {
                 var res = THSTensor_clamp_max(Handle, max.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_clamp_max_(IntPtr input, IntPtr max);
 
             public Tensor clamp_max_(Scalar max)
             {
@@ -3542,9 +2972,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_clamp_min(IntPtr input, IntPtr min);
-
             public Tensor clamp_min(Scalar min)
             {
                 var res = THSTensor_clamp_min(Handle, min.Handle);
@@ -3552,18 +2979,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_clamp_min_(IntPtr input, IntPtr min);
-
             public Tensor clamp_min_(Scalar min)
             {
                 var res = THSTensor_clamp_min_(Handle, min.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_diff(IntPtr tensor, long n, long dim, IntPtr prepend, IntPtr append);
 
             /// <summary>
             /// Computes the n-th forward difference along the given dimension.
@@ -3586,9 +3007,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_diag(IntPtr tensor, long dim);
-
             /// <summary>
             /// If input is a vector (1-D tensor), then returns a 2-D square tensor with the elements of input as the diagonal.
             /// If input is a matrix (2-D tensor), then returns a 1-D tensor with the diagonal elements of input.
@@ -3606,9 +3024,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_trace(IntPtr tensor);
-
             /// <summary>
             /// Returns the sum of the elements of the diagonal of the input 2-D matrix.
             /// </summary>
@@ -3621,9 +3036,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_diagflat(IntPtr tensor, long offset);
 
             /// <summary>
             /// If input is a vector (1-D tensor), then returns a 2-D square tensor with the elements of input as the diagonal.
@@ -3641,9 +3053,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_diagonal(IntPtr tensor, long offset, long dim1, long dim2);
 
             /// <summary>
             /// Returns a partial view of input with the its diagonal elements with respect to dim1 and dim2 appended as a dimension at the end of the shape.
@@ -3667,10 +3076,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_erf(IntPtr tensor);
-
             /// <summary>
             /// Computes the error function of the input.
             /// </summary>
@@ -3682,9 +3087,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_erf_(IntPtr tensor);
-
             /// <summary>
             /// Computes the error function of the input in place.
             /// </summary>
@@ -3694,9 +3096,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_erfc(IntPtr tensor);
 
             /// <summary>
             /// Computes the complementary error function of input.
@@ -3709,9 +3108,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_erfc_(IntPtr tensor);
-
             /// <summary>
             /// Computes the complementary error function of input in place
             /// </summary>
@@ -3723,11 +3119,8 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_erfinv(IntPtr tensor);
-
             /// <summary>
-            /// Computes the inverse error function of input. 
+            /// Computes the inverse error function of input.
             /// </summary>
             /// <returns></returns>
             public Tensor erfinv()
@@ -3737,11 +3130,8 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_erfinv_(IntPtr tensor);
-
             /// <summary>
-            /// Computes the inverse error function of input in place. 
+            /// Computes the inverse error function of input in place.
             /// </summary>
             /// <returns></returns>
             public Tensor erfinv_()
@@ -3750,9 +3140,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_eq(IntPtr tensor, IntPtr trg);
 
             public Tensor eq(Tensor target)
             {
@@ -3764,9 +3151,6 @@ namespace TorchSharp
 
             public Tensor equal(Tensor target) => eq(target);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_eq_(IntPtr tensor, IntPtr trg);
-
             public Tensor eq_(Tensor target)
             {
                 if (target is null) return false;
@@ -3774,9 +3158,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_eq_scalar(IntPtr tensor, IntPtr trg);
 
             public Tensor eq(Scalar target)
             {
@@ -3786,9 +3167,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_eq_scalar_(IntPtr tensor, IntPtr trg);
-
             public Tensor eq_(Scalar target)
             {
                 if (target is null) return false;
@@ -3797,9 +3175,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern bool THSTensor_equal(IntPtr tensor, IntPtr trg);
-
             public bool Equals(Tensor target)
             {
                 if (target is null) return false;
@@ -3807,9 +3182,6 @@ namespace TorchSharp
                 torch.CheckForErrors();
                 return res;
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern bool THSTensor_allclose(IntPtr tensor, IntPtr trg, double rtol, double atol, bool equal_nan);
 
             /// <summary>
             /// This function checks if all input and other lie within a certain distance from each other
@@ -3827,9 +3199,6 @@ namespace TorchSharp
                 return res;
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ge(IntPtr tensor, IntPtr trg);
-
             public Tensor ge(Tensor target)
             {
                 if (target is null) return false;
@@ -3840,9 +3209,6 @@ namespace TorchSharp
 
             public Tensor greater_equal(Tensor target) => ge(target);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ge_(IntPtr tensor, IntPtr trg);
-
             public Tensor ge_(Tensor target)
             {
                 if (target is null) return false;
@@ -3850,9 +3216,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ge_scalar(IntPtr tensor, IntPtr trg);
 
             public Tensor ge(Scalar target)
             {
@@ -3862,9 +3225,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ge_scalar_(IntPtr tensor, IntPtr trg);
-
             public Tensor ge_(Scalar target)
             {
                 if (target is null) return false;
@@ -3872,9 +3232,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_gt(IntPtr tensor, IntPtr trg);
 
             public Tensor gt(Tensor target)
             {
@@ -3886,9 +3243,6 @@ namespace TorchSharp
 
             public Tensor greater(Tensor target) => gt(target);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_gt_(IntPtr tensor, IntPtr trg);
-
             public Tensor gt_(Tensor target)
             {
                 if (target is null) return false;
@@ -3896,9 +3250,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_gt_scalar(IntPtr tensor, IntPtr trg);
 
             public Tensor gt(Scalar target)
             {
@@ -3908,9 +3259,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_gt_scalar_(IntPtr tensor, IntPtr trg);
-
             public Tensor gt_(Scalar target)
             {
                 if (target is null) return false;
@@ -3918,9 +3266,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_kron(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Computes the Kronecker product of input and other.
@@ -3933,9 +3278,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lcm(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Computes the element-wise least common multiple (LCM) of input and other.
@@ -3951,9 +3293,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lcm_(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Computes the element-wise least common multiple (LCM) of input and other, in place.
             /// </summary>
@@ -3968,9 +3307,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ldexp(IntPtr right, IntPtr left);
-
             /// <summary>
             /// Multiplies input by pow(2,other).
             /// </summary>
@@ -3983,9 +3319,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ldexp_(IntPtr right, IntPtr left);
 
             /// <summary>
             /// Multiplies input by pow(2,other) in place.
@@ -4000,9 +3333,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_le(IntPtr tensor, IntPtr trg);
-
             public Tensor le(Tensor target)
             {
                 var res = THSTensor_le(Handle, target.Handle);
@@ -4011,9 +3341,6 @@ namespace TorchSharp
             }
 
             public Tensor less_equal(Tensor target) => le(target);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_le_(IntPtr tensor, IntPtr trg);
 
             public Tensor le_(Tensor target)
             {
@@ -4024,9 +3351,6 @@ namespace TorchSharp
 
             public Tensor less_equal_(Tensor target) => le_(target);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_le_scalar(IntPtr tensor, IntPtr trg);
-
             public Tensor le(Scalar target)
             {
                 var res = THSTensor_le_scalar(Handle, target.Handle);
@@ -4034,18 +3358,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_le_scalar_(IntPtr tensor, IntPtr trg);
-
             public Tensor le_(Scalar target)
             {
                 var res = THSTensor_le_scalar_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lt(IntPtr tensor, IntPtr trg);
 
             public Tensor lt(Tensor target)
             {
@@ -4056,18 +3374,12 @@ namespace TorchSharp
 
             public Tensor less(Tensor target) => lt(target);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lt_(IntPtr tensor, IntPtr trg);
-
             public Tensor lt_(Tensor target)
             {
                 var res = THSTensor_lt_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lt_scalar(IntPtr tensor, IntPtr trg);
 
             public Tensor lt(Scalar target)
             {
@@ -4076,18 +3388,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_lt_scalar_(IntPtr tensor, IntPtr trg);
-
             public Tensor lt_(Scalar target)
             {
                 var res = THSTensor_lt_scalar_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_masked_fill(IntPtr tensor, IntPtr mask, IntPtr value);
 
             public Tensor masked_fill(Tensor mask, Scalar value)
             {
@@ -4096,9 +3402,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_masked_scatter(IntPtr tensor, IntPtr mask, IntPtr value);
-
             public Tensor masked_scatter(Tensor mask, Tensor value)
             {
                 var res = THSTensor_masked_scatter(Handle, mask.Handle, value.Handle);
@@ -4106,18 +3409,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_masked_scatter_(IntPtr tensor, IntPtr mask, IntPtr value);
-
             public Tensor masked_scatter_(Tensor mask, Tensor value)
             {
                 var res = THSTensor_masked_scatter_(Handle, mask.Handle, value.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_masked_select(IntPtr tensor, IntPtr mask);
 
             public Tensor masked_select(Tensor mask)
             {
@@ -4127,25 +3424,18 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_topk(IntPtr tensor, AllocatePinnedArray allocator, int k, long dim, bool largest, bool sorted);
-
-            public (Tensor values, Tensor indexes) topk(int k, int dim = -1, bool largest = true, bool sorted = true)
+            public (Tensor values, Tensor indexes) topk(int k, long dimension = -1, bool largest = true, bool sorted = true)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_topk(Handle, pa.CreateArray, k, dim, largest, sorted);
+                    THSTensor_topk(Handle, pa.CreateArray, k, dimension, largest, sorted);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
 
                 return (new Tensor(ptrArray[0]), new Tensor(ptrArray[1]));
             }
-
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_unbind(IntPtr tensor, AllocatePinnedArray allocator, long dim);
 
             /// <summary>
             /// Removes a tensor dimension.
@@ -4165,9 +3455,6 @@ namespace TorchSharp
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unfold(IntPtr tensor, long dim, long size, long step);
-
             /// <summary>
             /// Returns a view of the original tensor which contains all slices of size 'size' from the tensor in the given dimension.
             /// </summary>
@@ -4181,21 +3468,18 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dim);
-
             /// <summary>
             /// Splits the tensor into chunks. Each chunk is a view of the original tensor.
             /// </summary>
             /// <param name="size">The size of a single chunk</param>
-            /// <param name="dim">The dimension along which to split the tensor.</param>
+            /// <param name="dimension">The dimension along which to split the tensor.</param>
 
-            public Tensor[] split(long size, int dim = 0)
+            public Tensor[] split(long size, long dimension = 0L)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_split_with_size(Handle, pa.CreateArray, size, dim);
+                    THSTensor_split_with_size(Handle, pa.CreateArray, size, dimension);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
@@ -4203,23 +3487,20 @@ namespace TorchSharp
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dim);
-
             /// <summary>
             /// Splits the tensor into chunks. Each chunk is a view of the original tensor.
             /// </summary>
             /// <param name="sizes">A list of sizes for each chunk</param>
-            /// <param name="dim">The dimension along which to split the tensor.</param>
+            /// <param name="dimension">The dimension along which to split the tensor.</param>
 
-            public Tensor[] split(ReadOnlySpan<long> sizes, int dim = 0)
+            public Tensor[] split(ReadOnlySpan<long> sizes, long dimension = 0L)
             {
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
                     unsafe {
                         fixed (long* psizes = sizes) {
-                            THSTensor_split_with_sizes(Handle, pa.CreateArray, (IntPtr)psizes, sizes.Length, dim);
+                            THSTensor_split_with_sizes(Handle, pa.CreateArray, (IntPtr)psizes, sizes.Length, dimension);
                             torch.CheckForErrors();
                         }
                     }
@@ -4233,11 +3514,11 @@ namespace TorchSharp
             /// Splits the tensor into chunks. Each chunk is a view of the original tensor.
             /// </summary>
             /// <param name="sizes">A list of sizes for each chunk</param>
-            /// <param name="dim">The dimension along which to split the tensor.</param>
+            /// <param name="dimension">The dimension along which to split the tensor.</param>
 
-            public Tensor[] split(long[] sizes, int dim = 0)
+            public Tensor[] split(long[] sizes, long dimension = 0L)
             {
-                return split((ReadOnlySpan<long>)sizes, dim);
+                return split((ReadOnlySpan<long>)sizes, dimension);
             }
 
             /// <summary>
@@ -4249,9 +3530,6 @@ namespace TorchSharp
             {
                 return split((ReadOnlySpan<long>)sizes, 0);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_tensor_split_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size, long dim);
 
             /// <summary>
             /// Splits a tensor into multiple sub-tensors, all of which are views of input, along dimension dim according to the indices or number of sections specified by indices_or_sections.
@@ -4271,9 +3549,6 @@ namespace TorchSharp
 
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_tensor_split_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length, long dim);
 
             /// <summary>
             /// Splits a tensor into multiple sub-tensors, all of which are views of input, along dimension dim according to the indices or number of sections specified by indices_or_sections.
@@ -4298,25 +3573,19 @@ namespace TorchSharp
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_tensor_split_with_tensor_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr indices, long dim);
-
-            public Tensor[] tensor_split(Tensor indices, int dim = 0)
+            public Tensor[] tensor_split(Tensor indices, long dimension = 0L)
             {
                 if (indices.dtype != ScalarType.Int64) throw new ArgumentException("Tensor indices should be Int64 in 'tensor_split");
                 IntPtr[] ptrArray;
 
                 using (var pa = new PinnedArray<IntPtr>()) {
-                    THSTensor_tensor_split_with_tensor_sizes(Handle, pa.CreateArray, indices.Handle, dim);
+                    THSTensor_tensor_split_with_tensor_sizes(Handle, pa.CreateArray, indices.Handle, dimension);
                     torch.CheckForErrors();
                     ptrArray = pa.Array;
                 }
 
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_vsplit_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size);
 
             /// <summary>
             /// Splits input, a tensor with one or more dimensions, into multiple tensors vertically according to sizes.
@@ -4336,9 +3605,6 @@ namespace TorchSharp
 
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_vsplit_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length);
 
             /// <summary>
             /// Splits input, a tensor with one or more dimensions, into multiple tensors vertically according to sizes.
@@ -4369,10 +3635,6 @@ namespace TorchSharp
 
             public Tensor[] vsplit(Tensor indices) => tensor_split(indices, 0);
 
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_hsplit_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size);
-
             /// <summary>
             /// Splits input, a tensor with one or more dimensions, into multiple tensors horizontally according to sizes.
             /// </summary>
@@ -4391,9 +3653,6 @@ namespace TorchSharp
 
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_hsplit_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length);
 
             /// <summary>
             /// Splits input, a tensor with one or more dimensions, into multiple tensors horizontally according to sizes.
@@ -4424,9 +3683,6 @@ namespace TorchSharp
 
             public Tensor[] hsplit(Tensor indices) => tensor_split(indices, 1);
 
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_dsplit_with_size(IntPtr tensor, AllocatePinnedArray allocator, long size);
-
             /// <summary>
             /// Splits input, a tensor with three or more dimensions, into multiple tensors depthwise according to indices_or_sections. Each split is a view of input.
             /// </summary>
@@ -4445,9 +3701,6 @@ namespace TorchSharp
 
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_dsplit_with_sizes(IntPtr tensor, AllocatePinnedArray allocator, IntPtr psizes, int length);
 
             /// <summary>
             /// Splits input, a tensor with three or more dimensions, into multiple tensors depthwise according to indices_or_sections. Each split is a view of input.
@@ -4476,10 +3729,6 @@ namespace TorchSharp
             /// <param name="indices">A list of split points</param>
             public Tensor[] dsplit(Tensor indices) => tensor_split(indices, 2);
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_chunk(IntPtr tensor, AllocatePinnedArray allocator, long chunks, long dim);
-
             /// <summary>
             /// Splits a tensor into a specific number of chunks. Each chunk is a view of the input tensor.
             /// </summary>
@@ -4500,10 +3749,6 @@ namespace TorchSharp
                 return ptrArray.Select(x => new Tensor(x)).ToArray();
             }
 
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_kthvalue(IntPtr tensor, long k, long dim, bool keepdim, out IntPtr _out);
-
             /// <summary>
             /// Returns a named tuple (values, indices) where values is the k th smallest element of each row of the input tensor in the given dimension dim. And indices is the index location of each element found.
             /// If dim is not given, the last dimension of the input is chosen.
@@ -4521,9 +3766,6 @@ namespace TorchSharp
                 return (new Tensor(values), new Tensor(indices));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_max(IntPtr tensor);
-
             /// <summary>
             /// Returns the maximum value of all elements in the input tensor.
             /// </summary>
@@ -4533,10 +3775,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_max_elementwise(IntPtr tensor, IntPtr other);
 
             /// <summary>
             /// Computes the element-wise maximum of input and other.
@@ -4549,9 +3787,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_max_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dim, bool keep_dim);
 
             /// <summary>
             /// Returns a named tuple (values, indexes) where values is the maximum value of each row of the input tensor in the given dimension dim.
@@ -4574,9 +3809,6 @@ namespace TorchSharp
                 return (new Tensor(ptrArray[0]), new Tensor(ptrArray[1]));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mean(IntPtr tensor);
-
             /// <summary>
             /// Returns the mean value of all elements in the input tensor.
             /// </summary>
@@ -4587,9 +3819,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_quantile(IntPtr tensor, IntPtr q, long dim, bool keepdim);
 
             /// <summary>
             /// Returns the q-th quantiles of all elements in the input tensor, doing a linear interpolation when the q-th quantile lies between two data points.
@@ -4603,9 +3832,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_nanquantile(IntPtr tensor, IntPtr q, long dim, bool keepdim);
 
             /// <summary>
             /// This is a variant of torch.quantile() that “ignores” NaN values, computing the quantiles q as if NaN values in input did not exist.
@@ -4623,16 +3849,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mode(IntPtr tensor, AllocatePinnedArray allocator, long dim, bool keepdim);
-
             /// <summary>
             /// Returns a named tuple (values, indices) where values is the mode value of each row of the input tensor in the given dimension dim,
             /// i.e. a value which appears most often in that row, and indices is the index location of each mode value found.
             /// </summary>
             /// <param name="dim">The dimension to reduce, the last dimension by default.</param>
             /// <param name="keepdim">Whether the output tensor has dim retained or not</param>
-
 
             public (Tensor values, Tensor indices) mode(long dim = -1L, bool keepdim = false)
             {
@@ -4646,12 +3868,6 @@ namespace TorchSharp
 
                 return (values: new Tensor(ptrArray[0]), indices: new Tensor(ptrArray[1]));
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_mean_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_var_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
 
             /// <summary>
             /// Returns the mean value of each row of the input tensor in the given dimension dim. If dim is a list of dimensions, reduce over all of them.
@@ -4685,9 +3901,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_median(IntPtr tensor);
-
             /// <summary>
             /// Returns the median of the values in input.
             /// </summary>
@@ -4702,9 +3915,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_min(IntPtr tensor);
-
             /// <summary>
             /// Returns the minimum value of all elements in the input tensor.
             /// </summary>
@@ -4715,18 +3925,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_min_elementwise(IntPtr tensor, IntPtr other);
-
             public Tensor minimum(Tensor other)
             {
                 var res = THSTensor_min_elementwise(Handle, other.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern void THSTensor_min_along_dimension(IntPtr tensor, AllocatePinnedArray allocator, long dim, bool keep_dim);
 
             /// <summary>
             /// Returns a named tuple (values, indexes) where values is the minimum value of each row of the input tensor in the given dimension dim.
@@ -4751,9 +3955,6 @@ namespace TorchSharp
                 return (new Tensor(ptrArray[0]), new Tensor(ptrArray[1]));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_msort(IntPtr tensor);
-
             /// <summary>
             /// Sorts the elements of the input tensor along its first dimension in ascending order by value.
             /// </summary>
@@ -4763,9 +3964,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sort(IntPtr tensor, long dim, bool descending, bool stable, out IntPtr indices);
 
             /// <summary>
             /// Sorts the elements of the input tensor along a given dimension in ascending order by value.
@@ -4781,9 +3979,6 @@ namespace TorchSharp
                 return (new Tensor(res), new Tensor(indices));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ne(IntPtr tensor, IntPtr trg);
-
             public Tensor ne(Tensor target)
             {
                 var res = THSTensor_ne(Handle, target.Handle);
@@ -4792,9 +3987,6 @@ namespace TorchSharp
             }
 
             public Tensor not_equal(Tensor target) => ne(target);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ne_(IntPtr tensor, IntPtr trg);
 
             public Tensor ne_(Tensor target)
             {
@@ -4805,9 +3997,6 @@ namespace TorchSharp
 
             public Tensor not_equal_(Tensor target) => ne_(target);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ne_scalar(IntPtr tensor, IntPtr trg);
-
             public Tensor ne(Scalar target)
             {
                 var res = THSTensor_ne_scalar(Handle, target.Handle);
@@ -4815,18 +4004,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_ne_scalar_(IntPtr tensor, IntPtr trg);
-
             public Tensor ne_(Scalar target)
             {
                 var res = THSTensor_ne_scalar_(Handle, target.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_dist(IntPtr tensor, IntPtr other, float p);
 
             /// <summary>
             /// Returns the p-norm of (input - other).
@@ -4842,9 +4025,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_norm(IntPtr tensor, float p);
-
             /// <summary>
             /// Returns the matrix norm or vector norm of a given tensor.
             /// </summary>
@@ -4856,24 +4036,18 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_norm_along_dimension(IntPtr tensor, int dim, bool keepdim, float p);
-
             /// <summary>
             /// Returns the matrix norm or vector norm of a given tensor.
             /// </summary>
-            public Tensor norm(int dim, bool keepdim = false, float p = 2.0f)
+            public Tensor norm(long dimension, bool keepdim = false, float p = 2.0f)
             {
-                var res = THSTensor_norm_along_dimension(Handle, dim, keepdim, p);
+                var res = THSTensor_norm_along_dimension(Handle, dimension, keepdim, p);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_outer(IntPtr input, IntPtr vec2);
-
             /// <summary>
-            /// Outer product of input and vec2. 
+            /// Outer product of input and vec2.
             /// </summary>
             /// <param name="vec2">1-D input vector.</param>
             /// <remarks>If input is a vector of size n and vec2 is a vector of size m, then out must be a matrix of size n×m.</remarks>
@@ -4883,9 +4057,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_inner(IntPtr input, IntPtr vec2);
 
             /// <summary>
             /// Computes the dot product for 1D tensors.
@@ -4900,16 +4071,10 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_inverse(IntPtr tensor);
-
             /// <summary>
             /// Alias for torch.linalg.inv()
             /// </summary>
             public Tensor inverse() => torch.linalg.inv(this);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_prelu(IntPtr tensor, IntPtr trg);
 
             public Tensor prelu(Tensor target)
             {
@@ -4918,12 +4083,9 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fmax(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Computes the element-wise maximum of input and other.
-            /// 
+            ///
             /// This is like torch.maximum() except it handles NaNs differently: if exactly one of the two elements being compared is a NaN
             /// then the non-NaN element is taken as the maximum.
             /// Only if both elements are NaN is NaN propagated.
@@ -4937,12 +4099,9 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_fmin(IntPtr tensor, IntPtr trg);
-
             /// <summary>
             /// Computes the element-wise minimum of input and other.
-            /// 
+            ///
             /// This is like torch.minimum() except it handles NaNs differently: if exactly one of the two elements being compared is a NaN
             /// then the non-NaN element is taken as the minimum.
             /// Only if both elements are NaN is NaN propagated.
@@ -4954,9 +4113,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_renorm(IntPtr tensor, float p, long dim, float maxnorm);
 
             /// <summary>
             /// Returns a tensor where each sub-tensor of input along dimension dim is normalized such that the p-norm of the sub-tensor is lower than the value maxnorm
@@ -4972,9 +4128,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sigmoid(IntPtr tensor);
-
             /// <summary>
             /// Alias for torch.special.expit()
             /// </summary>
@@ -4986,9 +4139,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sigmoid_(IntPtr tensor);
-
             /// <summary>
             /// Alias for torch.special.expit(), works in place.
             /// </summary>
@@ -4999,11 +4149,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_std(IntPtr tensor, bool unbiased);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_var(IntPtr tensor, bool unbiased);
 
             /// <summary>
             /// Calculates the standard deviation of all elements in the tensor.
@@ -5031,11 +4176,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_std_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool unbiased, bool keepdim);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_var_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool unbiased, bool keepdim);
 
             /// <summary>Calculates the standard deviation of all elements in the tensor.</summary>
             /// <remarks>
@@ -5205,11 +4345,6 @@ namespace TorchSharp
             public Tensor var((long, long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
                 => var(stackalloc[] { dim.Item1, dim.Item2, dim.Item3 }, unbiased, keepdim, type);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_std_mean(IntPtr tensor, bool unbiased, out IntPtr mean);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_var_mean(IntPtr tensor, bool unbiased, out IntPtr mean);
 
             /// <summary>
             /// Calculates the standard deviation and mean of all elements in the tensor.
@@ -5239,11 +4374,6 @@ namespace TorchSharp
                 return (new Tensor(res), new Tensor(mean));
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_std_mean_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool unbiased, bool keepdim, out IntPtr mean);
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_var_mean_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool unbiased, bool keepdim, out IntPtr mean);
 
             /// <summary>Calculates the standard deviation and mean of all elements in the tensor.</summary>
             /// <remarks>
@@ -5414,9 +4544,6 @@ namespace TorchSharp
             public (Tensor @var, Tensor mean) var_mean((long, long, long) dim, bool unbiased = true, bool keepdim = false, ScalarType? type = null)
                 => var_mean(stackalloc[] { dim.Item1, dim.Item2, dim.Item3 }, unbiased, keepdim, type);
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sum(IntPtr tensor, bool has_type, sbyte scalar_type);
-
             /// <summary>
             /// Returns the sum of all elements in the :attr:`input` tensor.
             /// </summary>
@@ -5426,9 +4553,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_sum_along_dimensions(IntPtr tensor, IntPtr dimensions, int length, bool keepdim, bool has_type, sbyte scalar_type);
 
             private unsafe Tensor _sum(ReadOnlySpan<long> dimensions, bool keepdim = false, ScalarType? type = null)
             {
@@ -5478,9 +4602,6 @@ namespace TorchSharp
                 return _sum(stackalloc long[] { dim0, dim1, dim2 }, keepdim, type);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_expand(IntPtr tensor, IntPtr psizes, int length, [MarshalAs(UnmanagedType.U1)] bool isImplicit);
-
             /// <summary>
             ///  Returns a new view of the tensor with singleton dimensions expanded to a larger size.
             /// </summary>
@@ -5514,7 +4635,6 @@ namespace TorchSharp
 
             public Tensor expand_as(Tensor other) => expand(other.shape);
 
-
             /// <summary>
             ///  Returns a new view of the tensor with singleton dimensions expanded to a larger size.
             /// </summary>
@@ -5522,9 +4642,6 @@ namespace TorchSharp
             {
                 return expand((ReadOnlySpan<long>)sizes, false);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_repeat(IntPtr tensor, IntPtr psizes, int length);
 
             /// <summary>
             /// Repeats this tensor along the specified dimensions.
@@ -5540,9 +4657,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_repeat_interleave(IntPtr tensor, IntPtr repeats, long dim, long output_size);
-
             public Tensor repeat_interleave(Tensor repeats, long? dim = null, long? output_size = null)
             {
                 long _dim = dim ?? long.MinValue;
@@ -5552,9 +4666,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_repeat_interleave_int64(IntPtr tensor, long repeats, long dim, long output_size);
-
             public Tensor repeat_interleave(long repeats, long? dim = null, long? output_size = null)
             {
                 long _dim = dim ?? long.MinValue;
@@ -5563,9 +4674,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_broadcast_to(IntPtr tensor, IntPtr psizes, int length);
 
             /// <summary>
             /// Broadcasts input to the shape shape. Equivalent to calling input.expand(shape).
@@ -5581,9 +4689,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_movedim(IntPtr tensor, IntPtr src, int src_len, IntPtr dst, int dst_len);
-
             public Tensor movedim(long[] source, long[] destination)
             {
                 unsafe {
@@ -5596,9 +4701,6 @@ namespace TorchSharp
             }
 
             public Tensor moveaxis(long[] source, long[] destination) => movedim(source, destination);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_randn_out(IntPtr psizes, int length, IntPtr tensorOut);
 
             /// <summary>
             ///  Mutates the tensor to be filled with random values taken from a normal distribution with mean 0 and variance 1.
@@ -5614,9 +4716,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_rand_out(IntPtr psizes, int length, IntPtr tensorOut);
-
             /// <summary>
             ///  Mutates the tensor to be filled with random values taken from a uniform distribution in [0, 1).
             /// </summary>
@@ -5630,8 +4729,6 @@ namespace TorchSharp
                     }
                 }
             }
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_randint_out(long high, IntPtr psizes, int length, IntPtr tensorOut);
 
             /// <summary>
             ///  Mutates the tensor to be filled with random values taken from a normal distribution with mean 0 and variance 1.
@@ -5646,9 +4743,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_rand_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
             /// <summary>
             /// Returns a tensor with the same size as input that is filled with random numbers from a uniform distribution on the interval [0,1) .
@@ -5668,9 +4762,6 @@ namespace TorchSharp
                 return new Tensor(result);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_randn_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
             /// <summary>
             /// Returns a tensor with the same size as input that is filled with random numbers from a normal distribution with mean 0 and variance 1.
             /// </summary>
@@ -5688,9 +4779,6 @@ namespace TorchSharp
                 if (result == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(result);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_randint_like(IntPtr input, long low, long high, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
             /// <summary>
             /// Returns a tensor with the same shape as Tensor input filled with random integers generated uniformly in the range [low,high).
@@ -5710,9 +4798,6 @@ namespace TorchSharp
                 return new Tensor(result);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_randperm_out(long n, IntPtr tensorOut);
-
             /// <summary>
             ///  Mutates the tensor to be a 1-D tensor of size [n] with a random permutation of [0, n).
             /// </summary>
@@ -5722,9 +4807,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_bernoulli(IntPtr tensor, IntPtr gen);
 
             /// <summary>
             /// Draws binary random numbers (0 or 1) from a Bernoulli distribution.
@@ -5738,9 +4820,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_multinomial(IntPtr tensor, long num_samples, bool replacement, IntPtr gen);
 
             /// <summary>
             /// Returns a tensor where each row contains num_samples indices sampled from the multinomial probability distribution located in the corresponding row of tensor input.
@@ -5756,9 +4835,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_poisson(IntPtr tensor, IntPtr gen);
-
             /// <summary>
             /// Returns a tensor of the same size as input with each element sampled from a Poisson distribution with rate parameter given by the corresponding element in input
             /// </summary>
@@ -5770,9 +4846,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_bernoulli_0(IntPtr tensor, double p, IntPtr gen);
 
             /// <summary>
             /// Fills each location of the input tensor with an independent sample from Bernoulli(p)
@@ -5787,9 +4860,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_bernoulli_1(IntPtr tensor, IntPtr p_tensor, IntPtr gen);
-
             /// <summary>
             /// Fills each location of the input tensor with an independent sample from Bernoulli(p)
             /// </summary>
@@ -5803,18 +4873,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_binomial(IntPtr count, IntPtr prob, IntPtr gen);
-
             public Tensor binomial(Tensor prob, torch.Generator? generator = null)
             {
                 var res = THSTensor_binomial(Handle, prob.Handle, (generator is null) ? IntPtr.Zero : generator.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_cauchy_(IntPtr tensor, double median, double sigma, IntPtr gen);
 
             /// <summary>
             /// Fills the tensor with numbers drawn from the Cauchy distribution.
@@ -5826,9 +4890,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_exponential_(IntPtr tensor, double lambda, IntPtr gen);
 
             /// <summary>
             /// Fills the input tensor with elements drawn from the exponential distribution
@@ -5843,9 +4904,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_geometric_(IntPtr tensor, double p, IntPtr gen);
-
             /// <summary>
             /// Fills the input tensor with elements drawn from a geometric distribution.
             /// </summary>
@@ -5858,9 +4916,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_normal_(IntPtr tensor, double mean, double std, IntPtr gen);
 
             /// <summary>
             /// Fills the input tensor with elements samples from the normal distribution parameterized by mean and std.
@@ -5876,9 +4931,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_log_normal_(IntPtr tensor, double mean, double std, IntPtr gen);
-
             /// <summary>
             /// Fills the input tensor with numbers samples from the log-normal distribution parameterized by the given mean and standard deviation.
             /// </summary>
@@ -5893,9 +4945,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_random_(IntPtr tensor, double low, double high, IntPtr gen);
 
             /// <summary>
             /// Fills the input tensor with numbers sampled from the discrete uniform distribution over [from, to - 1].
@@ -5914,9 +4963,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_uniform_(IntPtr tensor, double low, double high, IntPtr gen);
-
             /// <summary>
             /// Fills the input tensor with numbers sampled from the continuous uniform distribution:
             /// </summary>
@@ -5931,9 +4977,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_arange_out(IntPtr start, IntPtr strp, IntPtr step, IntPtr tensorOut);
-
             /// <summary>
             ///  Mutates the tensor to be filled with with values from interval [start, end) and
             /// common difference step, starting from start.
@@ -5944,9 +4987,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_permute(IntPtr tensor, IntPtr psizes, int length);
 
             /// <summary>
             ///  Returns a view of the original tensor with its dimensions permuted.
@@ -5962,9 +5002,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_ones_out(IntPtr psizes, int length, IntPtr tensorOut);
 
             /// <summary>
             ///  Mutates the tensor to have the given size with all values set to 1
@@ -6031,9 +5068,6 @@ namespace TorchSharp
             {
                 return new_ones(new long[] { dim0, dim1, dim2, dim3 }, dtype, device, requires_grad);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_zeros_out(IntPtr psizes, int length, IntPtr tensorOut);
 
             /// <summary>
             ///  Mutates the tensor to have the given size with all values set to 0
@@ -6111,9 +5145,6 @@ namespace TorchSharp
             }
 
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_zeros_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
             /// <summary>
             /// Returns a tensor filled with the scalar value 0, with the same size as input.
             /// </summary>
@@ -6131,9 +5162,6 @@ namespace TorchSharp
                 if (result == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(result);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_ones_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
             /// <summary>
             /// Returns a tensor filled with the scalar value 1, with the same size as input.
@@ -6205,9 +5233,6 @@ namespace TorchSharp
                 return new_empty(new long[] { dim0, dim1, dim2, dim3 }, dtype, device, requires_grad);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_empty_out(IntPtr psizes, int length, IntPtr tensorOut);
-
             /// <summary>
             ///  Mutates the tensor to have the given size with all values uninitialized
             /// </summary>
@@ -6221,9 +5246,6 @@ namespace TorchSharp
                     }
                 }
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_empty_like(IntPtr input, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
             /// <summary>
             ///  Returns an uninitialized tensor with the same size as input.
@@ -6242,9 +5264,6 @@ namespace TorchSharp
                 if (result == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(result);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_full_out(IntPtr psizes, int length, IntPtr value, IntPtr tensorOut);
 
             /// <summary>
             ///  Mutates the tensor to have the given size with all values uninitialized
@@ -6327,9 +5346,6 @@ namespace TorchSharp
             }
 
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_full_like(IntPtr input, IntPtr value, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
             /// <summary>
             /// Returns a tensor with the same size as input filled with 'value.'
             /// </summary>
@@ -6348,9 +5364,6 @@ namespace TorchSharp
                 return new Tensor(result);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_detach(IntPtr tensor);
-
             public Tensor detach()
             {
                 var res = THSTensor_detach(Handle);
@@ -6358,18 +5371,12 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_detach_(IntPtr tensor);
-
             public Tensor detach_()
             {
                 var res = THSTensor_detach_(Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_eye_out(long rows, long columns, IntPtr tensorOut);
 
             /// <summary>
             ///  Mutates the tensor into a 2-D tensor with ones on the diagonal and zeros elsewhere.
@@ -6381,17 +5388,7 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_scatter(IntPtr tensor, long dim, IntPtr index, IntPtr source);
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_scatter_(IntPtr tensor, long dim, IntPtr index, IntPtr source);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_scatter_add(IntPtr tensor, long dim, IntPtr index, IntPtr source);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_scatter_add_(IntPtr tensor, long dim, IntPtr index, IntPtr source);
 
             /// <summary>
             ///  Writes all values from the tensor src into the input tensor at the indices specified in the index tensor. For each
@@ -6441,9 +5438,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_gather(IntPtr tensor, long dim, IntPtr index);
-
             /// <summary>
             /// Gathers values along an axis specified by dim.
             /// </summary>
@@ -6453,9 +5447,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_flip(IntPtr tensor, IntPtr psizes, int length);
 
             /// <summary>
             ///  Reverse the order of a n-D tensor along given axis in dims.
@@ -6471,9 +5462,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_fliplr(IntPtr tensor);
-
             /// <summary>
             /// Flip tensor in the left/right direction, returning a new tensor.
             /// </summary>
@@ -6484,9 +5472,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_flipud(IntPtr tensor);
-
             /// <summary>
             /// Flip tensor in the up/down direction, returning a new tensor.
             /// </summary>
@@ -6496,9 +5481,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_nanmean(IntPtr tensor, long dim, bool keepdim, sbyte scalar_type);
 
             /// <summary>
             /// Returns the mean of the values in input, ignoring NaN values.
@@ -6512,9 +5494,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_nanmedian(IntPtr tensor);
-
             /// <summary>
             /// Returns the median of the values in input, ignoring NaN values.
             /// </summary>
@@ -6525,9 +5504,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_nansum(IntPtr tensor);
-
             /// <summary>
             /// Returns the sum of all elements in the input tensor, treating NaN as zero.
             /// </summary>
@@ -6537,9 +5513,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_nan_to_num(IntPtr tensor, IntPtr nan, IntPtr posinf, IntPtr neginf);
 
             /// <summary>
             /// Replaces NaN, positive infinity, and negative infinity values in input with the values specified by nan, posinf, and neginf, respectively.
@@ -6561,9 +5534,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_nextafter(IntPtr tensor, IntPtr other);
-
             /// <summary>
             /// Return the next floating-point value after input towards other, elementwise.
             /// </summary>
@@ -6573,9 +5543,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_narrow(IntPtr tensor, long dim, long start, long length);
 
             /// <summary>
             ///  Returns a new tensor that is a narrowed version of the input along one dimension. The
@@ -6588,9 +5555,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_nonzero(IntPtr tensor);
 
             /// <summary>
             /// Returns a tensor containing the indices of all non-zero elements of input.
@@ -6612,9 +5576,6 @@ namespace TorchSharp
                 var t = new Tensor(res);
                 return t.chunk(t.shape[1], dim: 1);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_roll(IntPtr tensor, IntPtr shifts, int shLength, IntPtr dims, long dimLength);
 
             /// <summary>
             /// Roll the tensor along the given dimension(s).
@@ -6682,9 +5643,6 @@ namespace TorchSharp
                 }
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_slice(IntPtr tensor, long dim, long start, long length, long step);
-
             /// <summary>
             /// Returns a new tensor that is a sliced version of the input along one dimension. The
             /// dimension is input from start to finish-1. The
@@ -6698,9 +5656,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unsqueeze(IntPtr tensor, long dim);
-
             /// <summary>
             ///  Returns a new tensor with a dimension of size one inserted at the specified position.
             ///  The returned tensor shares the same underlying data with this tensor.
@@ -6712,9 +5667,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_unsqueeze_(IntPtr tensor, long dim);
-
             /// <summary>
             ///  Returns a new tensor with a dimension of size one inserted at the specified position.
             ///  The returned tensor shares the same underlying data with this tensor.
@@ -6725,9 +5677,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_where(IntPtr condition, IntPtr x, IntPtr y);
 
             /// <summary>
             /// Return a tensor of elements selected from either x or y, depending on condition.
@@ -6744,7 +5693,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
 
             // Operators overloading
 
@@ -7059,7 +6007,7 @@ namespace TorchSharp
                                    CultureInfo? cultureInfo = null,
                                    string newLine = "")
             {
-                if (String.IsNullOrEmpty(newLine))
+                if (string.IsNullOrEmpty(newLine))
                     newLine = Environment.NewLine;
 
                 if (device_type == DeviceType.META)
@@ -7259,7 +6207,6 @@ namespace TorchSharp
                 var hasMinus = new bool[colCount];
 
 
-
                 for (int i = 0; i < rowCount; i++) {
                     var row = new List<string>();
                     BuildRow(row, t[i], width, fltFormat, cultureInfo);
@@ -7410,16 +6357,12 @@ namespace TorchSharp
             public static explicit operator long(Tensor value) => value.ToInt64();
             public static explicit operator bool(Tensor value) => value.ToBoolean();
 
-
             /// <summary>
             /// Create a block diagonal matrix from provided tensors.
             /// </summary>
             /// <param name="tensors">One or more tensors with 0, 1, or 2 dimensions.</param>
             /// <returns></returns>
             public static Tensor block_diag(params Tensor[] tensors) => torch.block_diag(tensors);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_atleast_1d(IntPtr tensor);
 
             /// <summary>
             /// Returns a 1-dimensional view of an input tensor with zero dimensions. Input tensors with one or more dimensions are returned as-is.
@@ -7432,9 +6375,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_atleast_2d(IntPtr tensor);
-
             /// <summary>
             /// Returns a 2-dimensional view of an input tensor with zero dimensions. Input tensors with two or more dimensions are returned as-is.
             /// </summary>
@@ -7446,9 +6386,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_atleast_3d(IntPtr tensor);
-
             /// <summary>
             /// Returns a 3-dimensional view of an input tensor with zero dimensions. Input tensors with three or more dimensions are returned as-is.
             /// </summary>
@@ -7459,9 +6396,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_stft(IntPtr x, long n_fft, long hop_length, long win_length, IntPtr window, [MarshalAs(UnmanagedType.U1)] bool normalized, long onesided, [MarshalAs(UnmanagedType.U1)] bool return_complex);
 
             /// <summary>
             /// Short-time Fourier transform (STFT).
@@ -7508,9 +6442,6 @@ namespace TorchSharp
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_istft(IntPtr x, long n_fft, long hop_length, long win_length, IntPtr window, [MarshalAs(UnmanagedType.U1)] bool center, [MarshalAs(UnmanagedType.U1)] bool normalized, long onesided, long length, [MarshalAs(UnmanagedType.U1)] bool return_complex);
 
             /// <summary>
             /// Inverse short time Fourier Transform. This is expected to be the inverse of stft().
@@ -7565,34 +6496,34 @@ namespace TorchSharp
             internal Kind kind;
             internal Tensor? tensor;
 
-            static public TensorIndex Slice(long? start = null, long? stop = null, long? step = null)
+            public static TensorIndex Slice(long? start = null, long? stop = null, long? step = null)
             {
                 return new TensorIndex() { startIndexOrBoolOrSingle = start, step = step, stopIndex = stop, kind = Kind.Slice };
             }
 
-            static public TensorIndex Slice((int? start, int? end) range) => TensorIndex.Slice((long?)range.start, (long?)range.end);
+            public static TensorIndex Slice((int? start, int? end) range) => TensorIndex.Slice((long?)range.start, (long?)range.end);
 
 #if !NETSTANDARD2_0_OR_GREATER
-            static public TensorIndex Slice(System.Range range)
+            public static TensorIndex Slice(System.Range range)
             {
                 long? start = !range.Start.IsFromEnd ? range.Start.Value : -1 * range.Start.Value;
                 long? end = !range.End.IsFromEnd ? range.End.Value : (range.End.Value == 0) ? null : -1 * range.End.Value;
                 return TensorIndex.Slice(start, end);
             }
 #endif // NETSTANDARD2_0_OR_GREATER
-            static public TensorIndex Bool(bool value) => new TensorIndex() { startIndexOrBoolOrSingle = (value ? 1 : 0), kind = Kind.Bool };
+            public static TensorIndex Bool(bool value) => new TensorIndex() { startIndexOrBoolOrSingle = (value ? 1 : 0), kind = Kind.Bool };
 
-            static public TensorIndex Single(long? index) => new TensorIndex() { startIndexOrBoolOrSingle = index, kind = Kind.Single };
+            public static TensorIndex Single(long? index) => new TensorIndex() { startIndexOrBoolOrSingle = index, kind = Kind.Single };
 
-            static public TensorIndex Tensor(Tensor tensor) => new TensorIndex() { tensor = tensor, kind = Kind.Tensor };
+            public static TensorIndex Tensor(Tensor tensor) => new TensorIndex() { tensor = tensor, kind = Kind.Tensor };
 
-            static public TensorIndex Ellipsis = new TensorIndex() { kind = Kind.Ellipsis };
+            public static TensorIndex Ellipsis = new TensorIndex() { kind = Kind.Ellipsis };
 
-            static public TensorIndex None = new TensorIndex() { kind = Kind.None };
+            public static TensorIndex None = new TensorIndex() { kind = Kind.None };
 
-            static public TensorIndex Null = new TensorIndex() { kind = Kind.Null };
+            public static TensorIndex Null = new TensorIndex() { kind = Kind.Null };
 
-            static public TensorIndex Colon = Slice();
+            public static TensorIndex Colon = Slice();
 
             public static implicit operator TensorIndex(long value)
             {

--- a/src/TorchSharp/Tensor/Tensor.torch.cs
+++ b/src/TorchSharp/Tensor/Tensor.torch.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Linq;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -26,9 +26,6 @@ namespace TorchSharp
         /// </summary>
         public static IEnumerable<Tensor> atleast_3d(params Tensor[] input) => input.Select(t => t.atleast_3d());
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_block_diag(IntPtr tensor, int len);
-
         /// <summary>
         /// Create a block diagonal matrix from provided tensors.
         /// </summary>
@@ -44,9 +41,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
         }
-
-        [DllImport("LibTorchSharp")]
-        static extern void THSTensor_broadcast_tensors(IntPtr tensor, long length, AllocatePinnedArray allocator);
 
         /// <summary>
         /// Broadcasts the given tensors according to Torch broadcasting semantics.
@@ -87,10 +81,6 @@ namespace TorchSharp
         /// The result is sorted lexicographically, with the last index changing the fastest (C-style).
         /// </summary>
         public static Tensor nonzero(Tensor input) => input.nonzero();
-
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_cat(IntPtr tensor, int len, long dim);
 
         /// <summary>
         /// Concatenates the given sequence of seq tensors in the given dimension.
@@ -205,9 +195,6 @@ namespace TorchSharp
         /// <returns></returns>
         public static Tensor where(Tensor condition, Tensor x, Tensor y) => x.where(condition, y);
 
-        [DllImport("LibTorchSharp")]
-        static extern void THSTensor_where_list(IntPtr condition, AllocatePinnedArray allocator);
-
         /// <summary>
         /// Returns a tuple of 1-D tensors, one for each dimension in input, each containing the indices (in that dimension) of all non-zero elements of input .
         /// If input has nn dimensions, then the resulting tuple contains nn tensors of size zz, where zz is the total number of non-zero elements in the input tensor.
@@ -231,9 +218,6 @@ namespace TorchSharp
             return ptrArray.Select(x => new Tensor(x)).ToArray();
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_stack(IntPtr tensor, int len, long dim);
-
         /// <summary>
         /// Concatenates a sequence of tensors along a new dimension.
         /// </summary>
@@ -255,10 +239,7 @@ namespace TorchSharp
         /// </summary>
         /// <param name="input">The input tensor.</param>
         /// <param name="permutation">The desired ordering of dimensions</param>
-        static public Tensor permute(Tensor input, params long[] permutation) => input.permute(permutation);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_hstack(IntPtr tensor, int len);
+        public static Tensor permute(Tensor input, params long[] permutation) => input.permute(permutation);
 
         /// <summary>
         /// Stack tensors in sequence horizontally (column wise).
@@ -276,9 +257,6 @@ namespace TorchSharp
             }
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_vstack(IntPtr tensor, int len);
-
         /// <summary>
         /// Stack tensors in sequence vertically (row wise).
         /// </summary>
@@ -294,9 +272,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_column_stack(IntPtr tensors, int len);
 
         /// <summary>
         /// Creates a new tensor by horizontally stacking the input tensors.
@@ -315,9 +290,6 @@ namespace TorchSharp
             }
         }
 
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_row_stack(IntPtr tensor, int len);
-
         /// <summary>
         /// Stack tensors in sequence vertically (row wise).
         /// </summary>
@@ -333,9 +305,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_dstack(IntPtr tensor, int len);
 
         /// <summary>
         /// Stack tensors in sequence depthwise (along third axis).
@@ -353,9 +322,6 @@ namespace TorchSharp
                 return new Tensor(res);
             }
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_meshgrid(IntPtr tensor, long len, [MarshalAs(UnmanagedType.LPStr)] string indexing, AllocatePinnedArray allocator);
 
         /// <summary>
         /// Creates grids of coordinates specified by the 1D inputs in tensors.
@@ -394,9 +360,6 @@ namespace TorchSharp
         /// <param name="dim">The dimension to remove.</param>
         /// <returns>An array of all slices along a given dimension, already without it.</returns>
         public static Tensor[] unbind(Tensor tensor, int dim = 0) => tensor.unbind(dim);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTorch_lstsq(IntPtr input, IntPtr A, out IntPtr pQR);
 
         /// <summary>
         /// Computes the solution to the least squares and least norm problems for a full rank matrix A of size m×n and a matrix B of size m×k.
@@ -446,7 +409,7 @@ namespace TorchSharp
         /// <param name="input">The input tensor</param>
         /// <param name="min">The minimum value</param>
         /// <param name="max">The maximum value</param>
-        static public Tensor clamp(Tensor input, Scalar min = null, Scalar max = null) => input.clamp(min, max);
+        public static Tensor clamp(Tensor input, Scalar min = null, Scalar max = null) => input.clamp(min, max);
 
         /// <summary>
         /// Clamps all elements in input into the range [ min, max ] in place.
@@ -454,7 +417,7 @@ namespace TorchSharp
         /// <param name="input">The input tensor</param>
         /// <param name="min">The minimum value</param>
         /// <param name="max">The maximum value</param>
-        static public Tensor clamp_(Tensor input, Scalar min = null, Scalar max = null) => input.clamp_(min, max);
+        public static Tensor clamp_(Tensor input, Scalar min = null, Scalar max = null) => input.clamp_(min, max);
 
         /// <summary>
         /// Clamps all elements in input into the range [ min, max ].
@@ -462,7 +425,7 @@ namespace TorchSharp
         /// <param name="input">The input tensor</param>
         /// <param name="min">The minimum value</param>
         /// <param name="max">The maximum value</param>
-        static public Tensor clamp(Tensor input, Tensor min = null, Tensor max = null) => input.clamp(min, max);
+        public static Tensor clamp(Tensor input, Tensor min = null, Tensor max = null) => input.clamp(min, max);
 
         /// <summary>
         /// Clamps all elements in input into the range [ min, max ] in place.
@@ -470,15 +433,15 @@ namespace TorchSharp
         /// <param name="input">The input tensor</param>
         /// <param name="min">The minimum value</param>
         /// <param name="max">The maximum value</param>
-        static public Tensor clamp_(Tensor input, Tensor min = null, Tensor max = null) => input.clamp_(min, max);
+        public static Tensor clamp_(Tensor input, Tensor min = null, Tensor max = null) => input.clamp_(min, max);
 
-        static public Tensor clamp_max(Tensor input, Scalar max) => input.clamp_max(max);
+        public static Tensor clamp_max(Tensor input, Scalar max) => input.clamp_max(max);
 
-        static public Tensor clamp_max_(Tensor input, Scalar max) => input.clamp_max(max);
+        public static Tensor clamp_max_(Tensor input, Scalar max) => input.clamp_max(max);
 
-        static public Tensor clamp_min(Tensor input, Scalar min) => input.clamp_min(min);
+        public static Tensor clamp_min(Tensor input, Scalar min) => input.clamp_min(min);
 
-        static public Tensor clamp_min_(Tensor input, Scalar min) => input.clamp_min(min);
+        public static Tensor clamp_min_(Tensor input, Scalar min) => input.clamp_min(min);
 
         /// <summary>
         /// Returns the maximum value of each slice of the input tensor in the given dimension(s) dim.
@@ -487,7 +450,7 @@ namespace TorchSharp
         /// <param name="dims">The dimension or dimensions to reduce.</param>
         /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
         /// <param name="out">The output tensor -- optional.</param>
-        static public Tensor amax(Tensor input, long[] dims, bool keepdim = false, Tensor @out = null) => input.amax(dims, keepdim, @out);
+        public static Tensor amax(Tensor input, long[] dims, bool keepdim = false, Tensor @out = null) => input.amax(dims, keepdim, @out);
 
         /// <summary>
         /// Returns the minimum value of each slice of the input tensor in the given dimension(s) dim.
@@ -496,14 +459,14 @@ namespace TorchSharp
         /// <param name="dims">The dimension or dimensions to reduce.</param>
         /// <param name="keepdim">Whether the output tensor has dim retained or not.</param>
         /// <param name="out">The output tensor -- optional.</param>
-        static public Tensor amin(Tensor input, long[] dims, bool keepdim = false, Tensor @out = null) => input.amin(dims, keepdim, @out);
+        public static Tensor amin(Tensor input, long[] dims, bool keepdim = false, Tensor @out = null) => input.amin(dims, keepdim, @out);
 
         /// <summary>
         /// Returns a tensor with the same data and number of elements as the input but with the specified shape.
         /// </summary>
         /// <param name="input">The input tensor</param>
         /// <param name="shape">The new tensor shape.</param>
-        static public Tensor reshape(Tensor input, params long[] shape) => input.reshape(shape);
+        public static Tensor reshape(Tensor input, params long[] shape) => input.reshape(shape);
 
         /// <summary>
         /// Flattens input by reshaping it into a one-dimensional tensor.
@@ -512,7 +475,7 @@ namespace TorchSharp
         /// <param name="start_dim">The first dim to flatten</param>
         /// <param name="end_dim">The last dim to flatten.</param>
         /// <remarks>Flattening a zero-dimensional tensor will return a one-dimensional view.</remarks>
-        static public Tensor flatten(Tensor input, long start_dim = 0, long end_dim = -1) => input.flatten(start_dim, end_dim);
+        public static Tensor flatten(Tensor input, long start_dim = 0, long end_dim = -1) => input.flatten(start_dim, end_dim);
 
         /// <summary>
         /// Expands the dimension dim of the self tensor over multiple dimensions of sizes given by sizes.
@@ -520,7 +483,7 @@ namespace TorchSharp
         /// <param name="input">The input tensor</param>
         /// <param name="dim">Dimension to unflatten.</param>
         /// <param name="sizes">New shape of the unflattened dimension.</param>
-        static public Tensor unflatten(Tensor input, long dim, params long[] sizes) => input.unflatten(dim, sizes);
+        public static Tensor unflatten(Tensor input, long dim, params long[] sizes) => input.unflatten(dim, sizes);
 
         /// <summary>
         /// Expands the dimension dim of the self tensor over multiple dimensions of sizes given by sizes.
@@ -528,10 +491,7 @@ namespace TorchSharp
         /// <param name="input">The input tensor</param>
         /// <param name="dim">Dimension to unflatten.</param>
         /// <param name="sizes">New shape of the unflattened dimension.</param>
-        static public Tensor unflatten(Tensor input, long dim, torch.Size sizes) => input.unflatten(dim, sizes.Shape);
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_standard_gamma_(IntPtr tensor, IntPtr gen);
+        public static Tensor unflatten(Tensor input, long dim, torch.Size sizes) => input.unflatten(dim, sizes.Shape);
 
         public static Tensor _standard_gamma(Tensor input, torch.Generator generator = null)
         {
@@ -539,9 +499,6 @@ namespace TorchSharp
             if (res == IntPtr.Zero) { torch.CheckForErrors(); }
             return new Tensor(res);
         }
-
-        [DllImport("LibTorchSharp")]
-        extern static IntPtr THSTensor_sample_dirichlet_(IntPtr tensor, IntPtr gen);
 
         public static Tensor _sample_dirichlet(Tensor input, torch.Generator generator = null)
         {
@@ -553,7 +510,7 @@ namespace TorchSharp
 
         /// <summary>
         /// Accumulate the elements of alpha times source into the input tensor by adding to the indices in the order given in index.
-        /// 
+        ///
         /// For example, if dim == 0, index[i] == j, and alpha=-1, then the ith row of source is subtracted from the jth row of the input tensor.
         /// The dimth dimension of source must have the same size as the length of index(which must be a vector), and all other dimensions must match self, or an error will be raised.
         /// </summary>
@@ -567,7 +524,7 @@ namespace TorchSharp
 
         /// <summary>
         /// Accumulate, in place, the elements of alpha times source into the input tensor by adding to the indices in the order given in index.
-        /// 
+        ///
         /// For example, if dim == 0, index[i] == j, and alpha=-1, then the ith row of source is subtracted from the jth row of the input tensor.
         /// The dimth dimension of source must have the same size as the length of index(which must be a vector), and all other dimensions must match self, or an error will be raised.
         /// </summary>
@@ -607,7 +564,7 @@ namespace TorchSharp
 
         /// <summary>
         /// Fills the elements of the input tensor with value value by selecting the indices in the order given in index.
-        /// 
+        ///
         /// For example, if dim == 0, index[i] == j, and alpha=-1, then the ith row of source is subtracted from the jth row of the input tensor.
         /// The dimth dimension of source must have the same size as the length of index(which must be a vector), and all other dimensions must match self, or an error will be raised.
         /// </summary>
@@ -620,7 +577,7 @@ namespace TorchSharp
 
         /// <summary>
         /// Fills, in place, the elements of the input tensor with value value by selecting the indices in the order given in index.
-        /// 
+        ///
         /// For example, if dim == 0, index[i] == j, and alpha=-1, then the ith row of source is subtracted from the jth row of the input tensor.
         /// The dimth dimension of source must have the same size as the length of index(which must be a vector), and all other dimensions must match self, or an error will be raised.
         /// </summary>

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -238,7 +238,7 @@ namespace TorchSharp
             bool copied = false;
 
             if (tensor.device_type != DeviceType.CPU) {
-                tensor = tensor.to(torch.CPU);
+                tensor = tensor.to(CPU);
                 copied = true;
             }
 
@@ -301,7 +301,7 @@ namespace TorchSharp
 
             if (!skip) {
                 var device = tensor.device;
-                if (device.type != DeviceType.CPU) tensor.to(torch.CPU);
+                if (device.type != DeviceType.CPU) tensor.to(CPU);
                 tensor.bytes = bytes;
                 tensor.to(device);
             }
@@ -320,37 +320,25 @@ namespace TorchSharp
         {
             var array = doCopy ? (T[])rawArray.Clone() : rawArray;
 
-            switch (true) {
-            case bool _ when typeof(T) == typeof(byte): {
-                    return torch.tensor((array as byte[])!, dimensions, requires_grad: requires_grad); ;
-                }
-            case bool _ when typeof(T) == typeof(sbyte): {
-                    return torch.tensor((array as sbyte[])!, dimensions, requires_grad: requires_grad); ;
-                }
-            case bool _ when typeof(T) == typeof(short): {
-                    return torch.tensor((array as short[])!, dimensions, requires_grad: requires_grad); ;
-                }
-            case bool _ when typeof(T) == typeof(int): {
-                    return torch.tensor((array as int[])!, dimensions, requires_grad: requires_grad);
-                }
-            case bool _ when typeof(T) == typeof(long): {
-                    return torch.tensor((array as long[])!, dimensions, requires_grad: requires_grad);
-                }
-            case bool _ when typeof(T) == typeof(double): {
-                    return torch.tensor((array as double[])!, dimensions, requires_grad: requires_grad);
-                }
-            case bool _ when typeof(T) == typeof(float): {
-                    return torch.tensor((array as float[])!, dimensions, requires_grad: requires_grad);
-                }
-            case bool _ when typeof(T) == typeof(bool): {
-                    return torch.tensor((array as bool[])!, dimensions, requires_grad: requires_grad);
-                }
-            //case bool _ when typeof(T) == typeof(System.Numerics.Complex):
-            //    {
-            //        return ComplexFloat64Tensor.from(array as System.Numerics.Complex[], dimensions, requires_grad);
-            //    }
-            default: throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
-            }
+            return true switch {
+                true when typeof(T) == typeof(byte) => tensor((array as byte[])!, dimensions,
+                    requires_grad: requires_grad),
+                true when typeof(T) == typeof(sbyte) => tensor((array as sbyte[])!, dimensions,
+                    requires_grad: requires_grad),
+                true when typeof(T) == typeof(short) => tensor((array as short[])!, dimensions,
+                    requires_grad: requires_grad),
+                true when typeof(T) == typeof(int) => tensor((array as int[])!, dimensions,
+                    requires_grad: requires_grad),
+                true when typeof(T) == typeof(long) => tensor((array as long[])!, dimensions,
+                    requires_grad: requires_grad),
+                true when typeof(T) == typeof(double) => tensor((array as double[])!, dimensions,
+                    requires_grad: requires_grad),
+                true when typeof(T) == typeof(float) => tensor((array as float[])!, dimensions,
+                    requires_grad: requires_grad),
+                true when typeof(T) == typeof(bool) => tensor((array as bool[])!, dimensions,
+                    requires_grad: requires_grad),
+                _ => throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.")
+            };
         }
 
         /// <summary>
@@ -361,26 +349,26 @@ namespace TorchSharp
         /// <param name="device">The device to place the tensor on.</param>
         /// <param name="requires_grad">If true, the tensor must track its gradients.</param>
         /// <returns></returns>
-        public static Tensor ToTensor<T>(this T scalar, torch.Device? device = null, bool requires_grad = false) where T : struct
+        public static Tensor ToTensor<T>(this T scalar, Device? device = null, bool requires_grad = false) where T : struct
         {
             if (requires_grad && typeof(T) != typeof(float) && typeof(T) != typeof(double)) {
                 throw new ArgumentException(nameof(requires_grad), "Only floating point types support gradients.");
             }
 
             if (typeof(T) == typeof(byte))
-                return torch.tensor((byte)(object)scalar, uint8, device, requires_grad);
+                return tensor((byte)(object)scalar, uint8, device, requires_grad);
             if (typeof(T) == typeof(sbyte))
-                return torch.tensor((sbyte)(object)scalar, int8, device, requires_grad);
+                return tensor((sbyte)(object)scalar, int8, device, requires_grad);
             if (typeof(T) == typeof(short))
-                return torch.tensor((short)(object)scalar, int16, device, requires_grad);
+                return tensor((short)(object)scalar, int16, device, requires_grad);
             if (typeof(T) == typeof(int))
-                return torch.tensor((int)(object)scalar, int32, device, requires_grad);
+                return tensor((int)(object)scalar, int32, device, requires_grad);
             if (typeof(T) == typeof(long))
-                return torch.tensor((long)(object)scalar, int64, device, requires_grad);
+                return tensor((long)(object)scalar, int64, device, requires_grad);
             if (typeof(T) == typeof(float))
-                return torch.tensor((float)(object)scalar, float32, device, requires_grad);
+                return tensor((float)(object)scalar, float32, device, requires_grad);
             if (typeof(T) == typeof(double))
-                return torch.tensor((double)(object)scalar, float64, device, requires_grad);
+                return tensor((double)(object)scalar, float64, device, requires_grad);
             throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
         }
 

--- a/src/TorchSharp/Tensor/TensorTyped.handwritten.cs
+++ b/src/TorchSharp/Tensor/TensorTyped.handwritten.cs
@@ -1,33 +1,22 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 // The scalar 'from' factories for complex tensors require some hand-written code, cannot be generated.
 
 namespace TorchSharp
 {
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void GCHandleDeleter(IntPtr memory);
-
     public static partial class torch
     {
-
         internal partial class ComplexFloat32Tensor
         {
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_to_type(IntPtr handle, sbyte scalar_type);
-
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_arange(IntPtr start, IntPtr stop, IntPtr step, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requireGrad);
-
             /// <summary>
             /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
             /// common difference step, starting from start.
             /// </summary>
             /// <remarks>In the case of complex element types, 'arange' will create a complex tensor with img=0 in all elements.</remarks>
-            static public Tensor arange(Scalar start, Scalar stop, Scalar step, torch.Device device = null, bool requires_grad = false)
+            public static Tensor arange(Scalar start, Scalar stop, Scalar step, torch.Device device = null, bool requires_grad = false)
             {
                 device = torch.InitializeDevice(device);
 
@@ -45,9 +34,6 @@ namespace TorchSharp
 
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_newComplexFloat32Scalar(float real, float imaginary, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
             /// <summary>
             /// Create a scalar tensor from a single value
@@ -71,23 +57,11 @@ namespace TorchSharp
                 return new Tensor(handle);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_randint(long max, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_view_as_complex(IntPtr tensor);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_copy_(IntPtr handle, IntPtr source, [MarshalAs(UnmanagedType.U1)] bool non_blocking);
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSTensor_dispose(IntPtr handle);
-
             /// <summary>
             ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
             ///  The real and imaginary parts will be filled independently of each other.
             /// </summary>
-            static public Tensor randint(long max, long[] size, torch.Device device = null, bool requires_grad = false)
+            public static Tensor randint(long max, long[] size, torch.Device device = null, bool requires_grad = false)
             {
                 device = torch.InitializeDevice(device);
 
@@ -137,18 +111,12 @@ namespace TorchSharp
 
         internal partial class ComplexFloat64Tensor
         {
-            [DllImport("LibTorchSharp")]
-            static extern IntPtr THSTensor_to_type(IntPtr handle, sbyte scalar_type);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_arange(IntPtr start, IntPtr stop, IntPtr step, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requireGrad);
-
             /// <summary>
             /// Creates 1-D tensor of size [(end - start) / step] with values from interval [start, end) and
             /// common difference step, starting from start.
             /// </summary>
             /// <remarks>In the case of complex element types, 'arange' will create a complex tensor with img=0 in all elements.</remarks>
-            static public Tensor arange(Scalar start, Scalar stop, Scalar step, torch.Device device = null, bool requires_grad = false)
+            public static Tensor arange(Scalar start, Scalar stop, Scalar step, torch.Device device = null, bool requires_grad = false)
             {
                 device = torch.InitializeDevice(device);
 
@@ -166,9 +134,6 @@ namespace TorchSharp
 
                 return new Tensor(res);
             }
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_newComplexFloat64Scalar(double real, double imaginary, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
             /// <summary>
             /// Create a scalar tensor from a single value
@@ -192,23 +157,11 @@ namespace TorchSharp
                 return new Tensor(handle);
             }
 
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_randint(long max, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_view_as_complex(IntPtr tensor);
-
-            [DllImport("LibTorchSharp")]
-            extern static IntPtr THSTensor_copy_(IntPtr handle, IntPtr source, [MarshalAs(UnmanagedType.U1)] bool non_blocking);
-
-            [DllImport("LibTorchSharp")]
-            extern static void THSTensor_dispose(IntPtr handle);
-
             /// <summary>
             ///  Create a new tensor filled with random integer values taken from a uniform distribution in [0, max).
             ///  The real and imaginary parts will be filled independently of each other.
             /// </summary>
-            static public Tensor randint(long max, long[] size, torch.Device device = null, bool requires_grad = false)
+            public static Tensor randint(long max, long[] size, torch.Device device = null, bool requires_grad = false)
             {
                 device = torch.InitializeDevice(device);
 

--- a/src/TorchSharp/Utils/CRC32C.cs
+++ b/src/TorchSharp/Utils/CRC32C.cs
@@ -23,19 +23,13 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-
 using System;
-using System.Runtime.InteropServices;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp.Utils
 {
     public static class CRC32C
     {
-        // uint32_t crc32c_append(uint32_t crc, buffer input, size_t length)
-
-        [DllImport("LibTorchSharp")]
-        extern static uint crc32c_append(uint crc, IntPtr value, ulong length);
-
         /// <summary>
         /// Compule the CRC32C value for a byte array.
         /// </summary>

--- a/src/TorchSharp/Utils/TensorAccessor.cs
+++ b/src/TorchSharp/Utils/TensorAccessor.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp.Utils
 {
@@ -28,7 +29,7 @@ namespace TorchSharp.Utils
             // Get the data from native code.
 
             unsafe {
-                var res = torch.Tensor.THSTensor_data(tensor.Handle);
+                var res = THSTensor_data(tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 // NOTE: there is no safety here.
                 _tensor_data_ptr = res;
@@ -165,7 +166,7 @@ namespace TorchSharp.Utils
             }
 
             unsafe {
-                var res = torch.Tensor.THSTensor_data(tensor.Handle);
+                var res = THSTensor_data(tensor.Handle);
                 if (res == IntPtr.Zero) { torch.CheckForErrors(); }
                 // NOTE: there is no safety here.
                 T* ptr = (T*)res;
@@ -174,7 +175,7 @@ namespace TorchSharp.Utils
         }
 
         /// <summary>
-        /// Compare two tensors element-wise. 
+        /// Compare two tensors element-wise.
         /// </summary>
         /// <param name="left">A tensor</param>
         /// <param name="right">Another tensor</param>
@@ -194,7 +195,7 @@ namespace TorchSharp.Utils
         }
 
         /// <summary>
-        /// Compare two tensors element-wise. 
+        /// Compare two tensors element-wise.
         /// </summary>
         /// <param name="left">A tensor</param>
         /// <param name="right">Another tensor</param>
@@ -280,7 +281,7 @@ namespace TorchSharp.Utils
         {
             // If there was an overload for Enumerable.Range that
             // produced long integers, we wouldn't need this implementation.
-            
+
             long index = startingIndex;
             while (index < Count) {
                 yield return index;
@@ -290,7 +291,7 @@ namespace TorchSharp.Utils
 
 
         /// <summary>
-        /// Compare two tensors element-wise. 
+        /// Compare two tensors element-wise.
         /// </summary>
         /// <param name="obj">Another tensor</param>
         /// <returns></returns>

--- a/src/TorchSharp/Utils/tensorboard/SummaryWriter.cs
+++ b/src/TorchSharp/Utils/tensorboard/SummaryWriter.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Collections.Generic;
 using System.Threading;
 using Google.Protobuf;
@@ -33,7 +32,7 @@ namespace TorchSharp
                 /// <param name="createRunName">Create a time-based run name, even if log_dir is specified.</param>
                 public static Modules.SummaryWriter SummaryWriter(string log_dir = null, string filename_suffix = null, bool createRunName = false)
                 {
-                    if (createRunName && !String.IsNullOrEmpty(log_dir)) {
+                    if (createRunName && !string.IsNullOrEmpty(log_dir)) {
                         log_dir = CreateRunName(log_dir);
                     }
 
@@ -67,7 +66,7 @@ namespace TorchSharp
             {
                 _suffix = filename_suffix;
 
-                if (String.IsNullOrEmpty(log_dir)) {
+                if (string.IsNullOrEmpty(log_dir)) {
                     _log_dir = torch.utils.tensorboard.CreateRunName("runs");
                 } else {
                     _log_dir = log_dir;
@@ -78,7 +77,7 @@ namespace TorchSharp
                 }
 
                 var fileName = Path.Combine(_log_dir, $"events.out.tfevents.{DateTime.Now.Ticks}.{System.Net.Dns.GetHostName()}.{Process.GetCurrentProcess().Id}.{Interlocked.Increment(ref _global_uid)}");
-                if (!String.IsNullOrEmpty(_suffix)) {
+                if (!string.IsNullOrEmpty(_suffix)) {
                     fileName = fileName + "." + _suffix;
                 }
 

--- a/src/TorchSharp/netstandard.cs
+++ b/src/TorchSharp/netstandard.cs
@@ -152,7 +152,7 @@ namespace System
         }
 
         internal const float NegativeZero = (float)-0.0;
-        internal static bool IsNegative(float x) => (((UInt64)BitConverter.DoubleToInt64Bits(x)) & 0x8000000000000000) == 0x8000000000000000;
+        internal static bool IsNegative(float x) => (((ulong)BitConverter.DoubleToInt64Bits(x)) & 0x8000000000000000) == 0x8000000000000000;
 
         private const string CrtLibrary = "ucrtbase.dll";
         [DllImport(CrtLibrary)] private static extern float asinhf(float x);
@@ -180,7 +180,7 @@ namespace System
     internal static partial class NativeLibrary
     {
         [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError = true)]
-        private static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, int dwFlags);
+        internal static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, int dwFlags);
 
         public static bool TryLoad(string libraryPath, out IntPtr handle)
         {

--- a/src/TorchVision/Functional.cs
+++ b/src/TorchVision/Functional.cs
@@ -2,9 +2,8 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 using static TorchSharp.torch;
+using static TorchSharp.LibTorchSharp;
 
 // A number of implementation details in this file have been translated from the Python version of torchvision,
 // largely located in the files found in this folder:
@@ -132,11 +131,6 @@ namespace TorchSharp
                     if (res == IntPtr.Zero) { CheckForErrors(); }
                     return Tensor.UnsafeCreateTensor(res);
                 }
-
-                /* Tensor THSVision_AdjustHue(const Tensor i, const double hue_factor) */
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSVision_AdjustHue(IntPtr img, double hue_factor);
-
 
                 /// <summary>
                 /// Adjust the color saturation of an image.
@@ -704,10 +698,6 @@ namespace TorchSharp
                         }
                     }
 
-                    if (interpolation != InterpolationMode.Nearest) {
-                        throw new NotImplementedException("Interpolation mode != 'Nearest'");
-                    }
-
                     using var img0 = SqueezeIn(input, new ScalarType[] { ScalarType.Float32, ScalarType.Float64 }, out var needCast, out var needSqueeze, out var dtype);
 
                     using var img1 = torch.nn.functional.interpolate(img0, new long[] { h, w }, mode: interpolation, align_corners: null);
@@ -867,10 +857,6 @@ namespace TorchSharp
                     return kernel_Y.mm(kernel_X);
                 }
 
-                // EXPORT_API(Tensor) THSVision_ApplyGridTransform(Tensor img, Tensor grid, const int8_t m, const float* fill, const int64_t fill_length);
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSVision_ApplyGridTransform(IntPtr img, IntPtr grid, sbyte mode, IntPtr fill, long fill_length);
-
                 private static Tensor ApplyGridTransform(Tensor img, Tensor grid, InterpolationMode mode, IList<float> fill = null)
                 {
                     img = SqueezeIn(img, new ScalarType[] { grid.dtype }, out var needCast, out var needSqueeze, out var out_dtype);
@@ -890,21 +876,12 @@ namespace TorchSharp
                     return img;
                 }
 
-                /* Tensor THSVision_GenerateAffineGrid(Tensor theta, const int64_t w, const int64_t h, const int64_t ow, const int64_t oh); */
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSVision_GenerateAffineGrid(IntPtr theta, long w, long h, long ow, long oh);
-
-
                 private static Tensor GenerateAffineGrid(Tensor theta, long w, long h, long ow, long oh)
                 {
                     var img = THSVision_GenerateAffineGrid(theta.Handle, w, h, ow, oh);
                     if (img == IntPtr.Zero) { torch.CheckForErrors(); }
                     return Tensor.UnsafeCreateTensor(img);
                 }
-
-                /* Tensor THSVision_ComputeOutputSize(const float* matrix, const int64_t matrix_length, const int64_t w, const int64_t h); */
-                [DllImport("LibTorchSharp")]
-                extern static void THSVision_ComputeOutputSize(IntPtr matrix, long matrix_length, long w, long h, out int first, out int second);
 
                 private static (int, int) ComputeOutputSize(IList<float> matrix, long w, long h)
                 {
@@ -955,10 +932,6 @@ namespace TorchSharp
                     var hOffset = img.shape.Length - 2;
                     return (img.shape[hOffset + 1], img.shape[hOffset]);
                 }
-
-                /* Tensor THSVision_PerspectiveGrid(const float* coeffs, const int64_t coeffs_length, const int64_t ow, const int64_t oh, const int8_t scalar_type, const int device_type, const int device_index); */
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSVision_PerspectiveGrid(IntPtr coeffs, long coeffs_length, long ow, long oh, sbyte dtype, int device_type, int device_index);
 
                 private static Tensor PerspectiveGrid(IList<float> coeffs, long ow, long oh, ScalarType dtype, Device device)
                 {
@@ -1014,11 +987,6 @@ namespace TorchSharp
                     foreach (var c in t0) { c.Dispose(); }
                     return t1;
                 }
-
-                /* Tensor THSVision_ScaleChannel(Tensor ic); */
-                [DllImport("LibTorchSharp")]
-                extern static IntPtr THSVision_ScaleChannel(IntPtr img);
-
 
                 private static Tensor ScaleChannel(Tensor img_chan)
                 {

--- a/src/TorchVision/IO/SkiaSharpImager.cs
+++ b/src/TorchVision/IO/SkiaSharpImager.cs
@@ -2,12 +2,9 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
-
 using SkiaSharp;
 using static TorchSharp.torch;
-using static TorchSharp.TensorExtensionMethods;
+using static TorchSharp.LibTorchSharp;
 
 namespace TorchSharp
 {
@@ -23,7 +20,6 @@ namespace TorchSharp
                     this.quality = quality;
                 }
                 private int quality;
-
 
                 public override Tensor DecodeImage(byte[] bytes, ImageReadMode mode = ImageReadMode.UNCHANGED)
                 {
@@ -79,7 +75,6 @@ namespace TorchSharp
                     result.Encode(stream, skiaFormat, this.quality);
                     stream.Flush();
                 }
-
 
                 public override byte[] EncodeImage(Tensor image, ImageFormat format)
                 {
@@ -147,7 +142,6 @@ namespace TorchSharp
                     return result.MoveToOuterDisposeScope();
                 }
 
-
                 private SKEncodedImageFormat TranslateImageFormat(ImageFormat format)
                 {
                     switch (format) {
@@ -164,15 +158,6 @@ namespace TorchSharp
                     }
                     throw new NotSupportedException($"SkiaSharp does not support encoding images in the '{format}' format.");
                 }
-
-                [DllImport("LibTorchSharp")]
-                static extern void THSVision_BRGA_RGB(IntPtr inputBytes, IntPtr redBytes, IntPtr greenBytes, IntPtr blueBytes, long inputChannelCount, long imageSize);
-
-                [DllImport("LibTorchSharp")]
-                static extern void THSVision_BRGA_RGBA(IntPtr inputBytes, IntPtr redBytes, IntPtr greenBytes, IntPtr blueBytes, IntPtr alphaBytes, long inputChannelCount, long imageSize);
-
-                [DllImport("LibTorchSharp")]
-                static extern void THSVision_RGB_BRGA(IntPtr inputBytes, IntPtr outBytes, long inputChannelCount, long imageSize);
             }
         }
     }

--- a/src/TorchVision/LibTorchSharp.cs
+++ b/src/TorchVision/LibTorchSharp.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+using System;
+using System.Runtime.InteropServices;
+
+namespace TorchSharp
+{
+    internal static class LibTorchSharp
+    {
+        /* Tensor THSVision_AdjustHue(const Tensor i, const double hue_factor) */
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSVision_AdjustHue(IntPtr img, double hue_factor);
+
+        // EXPORT_API(Tensor) THSVision_ApplyGridTransform(Tensor img, Tensor grid, const int8_t m, const float* fill, const int64_t fill_length);
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSVision_ApplyGridTransform(IntPtr img, IntPtr grid, sbyte mode, IntPtr fill,
+            long fill_length);
+
+        /* Tensor THSVision_GenerateAffineGrid(Tensor theta, const int64_t w, const int64_t h, const int64_t ow, const int64_t oh); */
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSVision_GenerateAffineGrid(IntPtr theta, long w, long h, long ow, long oh);
+
+        /* Tensor THSVision_ComputeOutputSize(const float* matrix, const int64_t matrix_length, const int64_t w, const int64_t h); */
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSVision_ComputeOutputSize(IntPtr matrix, long matrix_length, long w, long h,
+            out int first, out int second);
+
+        /* Tensor THSVision_PerspectiveGrid(const float* coeffs, const int64_t coeffs_length, const int64_t ow, const int64_t oh, const int8_t scalar_type, const int device_type, const int device_index); */
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSVision_PerspectiveGrid(IntPtr coeffs, long coeffs_length, long ow, long oh,
+            sbyte dtype, int device_type, int device_index);
+
+        /* Tensor THSVision_ScaleChannel(Tensor ic); */
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSVision_ScaleChannel(IntPtr img);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSVision_BRGA_RGB(IntPtr inputBytes, IntPtr redBytes, IntPtr greenBytes, IntPtr blueBytes, long inputChannelCount, long imageSize);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSVision_BRGA_RGBA(IntPtr inputBytes, IntPtr redBytes, IntPtr greenBytes, IntPtr blueBytes, IntPtr alphaBytes, long inputChannelCount, long imageSize);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSVision_RGB_BRGA(IntPtr inputBytes, IntPtr outBytes, long inputChannelCount, long imageSize);
+    }
+}

--- a/src/TorchVision/Ops.cs
+++ b/src/TorchVision/Ops.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 
 using static TorchSharp.torch;
-using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 #nullable enable
 namespace TorchSharp

--- a/src/TorchVision/models/AlexNet.cs
+++ b/src/TorchVision/models/AlexNet.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using TorchSharp.Modules;
+
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.utils.data;
 
 namespace TorchSharp
 {

--- a/src/TorchVision/models/GoogleNet.cs
+++ b/src/TorchVision/models/GoogleNet.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using TorchSharp.Modules;
+
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.utils.data;
 
 namespace TorchSharp
 {

--- a/src/TorchVision/models/InceptionV3.cs
+++ b/src/TorchVision/models/InceptionV3.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using TorchSharp.Modules;
+
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.utils.data;
 
 namespace TorchSharp
 {

--- a/src/TorchVision/models/MobileNetV3.cs
+++ b/src/TorchVision/models/MobileNetV3.cs
@@ -12,10 +12,7 @@
 
 using System.Collections.Generic;
 using System;
-using System.Collections;
-using System.Linq;
 using static TorchSharp.torch;
-using static TorchSharp.torchvision;
 using static TorchSharp.torchvision.models._utils;
 using static TorchSharp.torchvision.ops;
 using TorchSharp.Modules;

--- a/src/TorchVision/models/ResNet.cs
+++ b/src/TorchVision/models/ResNet.cs
@@ -1,12 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using TorchSharp.Modules;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.utils.data;
 
 namespace TorchSharp
 {

--- a/src/TorchVision/models/Utils.cs
+++ b/src/TorchVision/models/Utils.cs
@@ -27,8 +27,6 @@
 
 using System;
 
-using static TorchSharp.torch;
-
 namespace TorchSharp
 {
     public static partial class torchvision

--- a/src/TorchVision/models/VGG.cs
+++ b/src/TorchVision/models/VGG.cs
@@ -1,12 +1,8 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
+
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Net;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.utils.data;
 
 namespace TorchSharp
 {

--- a/test/TorchSharpTest/TestJIT.cs
+++ b/test/TorchSharpTest/TestJIT.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using Xunit;
-using System.Security.Cryptography;
 
 #nullable enable
 

--- a/test/TorchSharpTest/TestLoadSave.cs
+++ b/test/TorchSharpTest/TestLoadSave.cs
@@ -5,13 +5,7 @@ using System.Linq;
 using TorchSharp.Modules;
 using static TorchSharp.torch.nn;
 using Xunit;
-using Google.Protobuf;
-using Tensorboard;
-using static TorchSharp.torch.utils.tensorboard;
-using ICSharpCode.SharpZipLib;
 using System.Collections.Generic;
-using Google.Protobuf.WellKnownTypes;
-using static Google.Protobuf.Reflection.SourceCodeInfo.Types;
 
 #nullable enable
 

--- a/test/TorchSharpTest/TestNNUtils.cs
+++ b/test/TorchSharpTest/TestNNUtils.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
-using System;
+
 using System.Linq;
 using Xunit;
-
-using TorchSharp;
-using System.Drawing;
 
 namespace TorchSharp
 {

--- a/test/TorchSharpTest/TestTorchAudio.cs
+++ b/test/TorchSharpTest/TestTorchAudio.cs
@@ -1,8 +1,6 @@
 using System;
 using Xunit;
 
-using TorchSharp;
-
 namespace TorchSharp
 {
     public class TestTorchAudio

--- a/test/TorchSharpTest/TestTorchAudioLoadSave.cs
+++ b/test/TorchSharpTest/TestTorchAudioLoadSave.cs
@@ -1,8 +1,6 @@
 using System;
 using Xunit;
 
-using TorchSharp;
-
 namespace TorchSharp
 {
     public class TestTorchAudioLoadSave

--- a/test/TorchSharpTest/TestTorchAudioModels.cs
+++ b/test/TorchSharpTest/TestTorchAudioModels.cs
@@ -1,7 +1,4 @@
-using System;
 using Xunit;
-
-using TorchSharp;
 
 namespace TorchSharp
 {

--- a/test/TorchSharpTest/TestTorchHub.cs
+++ b/test/TorchSharpTest/TestTorchHub.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
 using System.Reflection;
 using Xunit;
-
-using static TorchSharp.torch;
 
 #nullable enable
 namespace TorchSharp

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -8,8 +8,6 @@ using System.Globalization;
 using Xunit;
 using Xunit.Sdk;
 using static TorchSharp.torch;
-using ICSharpCode.SharpZipLib;
-using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 

--- a/test/TorchSharpTest/TestTorchVision.cs
+++ b/test/TorchSharpTest/TestTorchVision.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using TorchSharp.Modules;
 using static TorchSharp.torchvision.models;
 using Xunit;
 

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using static TorchSharp.torch.nn;
-using static TorchSharp.torch.nn.functional;
 using Xunit;
 
 using static TorchSharp.torch;


### PR DESCRIPTION
In order to follow [Native interoperability best practices](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices), I've moved *P/Invoke declarations into in a class with the same name as the native library*.