### PR TITLE
implementing torch.tensordot and some code cleanup

### DIFF
--- a/src/Native/LibTorchSharp/THSLinearAlgebra.cpp
+++ b/src/Native/LibTorchSharp/THSLinearAlgebra.cpp
@@ -6,56 +6,56 @@
 
 Tensor THSLinalg_cholesky(const Tensor tensor)
 {
-    CATCH_TENSOR(torch::linalg::cholesky(*tensor));
+    CATCH_TENSOR(torch::linalg::cholesky(*tensor))
 }
 
 Tensor THSLinalg_cholesky_ex(const Tensor tensor, bool check_errors, Tensor* info)
 {
     std::tuple<at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg_cholesky_ex(*tensor, check_errors););
+    CATCH(res = torch::linalg_cholesky_ex(*tensor, check_errors);)
     *info = ResultTensor(std::get<1>(res));
     return ResultTensor(std::get<0>(res));
 }
 
 Tensor THSLinalg_cond_int(const Tensor tensor, const int p)
 {
-    CATCH_TENSOR(torch::linalg_cond(*tensor, p));
+    CATCH_TENSOR(torch::linalg_cond(*tensor, p))
 }
 
 Tensor THSLinalg_cond_float(const Tensor tensor, const double p)
 {
-    CATCH_TENSOR(torch::linalg_cond(*tensor, p));
+    CATCH_TENSOR(torch::linalg_cond(*tensor, p))
 }
 
 Tensor THSLinalg_cond_str(const Tensor tensor, const char* p)
 {
-    CATCH_TENSOR(p != nullptr ? torch::linalg_cond(*tensor, p) : torch::linalg_cond(*tensor));
+    CATCH_TENSOR(p != nullptr ? torch::linalg_cond(*tensor, p) : torch::linalg_cond(*tensor))
 }
 
 Tensor THSLinalg_cond_none(const Tensor tensor)
 {
-    CATCH_TENSOR(torch::linalg_cond(*tensor));
+    CATCH_TENSOR(torch::linalg_cond(*tensor))
 }
 
 Tensor THSLinalg_cross(const Tensor input, const Tensor other, const int64_t dim)
 {
-    CATCH_TENSOR(torch::linalg_cross(*input, *other, dim));
+    CATCH_TENSOR(torch::linalg_cross(*input, *other, dim))
 }
 
 Tensor THSLinalg_det(const Tensor tensor)
 {
-    CATCH_TENSOR(torch::linalg::det(*tensor));
+    CATCH_TENSOR(torch::linalg::det(*tensor))
 }
 
 Tensor THSTensor_logdet(const Tensor tensor)
 {
-    CATCH_TENSOR(torch::logdet(*tensor));
+    CATCH_TENSOR(torch::logdet(*tensor))
 }
 
 Tensor THSLinalg_slogdet(const Tensor tensor, Tensor* logabsdet)
 {
     std::tuple<at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg::slogdet(*tensor););
+    CATCH(res = torch::linalg::slogdet(*tensor);)
     *logabsdet = ResultTensor(std::get<1>(res));
     return ResultTensor(std::get<0>(res));
 }
@@ -100,30 +100,30 @@ Tensor THSLinalg_eigh(const Tensor tensor, const char UPLO, Tensor* eigenvectors
 
 Tensor THSLinalg_eigvals(const Tensor tensor)
 {
-    CATCH_TENSOR(torch::linalg::eigvals(*tensor));
+    CATCH_TENSOR(torch::linalg::eigvals(*tensor))
 }
 
 Tensor THSLinalg_eigvalsh(const Tensor tensor, const char UPLO)
 {
     std::string _uplo;
     _uplo.push_back(UPLO);
-    CATCH_TENSOR(torch::linalg::eigvalsh(*tensor, _uplo));
+    CATCH_TENSOR(torch::linalg::eigvalsh(*tensor, _uplo))
 }
 
 Tensor THSLinalg_householder_product(const Tensor tensor, const Tensor tau)
 {
-    CATCH_TENSOR(torch::linalg::householder_product(*tensor, *tau));
+    CATCH_TENSOR(torch::linalg::householder_product(*tensor, *tau))
 }
 
 Tensor THSLinalg_inv(const Tensor tensor)
 {
-    CATCH_TENSOR(torch::linalg::inv(*tensor));
+    CATCH_TENSOR(torch::linalg::inv(*tensor))
 }
 
 Tensor THSLinalg_inv_ex(const Tensor tensor, bool check_errors, Tensor* info)
 {
     std::tuple<at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg_inv_ex(*tensor, check_errors););
+    CATCH(res = torch::linalg_inv_ex(*tensor, check_errors);)
     *info = ResultTensor(std::get<1>(res));
     return ResultTensor(std::get<0>(res));
 }
@@ -131,7 +131,7 @@ Tensor THSLinalg_inv_ex(const Tensor tensor, bool check_errors, Tensor* info)
 Tensor THSLinalg_lstsq_none(const Tensor A, const Tensor B, Tensor* residuals, Tensor* rank, Tensor* singular_values)
 {
     std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg::lstsq(*A, *B, c10::nullopt, c10::nullopt););
+    CATCH(res = torch::linalg::lstsq(*A, *B, c10::nullopt, c10::nullopt);)
     *residuals = ResultTensor(std::get<1>(res));
     *rank = ResultTensor(std::get<2>(res));
     *singular_values = ResultTensor(std::get<3>(res));
@@ -141,7 +141,7 @@ Tensor THSLinalg_lstsq_none(const Tensor A, const Tensor B, Tensor* residuals, T
 Tensor THSLinalg_lstsq_rcond(const Tensor A, const Tensor B, const double rcond, Tensor* residuals, Tensor* rank, Tensor* singular_values)
 {
     std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg::lstsq(*A, *B, rcond, c10::nullopt););
+    CATCH(res = torch::linalg::lstsq(*A, *B, rcond, c10::nullopt);)
     *residuals = ResultTensor(std::get<1>(res));
     *rank = ResultTensor(std::get<2>(res));
     *singular_values = ResultTensor(std::get<3>(res));
@@ -151,7 +151,7 @@ Tensor THSLinalg_lstsq_rcond(const Tensor A, const Tensor B, const double rcond,
 Tensor THSLinalg_lu(const Tensor A, const bool pivot, Tensor* L, Tensor* U)
 {
     std::tuple<at::Tensor, at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg::lu(*A, pivot););
+    CATCH(res = torch::linalg::lu(*A, pivot);)
     *L = ResultTensor(std::get<1>(res));
     *U = ResultTensor(std::get<2>(res));
     return ResultTensor(std::get<0>(res));
@@ -160,7 +160,7 @@ Tensor THSLinalg_lu(const Tensor A, const bool pivot, Tensor* L, Tensor* U)
 Tensor THSLinalg_lu_factor(const Tensor A, const bool pivot, Tensor* pivots)
 {
     std::tuple<at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg::lu_factor(*A, pivot););
+    CATCH(res = torch::linalg::lu_factor(*A, pivot);)
     *pivots = ResultTensor(std::get<1>(res));
     return ResultTensor(std::get<0>(res));
 }
@@ -168,7 +168,7 @@ Tensor THSLinalg_lu_factor(const Tensor A, const bool pivot, Tensor* pivots)
 Tensor THSLinalg_ldl_factor(const Tensor A, const bool hermitian, Tensor* pivots)
 {
     std::tuple<at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg_ldl_factor(*A, hermitian););
+    CATCH(res = torch::linalg_ldl_factor(*A, hermitian);)
     *pivots = ResultTensor(std::get<1>(res));
     return ResultTensor(std::get<0>(res));
 }
@@ -176,7 +176,7 @@ Tensor THSLinalg_ldl_factor(const Tensor A, const bool hermitian, Tensor* pivots
 Tensor THSLinalg_ldl_factor_ex(const Tensor A, const bool hermitian, const bool check_errors, Tensor* pivots, Tensor* info)
 {
     std::tuple<at::Tensor, at::Tensor, at::Tensor> res;
-    CATCH(res = torch::linalg_ldl_factor_ex(*A, hermitian, check_errors););
+    CATCH(res = torch::linalg_ldl_factor_ex(*A, hermitian, check_errors);)
     *pivots = ResultTensor(std::get<1>(res));
     *info = ResultTensor(std::get<2>(res));
     return ResultTensor(std::get<0>(res));
@@ -184,25 +184,25 @@ Tensor THSLinalg_ldl_factor_ex(const Tensor A, const bool hermitian, const bool 
 
 Tensor THSLinalg_ldl_solve(const Tensor LD, const Tensor pivots, const Tensor B, const bool hermitian)
 {
-    CATCH_TENSOR(torch::linalg_ldl_solve(*LD, *pivots, *B, hermitian));
+    CATCH_TENSOR(torch::linalg_ldl_solve(*LD, *pivots, *B, hermitian))
 }
 
 Tensor THSLinalg_matrix_norm(const Tensor tensor, const Scalar ord, const int64_t* dim, const int dim_length, const bool keepdim)
 {
     auto dims = c10::ArrayRef<int64_t>(dim, dim_length);
-    CATCH_TENSOR(torch::linalg::matrix_norm(*tensor, *ord, dims, keepdim, c10::nullopt));
+    CATCH_TENSOR(torch::linalg::matrix_norm(*tensor, *ord, dims, keepdim, c10::nullopt))
 }
 
 Tensor THSLinalg_matrix_norm_fronuc(const Tensor tensor, const int8_t fronuc, const int64_t* dim, const int dim_length, const bool keepdim)
 {
     auto dims = c10::ArrayRef<int64_t>(dim, dim_length);
-    CATCH_TENSOR(torch::linalg::matrix_norm(*tensor, (fronuc == 0) ? "fro" : "nuc", dims, keepdim, c10::nullopt));
+    CATCH_TENSOR(torch::linalg::matrix_norm(*tensor, (fronuc == 0) ? "fro" : "nuc", dims, keepdim, c10::nullopt))
 }
 
 Tensor THSLinalg_vector_norm(const Tensor tensor, const Scalar ord, const int64_t* dim, const int dim_length, const bool keepdim)
 {
     auto dims = c10::ArrayRef<int64_t>(dim, dim_length);
-    CATCH_TENSOR(torch::linalg::vector_norm(*tensor, *ord, dims, keepdim, c10::nullopt));
+    CATCH_TENSOR(torch::linalg::vector_norm(*tensor, *ord, dims, keepdim, c10::nullopt))
 }
 
 Tensor THSLinalg_matrix_rank(const Tensor tensor, const double atol, const bool has_atol, const double rtol, const bool has_rtol, const bool hermitian)
@@ -210,7 +210,7 @@ Tensor THSLinalg_matrix_rank(const Tensor tensor, const double atol, const bool 
     auto atol_ = has_atol ? atol : c10::optional<double>();
     auto rtol_ = has_rtol ? rtol : c10::optional<double>();
 
-    CATCH_TENSOR(torch::linalg::matrix_rank(*tensor, atol_, rtol_, hermitian));
+    CATCH_TENSOR(torch::linalg::matrix_rank(*tensor, atol_, rtol_, hermitian))
 }
 
 Tensor THSLinalg_matrix_rank_tensor(const Tensor tensor, const Tensor atol, const Tensor rtol, const bool hermitian)
@@ -218,41 +218,41 @@ Tensor THSLinalg_matrix_rank_tensor(const Tensor tensor, const Tensor atol, cons
     const c10::optional<at::Tensor> atol_ = atol != nullptr ? *atol : c10::optional<at::Tensor>();
     const c10::optional<at::Tensor> rtol_ = rtol != nullptr ? *rtol : c10::optional<at::Tensor>();
 
-    CATCH_TENSOR(torch::linalg::matrix_rank(*tensor, atol_, rtol_, hermitian));
+    CATCH_TENSOR(torch::linalg::matrix_rank(*tensor, atol_, rtol_, hermitian))
 }
 
 Tensor THSLinalg_matrix_power(const Tensor tensor, const int64_t n)
 {
-    CATCH_TENSOR(torch::linalg::matrix_power(*tensor, n));
+    CATCH_TENSOR(torch::linalg::matrix_power(*tensor, n))
 }
 
 Tensor THSLinalg_multi_dot(const Tensor* tensors, const int length)
 {
-    CATCH_TENSOR(torch::linalg::multi_dot(toTensors<at::Tensor>((torch::Tensor**)tensors, length)));
+    CATCH_TENSOR(torch::linalg::multi_dot(toTensors<at::Tensor>((torch::Tensor**)tensors, length)))
 }
 
 Tensor THSLinalg_norm_str(const Tensor tensor, const char* p, const int64_t* dim, const int dim_length, const bool keepdim)
 {
     c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
-    CATCH_TENSOR(torch::linalg::norm(*tensor, p, dims, keepdim, c10::nullopt));
+    CATCH_TENSOR(torch::linalg::norm(*tensor, p, dims, keepdim, c10::nullopt))
 }
 
 Tensor THSLinalg_norm_float(const Tensor tensor, const double p, const int64_t* dim, const int dim_length, const bool keepdim)
 {
     c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
-    CATCH_TENSOR(torch::linalg::norm(*tensor, p, dims, keepdim, c10::nullopt));
+    CATCH_TENSOR(torch::linalg::norm(*tensor, p, dims, keepdim, c10::nullopt))
 }
 
 Tensor THSLinalg_norm_int(const Tensor tensor, const int p, const int64_t* dim, const int dim_length, const bool keepdim)
 {
     c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
-    CATCH_TENSOR(torch::linalg::norm(*tensor, p, dims, keepdim, c10::nullopt));
+    CATCH_TENSOR(torch::linalg::norm(*tensor, p, dims, keepdim, c10::nullopt))
 }
 
 Tensor THSLinalg_norm_opt(const Tensor tensor, const int64_t* dim, const int dim_length, const bool keepdim)
 {
     c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
-    CATCH_TENSOR(torch::linalg::norm(*tensor, c10::nullopt, dims, keepdim, c10::nullopt));
+    CATCH_TENSOR(torch::linalg::norm(*tensor, c10::nullopt, dims, keepdim, c10::nullopt))
 }
 
 Tensor THSLinalg_pinv(const Tensor tensor, const double atol, const bool has_atol, const double rtol, const bool has_rtol, const bool hermitian)
@@ -260,7 +260,7 @@ Tensor THSLinalg_pinv(const Tensor tensor, const double atol, const bool has_ato
     auto atol_ = has_atol ? atol : c10::optional<double>();
     auto rtol_ = has_rtol ? rtol : c10::optional<double>();
 
-    CATCH_TENSOR(torch::linalg_pinv(*tensor, atol_, rtol_, hermitian));
+    CATCH_TENSOR(torch::linalg_pinv(*tensor, atol_, rtol_, hermitian))
 }
 
 Tensor THSLinalg_pinv_tensor(const Tensor tensor, const Tensor atol, const Tensor rtol, const bool hermitian)
@@ -268,25 +268,25 @@ Tensor THSLinalg_pinv_tensor(const Tensor tensor, const Tensor atol, const Tenso
     const c10::optional<at::Tensor> atol_ = atol != nullptr ? *atol : c10::optional<at::Tensor>();
     const c10::optional<at::Tensor> rtol_ = rtol != nullptr ? *rtol : c10::optional<at::Tensor>();
 
-    CATCH_TENSOR(torch::linalg_pinv(*tensor, atol_, rtol_, hermitian));
+    CATCH_TENSOR(torch::linalg_pinv(*tensor, atol_, rtol_, hermitian))
 }
 
 Tensor THSLinalg_pinverse(const Tensor tensor, const double rcond, const bool hermitian)
 {
-    CATCH_TENSOR(torch::linalg::pinv(*tensor, rcond, hermitian));
+    CATCH_TENSOR(torch::linalg::pinv(*tensor, rcond, hermitian))
 }
 
 Tensor THSLinalg_qr(const Tensor tensor, const char mode, Tensor* R)
 {
     std::tuple<at::Tensor, at::Tensor> res;
     if (mode == 0) {
-        CATCH(res = torch::linalg_qr(*tensor, "reduced"););
+        CATCH(res = torch::linalg_qr(*tensor, "reduced");)
     }
     else if (mode == 1) {
-        CATCH(res = torch::linalg_qr(*tensor, "complete"););
+        CATCH(res = torch::linalg_qr(*tensor, "complete");)
     }
     else {
-        CATCH(res = torch::linalg_qr(*tensor, "r"););
+        CATCH(res = torch::linalg_qr(*tensor, "r");)
     }
     *R = ResultTensor(std::get<1>(res));
     return ResultTensor(std::get<0>(res));
@@ -295,7 +295,7 @@ Tensor THSLinalg_qr(const Tensor tensor, const char mode, Tensor* R)
 
 Tensor THSLinalg_solve(const Tensor tensor, Tensor other, bool left)
 {
-    CATCH_TENSOR(torch::linalg::solve(*tensor, *other, left));
+    CATCH_TENSOR(torch::linalg::solve(*tensor, *other, left))
 }
 
 Tensor THSLinalg_solve_ex(const Tensor tensor, Tensor other, bool left, bool check_errors, Tensor* S)
@@ -317,79 +317,79 @@ Tensor THSLinalg_svd(const Tensor tensor, const bool full_matrices, Tensor* S, T
 
 Tensor THSLinalg_svdvals(const Tensor tensor)
 {
-    CATCH_TENSOR(res = torch::linalg::svdvals(*tensor, c10::nullopt));
+    CATCH_TENSOR(res = torch::linalg::svdvals(*tensor, c10::nullopt))
 }
 
 Tensor THSLinalg_tensorinv(const Tensor tensor, const int64_t ind)
 {
-    CATCH_TENSOR(torch::linalg::tensorinv(*tensor, ind));
+    CATCH_TENSOR(torch::linalg::tensorinv(*tensor, ind))
 }
 
 Tensor THSLinalg_tensorsolve(const Tensor tensor, Tensor other, const int64_t* dim, const int dim_length)
 {
     c10::optional<at::IntArrayRef> dims = (dim == nullptr) ? c10::nullopt : c10::optional<at::IntArrayRef>(at::ArrayRef<int64_t>(dim, dim_length));
-    CATCH_TENSOR(torch::linalg::tensorsolve(*tensor, *other, dims));
+    CATCH_TENSOR(torch::linalg::tensorsolve(*tensor, *other, dims))
 }
 
 Tensor THSLinalg_vander(const Tensor tensor, const int64_t N)
 {
-    CATCH_TENSOR(torch::linalg_vander(*tensor, N));
+    CATCH_TENSOR(torch::linalg_vander(*tensor, N))
 }
 
 Tensor THSLinalg_vecdot(const Tensor x, const Tensor y, const int64_t dim, Tensor out)
 {
-    CATCH_TENSOR(out == nullptr ? torch::linalg_vecdot(* x, *y, dim) : torch::linalg_vecdot_out(*out, *x, *y, dim));
+    CATCH_TENSOR(out == nullptr ? torch::linalg_vecdot(* x, *y, dim) : torch::linalg_vecdot_out(*out, *x, *y, dim))
 }
 
 Tensor THSTensor_lu_solve(const Tensor B, const Tensor LU, const Tensor pivots, bool left, bool adjoint, Tensor out)
 {
-    CATCH_TENSOR(out == nullptr ? torch::linalg_lu_solve(*LU, *pivots, *B, left, adjoint) : torch::linalg_lu_solve_out(*out, *LU, *pivots, *B, left, adjoint));
+    CATCH_TENSOR(out == nullptr ? torch::linalg_lu_solve(*LU, *pivots, *B, left, adjoint) : torch::linalg_lu_solve_out(*out, *LU, *pivots, *B, left, adjoint))
 }
 
 Tensor THSTensor_cholesky(const Tensor tensor, const bool upper)
 {
-    CATCH_TENSOR(tensor->cholesky(upper));
+    CATCH_TENSOR(tensor->cholesky(upper))
 }
 
 Tensor THSTensor_cholesky_inverse(const Tensor tensor, const bool upper)
 {
-    CATCH_TENSOR(tensor->cholesky_inverse(upper));
+    CATCH_TENSOR(tensor->cholesky_inverse(upper))
 }
 
 Tensor THSTensor_cholesky_solve(const Tensor tensor, const Tensor tensor2, const bool upper)
 {
-    CATCH_TENSOR(tensor->cholesky_solve(*tensor2, upper));
+    CATCH_TENSOR(tensor->cholesky_solve(*tensor2, upper))
 }
 
 Tensor THSTensor_diag(const Tensor tensor, const int64_t diagonal)
 {
-    CATCH_TENSOR(tensor->diag(diagonal));
+    CATCH_TENSOR(tensor->diag(diagonal))
 }
 
 Tensor THSTensor_trace(const Tensor tensor)
 {
-    CATCH_TENSOR(tensor->trace());
+    CATCH_TENSOR(tensor->trace())
 }
 
 Tensor THSTensor_diagflat(const Tensor tensor, const int64_t offset)
 {
-    CATCH_TENSOR(tensor->diagflat(offset));
+    CATCH_TENSOR(tensor->diagflat(offset))
 }
 
 Tensor THSTensor_diagonal(const Tensor tensor, const int64_t offset, const int64_t dim1, const int64_t dim2)
 {
-    CATCH_TENSOR(tensor->diagonal(offset, dim1, dim2));
+    CATCH_TENSOR(tensor->diagonal(offset, dim1, dim2))
 }
 
 Tensor THSTensor_kron(const Tensor left, const Tensor right)
 {
-    CATCH_TENSOR(left->kron(*right));
+    CATCH_TENSOR(left->kron(*right))
 }
 
 Tensor THSTensor_kthvalue(const Tensor input, int64_t k, int64_t dim, bool keepdim, Tensor* out)
 {
     std::tuple<at::Tensor, at::Tensor> res;
-    CATCH(res = input->kthvalue(k, dim, keepdim););
+    CATCH(res = input->kthvalue(k, dim, keepdim);)
     *out = ResultTensor(std::get<1>(res));
     return ResultTensor(std::get<0>(res));
 
@@ -397,22 +397,22 @@ Tensor THSTensor_kthvalue(const Tensor input, int64_t k, int64_t dim, bool keepd
 
 Tensor THSTensor_lcm(const Tensor tensor, const Tensor other)
 {
-    CATCH_TENSOR(tensor->lcm(*other));
+    CATCH_TENSOR(tensor->lcm(*other))
 }
 
 Tensor THSTensor_lcm_(const Tensor tensor, const Tensor other)
 {
-    CATCH_TENSOR(tensor->lcm_(*other));
+    CATCH_TENSOR(tensor->lcm_(*other))
 }
 
 Tensor THSTensor_lgamma(const Tensor tensor)
 {
-    CATCH_TENSOR(tensor->lgamma());
+    CATCH_TENSOR(tensor->lgamma())
 }
 
 Tensor THSTensor_norm(const Tensor tensor, float p)
 {
-    CATCH_TENSOR(tensor->norm(p));
+    CATCH_TENSOR(tensor->norm(p))
 }
 
 Tensor THSTensor_lu(const Tensor tensor, bool pivot, bool get_infos, Tensor* infos, Tensor* pivots)
@@ -426,13 +426,13 @@ Tensor THSTensor_lu(const Tensor tensor, bool pivot, bool get_infos, Tensor* inf
 
 Tensor THSTensor_lu_solve(const Tensor tensor, const Tensor LU_data, const Tensor LU_pivots)
 {
-    CATCH_TENSOR(tensor->lu_solve(*LU_data, *LU_pivots));
+    CATCH_TENSOR(tensor->lu_solve(*LU_data, *LU_pivots))
 }
 
 Tensor THSTensor_lu_unpack(const Tensor LU_data, const Tensor LU_pivots, bool unpack_data, bool unpack_pivots, Tensor* L, Tensor* U)
 {
     std::tuple<at::Tensor, at::Tensor, at::Tensor> res;
-    CATCH(res = torch::lu_unpack(*LU_data, *LU_pivots, unpack_data, unpack_pivots););
+    CATCH(res = torch::lu_unpack(*LU_data, *LU_pivots, unpack_data, unpack_pivots);)
     *U = ResultTensor(std::get<2>(res));
     *L = ResultTensor(std::get<1>(res));
     return ResultTensor(std::get<0>(res));
@@ -440,11 +440,23 @@ Tensor THSTensor_lu_unpack(const Tensor LU_data, const Tensor LU_pivots, bool un
 
 Tensor THSTensor_norm_along_dimension(const Tensor tensor, const int64_t dim, const bool keepdim, float p)
 {
-    CATCH_TENSOR(tensor->norm(p, dim, keepdim));
+    CATCH_TENSOR(tensor->norm(p, dim, keepdim))
 }
 
 Tensor THSTensor_t(const Tensor tensor)
 {
-    CATCH_TENSOR(tensor->t());
+    CATCH_TENSOR(tensor->t())
 }
 
+Tensor THSLinalg_tensordot(
+    const Tensor input1,
+    const Tensor input2,
+    const int64_t* dims1,
+    const int dims1_length,
+    const int64_t* dims2,
+    const int dims2_length)
+{
+    auto d1 = c10::ArrayRef<int64_t>(dims1, dims1_length);
+    auto d2 = c10::ArrayRef<int64_t>(dims2, dims2_length);
+    CATCH_TENSOR(tensordot(*input1, *input2, d1, d2))
+}

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -984,6 +984,8 @@ EXPORT_API(Tensor) THSTensor_norm(const Tensor tensor, float p);
 
 EXPORT_API(Tensor) THSTensor_norm_along_dimension(const Tensor tensor, const int64_t dim, const bool keepdim, float p);
 
+EXPORT_API(Tensor) THSLinalg_tensordot(const Tensor input1, const Tensor input2, const int64_t* dims1, const int dims1_length, const int64_t* dims2, const int dims2_length);
+
 EXPORT_API(int64_t) THSTensor_numel(const Tensor tensor);
 
 EXPORT_API(Tensor) THSTensor_ones(const int64_t* sizes, const int length, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad);

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSLinalg.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSLinalg.cs
@@ -153,5 +153,7 @@ namespace TorchSharp.PInvoke
         [DllImport("LibTorchSharp")]
         internal static extern IntPtr THSLinalg_lu_solve(IntPtr B, IntPtr LU, IntPtr pivots, [MarshalAs(UnmanagedType.U1)] bool left, [MarshalAs(UnmanagedType.U1)] bool adjoint, IntPtr output);
 
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSLinalg_tensordot(IntPtr input1, IntPtr input2, IntPtr dims1, int dims1_length, IntPtr dims2, int dims2_length);
     }
 }

--- a/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
+++ b/src/TorchSharp/Tensor/Tensor.LinearAlgebra.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
+using System.Linq;
 using static TorchSharp.PInvoke.LibTorchSharp;
 
 namespace TorchSharp
@@ -8,6 +9,56 @@ namespace TorchSharp
     {
         public partial class Tensor
         {
+            // https://pytorch.org/docs/stable/generated/torch.tensordot
+            /// <summary>
+            /// Returns a contraction of a and b over multiple dimensions.
+            /// tensordot implements a generalized matrix product.
+            /// </summary>
+            public Tensor tensordot(Tensor b, long[] dims1, long[] dims2)
+            {
+                IntPtr res;
+                unsafe {
+                    fixed (long* pdims1 = dims1, pdims2 = dims2) {
+                        res = THSLinalg_tensordot(Handle, b.Handle,(IntPtr)pdims1, dims1.Length,(IntPtr)pdims2, dims2.Length);
+                    }
+                }
+                if (res == IntPtr.Zero) {
+                    CheckForErrors();
+                }
+                return new Tensor(res);
+            }
+
+            // https://pytorch.org/docs/stable/generated/torch.tensordot
+            /// <summary>
+            /// Returns a contraction of this tensor and <paramref name="b"/> over multiple dimensions.
+            /// tensordot implements a generalized matrix product.
+            /// </summary>
+            /// <param name="b">Right tensor to contract</param>
+            /// <param name="dims">dimensions to contract for this tensor and <paramref name="b"/> respectively</param>
+            /// <returns>contraction</returns>
+            public Tensor tensordot(Tensor b, (long, long)[] dims)
+                => tensordot(b, dims.Select(t => t.Item1).ToArray(), dims.Select(t => t.Item2).ToArray());
+
+            // https://pytorch.org/docs/stable/generated/torch.tensordot
+            /// <summary>
+            /// Returns a contraction of this tensor and <paramref name="b"/> over multiple dimensions.
+            /// tensordot implements a generalized matrix product.
+            /// </summary>
+            /// <param name="b">Right tensor to contract</param>
+            /// <param name="dims">number of dimensions to contract for this tensor and <paramref name="b"/></param>
+            /// <returns>contraction</returns>
+            public Tensor tensordot(Tensor b, long dims = 2)
+            {
+                if (dims < 0) throw new ArgumentOutOfRangeException(nameof(dims), dims, "must be >= 0");
+
+                var list = new long[dims];
+                for (long i = 0; i <= dims; i++) {
+                    list[i] = i;
+                }
+
+                return tensordot(b, list, list);
+            }
+
             /// <summary>
             /// Computes the Cholesky decomposition of a symmetric positive-definite matrix AA or for batches of symmetric positive-definite matrices.
             /// </summary>

--- a/src/TorchSharp/Tensor/torch.OtherOperations.cs
+++ b/src/TorchSharp/Tensor/torch.OtherOperations.cs
@@ -121,7 +121,7 @@ namespace TorchSharp
 
         // https://pytorch.org/docs/stable/generated/torch.cartesian_prod
         /// <summary>
-        /// Do cartesian product of the given sequence of tensors. 
+        /// Do cartesian product of the given sequence of tensors.
         /// </summary>
         /// <param name="tensors"></param>
         public static Tensor cartesian_prod(IList<Tensor> tensors)
@@ -136,7 +136,7 @@ namespace TorchSharp
 
         // https://pytorch.org/docs/stable/generated/torch.cartesian_prod
         /// <summary>
-        /// Do cartesian product of the given sequence of tensors. 
+        /// Do cartesian product of the given sequence of tensors.
         /// </summary>
         /// <param name="tensors"></param>
         public static Tensor cartesian_prod(params Tensor[] tensors) => cartesian_prod((IList<Tensor>)tensors);
@@ -265,14 +265,14 @@ namespace TorchSharp
         /// <summary>
         /// Creates a tensor whose diagonals of certain 2D planes (specified by dim1 and dim2) are filled by input.
         /// To facilitate creating batched diagonal matrices, the 2D planes formed by the last two dimensions of the returned tensor are chosen by default.
-        /// 
+        ///
         /// The argument offset controls which diagonal to consider:
         ///   If offset is equal to 0, it is the main diagonal.
         ///   If offset is greater than 0, it is above the main diagonal.
         ///   If offset is less than 0, it is below the main diagonal.
-        ///   
+        ///
         /// The size of the new matrix will be calculated to make the specified diagonal of the size of the last input dimension.Note that for offset other than 0,
-        /// 
+        ///
         /// the order of dim1 and dim2 matters.Exchanging them is equivalent to changing the sign of offset.
         /// </summary>
         /// <param name="input">The input tensor.</param>
@@ -640,8 +640,38 @@ namespace TorchSharp
             => throw new NotImplementedException();
 
         // https://pytorch.org/docs/stable/generated/torch.tensordot
-        [Obsolete("not implemented", true)]
-        public static Tensor tensordot(Tensor a, Tensor b, long dims = 2) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns a contraction of <paramref name="a"/> and <paramref name="b"/> over multiple dimensions.
+        /// tensordot implements a generalized matrix product.
+        /// </summary>
+        /// <param name="a">Left tensor to contract</param>
+        /// <param name="b">Right tensor to contract</param>
+        /// <param name="dims">number of dimensions to contract for <paramref name="a"/> and <paramref name="b"/></param>
+        /// <returns>contraction</returns>
+        public static Tensor tensordot(Tensor a, Tensor b, long dims = 2) => a.tensordot(b, dims);
+
+        // https://pytorch.org/docs/stable/generated/torch.tensordot
+        /// <summary>
+        /// Returns a contraction of <paramref name="a"/> and <paramref name="b"/> over multiple dimensions.
+        /// tensordot implements a generalized matrix product.
+        /// </summary>
+        /// <param name="a">Left tensor to contract</param>
+        /// <param name="b">Right tensor to contract</param>
+        /// <param name="dims1">dimensions to contract for <paramref name="a"/></param>
+        /// <param name="dims2">dimensions to contract for <paramref name="b"/></param>
+        /// <returns>contraction</returns>
+        public static Tensor tensordot(Tensor a, Tensor b, long[] dims1, long[] dims2) => a.tensordot(b, dims1, dims2);
+
+        // https://pytorch.org/docs/stable/generated/torch.tensordot
+        /// <summary>
+        /// Returns a contraction of <paramref name="a"/> and <paramref name="b"/> over multiple dimensions.
+        /// tensordot implements a generalized matrix product.
+        /// </summary>
+        /// <param name="a">Left tensor to contract</param>
+        /// <param name="b">Right tensor to contract</param>
+        /// <param name="dims">dimensions to contract for <paramref name="a"/> and <paramref name="b"/> respectively</param>
+        /// <returns>contraction</returns>
+        public static Tensor tensordot(Tensor a, Tensor b, (long, long)[] dims) => a.tensordot(b, dims);
 
         // https://pytorch.org/docs/stable/generated/torch.trace
         /// <summary>
@@ -688,7 +718,7 @@ namespace TorchSharp
         {
             if (!torch.is_integral(dtype))
                 throw new ArgumentException("dtype must be integral.");
-            
+
             if (device == null) {
                 device = torch.CPU;
             }


### PR DESCRIPTION
## Changes

- removing unused `using` and prefixes in unit tests
- removing unused `torch.` prefixes in unit tests
- removing redundant `;` at the end of the `CATCH` and `CATCHTENSOR` macros
- implementing `tensordot`


## Note
my local build is not working

```cmd
dotnet build /p:SkipCuda=true /p:SkipNetFxBuild=true -c Debug
```
returns
```
Build FAILED.

CMake Error : error : generator : Visual Studio 17 2022 [C:\Users\movgp\TorchSharp\src\Native\build.proj]
C:\Users\movgp\TorchSharp\src\Native\build.proj(53,5): error MSB3073: The command ""C:\Users\movgp\TorchSharp\src\Native\build.cmd" Debug x64 --libtorchpath
 C:\Users\movgp\TorchSharp\bin/obj/AnyCPU.Debug\libtorch-cpu\libtorch-win-shared-with-deps-debug-1.13.0cpu\libtorch\share\cmake\Torch" exited with code -1.
    0 Warning(s)
    2 Error(s)
```
Using this pull request to check everything.