### PR TITLE
Fix the datatype of the returned tensor in Blend function

### DIFF
--- a/src/TorchVision/Functional.cs
+++ b/src/TorchVision/Functional.cs
@@ -845,7 +845,7 @@ namespace TorchSharp
                     using var t2 = img2 * (1.0 - ratio);
                     using var t3 = (t0 + t2);
                     using var t4 = t3.clamp(0, bound);
-                    return t4.to(img2.dtype);
+                    return t4.to(img1.dtype);
                 }
 
                 private static Tensor BlurredDegenerateImage(Tensor input)

--- a/test/TorchSharpTest/TestTorchVision.cs
+++ b/test/TorchSharpTest/TestTorchVision.cs
@@ -1206,5 +1206,13 @@ namespace TorchSharp
             var input = torch.arange(9).reshape(3, 3).to(float32) / 255.0f;
             Assert.Throws<ArgumentOutOfRangeException>(() => functional.solarize(input, 25000));
         }
+
+        [Fact]
+        public void Adjust_Contrast_ReturnsTensorWithCorrectDtype()
+        {
+            var img1 = torch.randn(1, 32, 32).to(torch.uint8);
+            var img2 = torchvision.transforms.functional.adjust_contrast(img1, 2);
+            Assert.Equal(img1.dtype, img2.dtype);
+        }
     }
 }


### PR DESCRIPTION
The `Blend()` function in `TorchVision/Functional.cs` converts the returned tensor to the wrong dtype. 

Working pytorch code:
```python
import torch
import torchvision.transforms.functional as F

img1 = torch.randn((1,32,32)).to(torch.uint8)
img2 = F.adjust_contrast(img1, 2)
assert(img1.dtype == img2.dtype)
```

Non working torchsharp code:
```c#
using TorchSharp;
using F = TorchSharp.torchvision.transforms.functional;

var img1 = torch.randn(1,32,32).to(ScalarType.Byte);
var img2 = F.adjust_contrast(img1, 2);
Debug.Assert(img1.dtype == img2.dtype);
```

```
Process terminated. Assertion failed.
   at TorchSharpExample.Program.Main(String[] args)
```

The original torchsharp code was introduced in this commit https://github.com/pytorch/vision/commit/e79caddf7490a1cb7f460fe353880fb8b54505a8#diff-497b983ae7c82237c4a0722bc6f6637525e0cdf8369dbd78ee19cf986bffe258R109

Implemented with `to(img1.dtype)`:
```python
def _blend(img1, img2, ratio):
    bound = 1 if img1.dtype.is_floating_point else 255
    return (ratio * img1 + (1 - ratio) * img2).clamp(0, bound).to(img1.dtype)
```

However the c# version was introduced here https://github.com/dotnet/TorchSharp/blob/418bd160d11f5b149fbfa79d2758a76f4456eab7/src/TorchSharp/TorchVision/Adjustment.cs#L17C81-L17C81

Implemented with `to(img2.dtype)`
```c#
protected Tensor Blend(Tensor img1, Tensor img2, double ratio)
{
    var bound = img1.IsIntegral() ? 255.0 : 1.0;
    return (img1 * ratio + img2 * (1.0 - ratio)).clamp(0, bound).to(img2.dtype);
}
```

So the torchsharp code has never matched the pytorch implementation for this functions return dtype.