### PR TITLE
Updated the NuGet metadata to use a license expression rather than a reference to a license file.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,15 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+## NuGet Version 0.99.7
+
+Updated the NuGet metadata to use a license expression rather than a reference to a license file. This will help with automated license checking by users.
+
+__API Changes__:
+
+__Fixed Bugs__:
+
+
 ## NuGet Version 0.99.6
 
 __Breaking Changes__:

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>99</MinorVersion>
-    <PatchVersion>6</PatchVersion>
+    <PatchVersion>7</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -9,7 +9,7 @@
   <!-- libtorch main parts -->
   <PropertyGroup Condition="'$(_IsAuxPackage)' != 'true' AND '$(_IsLibTorchPackage)' == 'true'">
     <Authors>PyTorch contributors;TorchSharp contributors</Authors>
-    <PackageLicenseFile>LICENSE-LIBTORCH.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dotnet/TorchSharp</PackageProjectUrl>
     <PackageTags>TorchSharp LibTorch PyTorch Torch DL DNN Deep ML Machine Learning Neural Network</PackageTags>
     <Copyright>Copyright PyTorch contributors</Copyright>
@@ -25,7 +25,7 @@
     <PackageTags></PackageTags>
     <Copyright>(see main package)</Copyright>
     <Owners>The .NET Foundation and Contributors</Owners>
-    <PackageLicenseFile>LICENSE-LIBTORCH.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageDescription>(see main package)</PackageDescription>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
@@ -33,7 +33,7 @@
   <!-- TorchSharp, TorchSharp=cpu, TorchSharp-cuda-linux, TorchSharp-cuda=windows -->
   <PropertyGroup Condition="'$(_IsLibTorchPackage)' != 'true'">
     <Authors>TorchSharp contributors</Authors>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dotnet/TorchSharp</PackageProjectUrl>
     <PackageTags>TorchSharp LibTorch PyTorch Torch DL DNN Deep ML Machine Learning Neural Network</PackageTags>
     <Copyright>Copyright .NET Foundation and Contributors</Copyright>


### PR DESCRIPTION
This apparently the preferred way for NuGet packages.