### PR TITLE
Fix torch.squeeze issue.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,16 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+## NuGet Version 0.99.6
+
+__Breaking Changes__:
+
+There was a second version of `torch.squeeze()` with incorrect default arguments. It has now been removed.
+
+__API Changes__:
+
+Removed incorrect `torch.squeeze()` method.<br/>
+
 ## NuGet Version 0.99.5
 
 __API Changes__:

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>99</MinorVersion>
-    <PatchVersion>5</PatchVersion>
+    <PatchVersion>6</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/TorchSharp/Tensor/torch.IndexingSlicingJoiningMutatingOps.cs
+++ b/src/TorchSharp/Tensor/torch.IndexingSlicingJoiningMutatingOps.cs
@@ -465,10 +465,6 @@ namespace TorchSharp
         public static Tensor[] split(Tensor tensor, long[] split_size_or_sections, long dim = 0L)
             => tensor.split(split_size_or_sections, dim);
 
-        // https://pytorch.org/docs/stable/generated/torch.squeeze
-        public static Tensor squeeze(Tensor input, long dim = 0L)
-            => input.squeeze(dim);
-
         // https://pytorch.org/docs/stable/generated/torch.stack
         /// <summary>
         /// Concatenates a sequence of tensors along a new dimension.


### PR DESCRIPTION
There was a second version of `torch.squeeze()` with incorrect default arguments. It has now been removed.