### PR TITLE
Fixed a couple of bugs.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -9,7 +9,13 @@ __API Changes__:
 Fixing misspelling of 'DetachFromDisposeScope,' deprecating the old spelling.<br/>
 Adding allow_tf32<br/>
 Adding overloads of Module.save() and Module.load() taking a 'Stream' argument.<br/>
-Adding torch.softmax() as an alias for torch.special.softmax()<br/>
+Adding torch.softmax() and Tensor.softmax() as aliases for torch.special.softmax()<br/>
+
+__Fixed Bugs__:
+
+#913 conv = nn.Conv2d(c1, 1, 1, bias=False).requires_grad_(False)<br/>
+#910 nn.Module.modules is missing<br/>
+#912 nn.Module save and state_ dict method error<br/>
 
 ## NuGet Version 0.99.2
 

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -475,6 +475,11 @@ namespace TorchSharp
                 }
 
                 /// <summary>
+                /// Returns an enumerable of buffers.
+                /// </summary>
+                public virtual IEnumerable<Tensor> buffers(bool recurse = true) => named_buffers(recurse).Select(np => np.buffer);
+
+                /// <summary>
                 /// Returns an enumerable of immediate children modules, yielding both the name of the module as well as the module itself.
                 /// </summary>
                 /// <returns>(string, Module) – Tuple containing a name and child module</returns>
@@ -496,6 +501,16 @@ namespace TorchSharp
                         }
                     }
                 }
+
+                /// <summary>
+                /// Returns an enumerable of modules.
+                /// </summary>
+                public virtual IEnumerable<Module> modules() => named_modules().Select(np => np.module);
+
+                /// <summary>
+                /// Returns an enumerable of immediate modules.
+                /// </summary>
+                public virtual IEnumerable<Module> children() => named_children().Select(np => np.module);
 
                 /// <summary>
                 /// Returns a dictionary containing a whole state of the module.

--- a/src/TorchSharp/NN/ModuleList.cs
+++ b/src/TorchSharp/NN/ModuleList.cs
@@ -136,7 +136,7 @@ namespace TorchSharp
             /// <remarks>
             /// ModuleList can be indexed like a regular list, but modules it contains are properly registered, and will be visible by all Module methods.
             /// </remarks>
-            public static ModuleList<T> ModuleList<T>(params T[] modules) where T : Module => new ModuleList<T>();
+            public static ModuleList<T> ModuleList<T>(params T[] modules) where T : Module => new ModuleList<T>(modules);
         }
     }
 }

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -616,7 +616,7 @@ namespace TorchSharp
 
             public Tensor requires_grad_(bool requires_grad = true)
             {
-                this.requires_grad = true;
+                this.requires_grad = requires_grad;
                 return this;
             }
 
@@ -2467,6 +2467,14 @@ namespace TorchSharp
                     CheckForErrors();
                 return new Tensor(res);
             }
+
+            /// <summary>
+            /// Computes the softmax function for the input tensor.
+            /// </summary>
+            /// <param name="dim">A dimension along which softmax will be computed.</param>
+            /// <param name="dtype">The desired data type of returned tensor.</param>
+            public Tensor softmax(long dim, ScalarType? dtype = null) =>
+                torch.special.softmax(this, dim, dtype);
 
             public Tensor softplus()
             {

--- a/src/TorchSharp/Tensor/torch.OtherOperations.cs
+++ b/src/TorchSharp/Tensor/torch.OtherOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 #nullable enable
 using System;
 using System.Collections.Generic;

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -1087,5 +1087,52 @@ namespace TorchSharp
                 return t0;
             }
         }
+
+
+        [Fact]
+        public void Validate912()
+        {
+            var test = new Test_912(2);
+            Dictionary<string, Tensor> sd = test.state_dict(); // No layer2.modules keyword
+            Assert.Contains(sd.Keys, k => k.StartsWith("layer2.modules"));
+        }
+
+        public class Test_912 : nn.Module
+        {
+            public nn.Module layer;
+            public nn.Module layer2;
+
+            public Test_912(int layernum) : base("Test_912")
+            {
+                layer = nn.Linear(16, 2);
+                layer2 = new Test2_912((from l in Enumerable.Range(0, layernum)
+                                    select new Test3_912()).ToArray(),
+                                    (from l in Enumerable.Range(0, layernum)
+                                     select new Test3_912()).ToArray());
+                this.RegisterComponents();
+            }
+        }
+        public class Test2_912 : nn.Module
+        {
+            public new Modules.ModuleList<Test3_912> modules;
+            public Modules.ModuleList<nn.Module> modules2;
+            public nn.Module layer;
+            public Test2_912(Test3_912[] ms, nn.Module[] ms2) : base("Test2_912")
+            {
+                layer = nn.Linear(16, 2);
+                modules = nn.ModuleList(ms);
+                modules2 = nn.ModuleList(ms2);
+                this.RegisterComponents();
+            }
+        }
+        public class Test3_912 : nn.Module
+        {
+            public nn.Module layer;
+            public Test3_912() : base("Test3_912")
+            {
+                layer = nn.Linear(16, 2);
+                this.RegisterComponents();
+            }
+        }
     }
 }


### PR DESCRIPTION
Tensor.requires_grad_ ignored the argument passed.
Tensor.softmax (not documented in PyTorch docs) added.
Adding Module.modules() and Module.buffers()
Fixed ModuleList<T> factory method, which ignored all the input modules.