### PR TITLE
Fix exception in Grayscale.cs

### DIFF
--- a/src/TorchVision/Grayscale.cs
+++ b/src/TorchVision/Grayscale.cs
@@ -17,8 +17,9 @@ namespace TorchSharp
 
             public Tensor call(Tensor input)
             {
-                if (input.shape[1] == 1) return input.alias();
-                if (input.shape[1] != 3)
+                int cDim = (int)input.Dimensions - 3;
+                if (input.shape[cDim] == 1) return input.alias();
+                if (input.shape[cDim] != 3)
                     throw new ArgumentException("RGB input to 'Grayscale' transform must have 3 channels.");
                 return transforms.functional.rgb_to_grayscale(input, outputChannels);
             }


### PR DESCRIPTION
TorchSharp `Greyscale()` transform assumes batch dimension when calculating the channel dim `channel = image.shape[1]` but this is not correct, as for a non-batched tensor `channel = image.shape[0]` The channel dim should be calculated using something such as  `channel = image.shape[image.ndim - 3]`

Example working pytorch:

```python
img = torch.rand((1, 32, 32))
result = torchvision.transforms.functional.rgb_to_grayscale(img)
result = torchvision.transforms.Grayscale()(img)
```

Example failing Torchsharp
```c#
var img = torch.rand(1, 32, 32);
var res = torchvision.transforms.functional.rgb_to_grayscale(img);
var res2 = torchvision.transforms.Grayscale().call(img);
```