### PR TITLE
Adding 1-d array overloads for 'as_tensor()'

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -13,6 +13,9 @@ Requirements:
 - git
 - cmake (tested with 3.18)
 
+__NOTE:__ At this moment, VS versions 17.4.X will not build the native code library. Use 17.3.X until further notice. See: https://github.com/dotnet/TorchSharp/issues/858 for more information.
+
+
 ## Linux
 
 Requirements:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Please check the [Release Notes](RELEASENOTES.md) file for news on what's been u
 
 __TorchSharp is now in the .NET Foundation!__
 
-If you are using TorchSharp from NuGet, you should be using a version >= 0.95.1 of TorchSharp, and >= 1.10.0.1 of the libtorch-xxx redistributable packages. We recommend using one of the 'bundled' packages: TorchSharp-cpu, TorchSharp-cuda-windows, or TorchSharp-cuda-linux. They will pull in the right libtorch backends.
+If you are using TorchSharp from NuGet, you should be using a version >= 0.98.3 of TorchSharp, and >= 1.12.0 of the libtorch-xxx redistributable packages. We recommend using one of the 'bundled' packages: TorchSharp-cpu, TorchSharp-cuda-windows, or TorchSharp-cuda-linux. They will pull in the right libtorch backends.
+
+__NOTE:__ At this moment, VS versions 17.4.X will not build the TorchSharp native code library. Use 17.3.X until further notice. See: https://github.com/dotnet/TorchSharp/issues/858 for more information and workarounds.
 
 __NOTE:__ Please do __not__ use 0.95.0 -- the package was released to NuGet in error, and without its many dependencies.
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -14,6 +14,7 @@ __API Changes__:
 
 Added a number of 1.13 APIs under `torch.special`<br/>
 Added a `maximize` flag to the ASGD, Rprop and RMSprop optimizers.<br/>
+Added PolynomialLR scheduler<br/>
 The return type of Sequential.append() has changed from 'void' to 'Sequential.'<br/>
 
 __Fixed Bugs__:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -16,6 +16,7 @@ Added a number of 1.13 APIs under `torch.special`<br/>
 Added a `maximize` flag to the ASGD, Rprop and RMSprop optimizers.<br/>
 Added PolynomialLR scheduler<br/>
 The return type of Sequential.append() has changed from 'void' to 'Sequential.'<br/>
+Added 1-dimensional array overloads for `torch.as_tensor()`<br/>
 
 __Fixed Bugs__:
 
@@ -23,7 +24,7 @@ __Fixed Bugs__:
 #838 New Bernoulli get "Object reference not set to an instance of an object."<br/>
 #845 registered buffers are being ignored in move model to device<br/>
 #851 tensor.ToString(TorchSharp.TensorStringStyle.Numpy)<br/>
-#852 The content returned by torch.nn.Sequential.append is inconsistent with the official<br/>
+#852 The content returned by torch.nn.Sequential.append() is inconsistent with the official<br/>
 
 ## NuGet Version 0.99.0
 

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>99</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/TorchSharp/Tensor/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Tensor.Factories.cs
@@ -107,9 +107,19 @@ namespace TorchSharp
             return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
+        public static Tensor as_tensor(bool[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
+        }
+
         public static Tensor as_tensor(IList<byte> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
             return torch.from_array(rawArray.ToArray(), dtype, device);
+        }
+
+        public static Tensor as_tensor(byte[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
         }
 
         public static Tensor as_tensor(IList<sbyte> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
@@ -117,9 +127,19 @@ namespace TorchSharp
             return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
+        public static Tensor as_tensor(sbyte[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
+        }
+
         public static Tensor as_tensor(IList<short> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
             return torch.from_array(rawArray.ToArray(), dtype, device);
+        }
+
+        public static Tensor as_tensor(short[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
         }
 
         public static Tensor as_tensor(IList<int> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
@@ -127,9 +147,19 @@ namespace TorchSharp
             return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
+        public static Tensor as_tensor(int[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
+        }
+
         public static Tensor as_tensor(IList<long> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
             return torch.from_array(rawArray.ToArray(), dtype, device);
+        }
+
+        public static Tensor as_tensor(long[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
         }
 
         public static Tensor as_tensor(IList<float> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
@@ -137,9 +167,19 @@ namespace TorchSharp
             return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
+        public static Tensor as_tensor(float[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
+        }
+
         public static Tensor as_tensor(IList<double> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
             return torch.from_array(rawArray.ToArray(), dtype, device);
+        }
+
+        public static Tensor as_tensor(double[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
         }
 
         public static Tensor as_tensor(IList<(float, float)> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
@@ -147,9 +187,19 @@ namespace TorchSharp
             return torch.from_array(rawArray.ToArray(), dtype, device);
         }
 
+        public static Tensor as_tensor((float, float)[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
+        }
+
         public static Tensor as_tensor(IList<System.Numerics.Complex> rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
         {
             return torch.from_array(rawArray.ToArray(), dtype, device);
+        }
+
+        public static Tensor as_tensor(System.Numerics.Complex[] rawArray, torch.ScalarType? dtype = null, torch.Device? device = null)
+        {
+            return torch.from_array(rawArray, dtype, device);
         }
 
 

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -986,5 +986,12 @@ namespace TorchSharp
             var str = a.ToString(TorchSharp.TensorStringStyle.Numpy);
             Assert.Equal("[[100 200 300 400]]", str);
         }
+
+        [Fact]
+        public void Validate852()
+        {
+            float[] a = new float[12];
+            var x = torch.as_tensor(a);
+        }
     }
 }


### PR DESCRIPTION
The unit test is only meant not to verify that there is no compile-time error.