### PR TITLE
Port torchvision.utils.make_grid and torchvision.utils.save_image from pytorch.

### DIFF
--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -121,11 +121,26 @@ namespace TorchSharp
                 double pad_value = 0.0f,
                 Imager imager = null)
             {
+                using var filestream = new FileStream(filename, FileMode.OpenOrCreate);
+                save_image(tensor, filestream, format, nrow, padding, normalize, value_range, scale_each, pad_value, imager);
+            }
+
+            public static void save_image(
+                Tensor tensor,
+                Stream filestream,
+                ImageFormat format,
+                long nrow = 8,
+                int padding = 2,
+                bool normalize = false,
+                (double low, double high)? value_range = null,
+                bool scale_each = false,
+                double pad_value = 0.0f,
+                Imager imager = null)
+            {
                 var grid = make_grid(tensor, nrow, padding, normalize, value_range, scale_each, pad_value);
                 // Add 0.5 after unnormalizing to [0, 255] to round to nearest integer
                 var narr = grid.mul(255).add_(0.5).clamp_(0, 255).to(uint8, CPU);
-                using (var filestream = new FileStream(filename, FileMode.OpenOrCreate))
-                    (imager ?? DefaultImager).EncodeImage(narr, format, filestream);
+                (imager ?? DefaultImager).EncodeImage(narr, format, filestream);
             }
         }
     }

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -85,8 +85,10 @@ namespace TorchSharp
                     }
                 }
 
-                if (tensor.size(0) == 1)
-                    return tensor.unsqueeze(0);
+                if (tensor.size(0) == 1) {
+                    tensor = tensor.unsqueeze(0);
+                    return tensor.MoveToOuterDisposeScope();
+                }
 
                 var nmaps = tensor.size(0);
                 var xmaps = Math.Min(nrow, nmaps);

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using TorchSharp;
 using static TorchSharp.torch;
 using static TorchSharp.torchvision.io;
 
@@ -16,9 +15,9 @@ namespace TorchSharp
                 long nrow = 8,
                 int padding = 2,
                 bool normalize = false,
-                (float low, float high)? value_range = null,
+                (double low, double high)? value_range = null,
                 bool scale_each = false,
-                float pad_value = 0.0f)
+                double pad_value = 0.0f)
             {
                 return make_grid(torch.stack(tensors, dim: 0), nrow, padding, normalize, value_range, scale_each, pad_value);
             }
@@ -28,9 +27,9 @@ namespace TorchSharp
                 long nrow = 8,
                 int padding = 2,
                 bool normalize = false,
-                (float low, float high)? value_range = null,
+                (double low, double high)? value_range = null,
                 bool scale_each = false,
-                float pad_value = 0.0f)
+                double pad_value = 0.0f)
             {
                 if (tensor.Dimensions == 2) // Single image H x W
                 {
@@ -51,13 +50,13 @@ namespace TorchSharp
 
                 if (normalize == true)
                 {
-                    void norm_ip(Tensor img, float low, float high)
+                    void norm_ip(Tensor img, double low, double high)
                     {
                         img.clamp_(min: low, max: high);
                         img.sub_(low).div_(Math.Max(high - low, 1e-5));
                     }
 
-                    void norm_range(Tensor t, (float low, float high)? range)
+                    void norm_range(Tensor t, (double low, double high)? range)
                     {
                         if (range.HasValue)
                         {
@@ -88,7 +87,7 @@ namespace TorchSharp
 
                 var nmaps = tensor.size(0);
                 var xmaps = Math.Min(nrow, nmaps);
-                var ymaps = (long)Math.Ceiling((float)nmaps / xmaps);
+                var ymaps = (long)Math.Ceiling((double)nmaps / xmaps);
                 var width = tensor.size(3) + padding;
                 var height = tensor.size(2) + padding;
                 var num_channels = tensor.size(1);
@@ -113,13 +112,13 @@ namespace TorchSharp
             public static void save_image(
                 Tensor tensor,
                 string filename,
-                TorchSharp.torchvision.ImageFormat format,
+                ImageFormat format,
                 long nrow = 8,
                 int padding = 2,
                 bool normalize = false,
-                (float low, float high)? value_range = null,
+                (double low, double high)? value_range = null,
                 bool scale_each = false,
-                float pad_value = 0.0f,
+                double pad_value = 0.0f,
                 Imager imager = null)
             {
                 var grid = make_grid(tensor, nrow, padding, normalize, value_range, scale_each, pad_value);

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -31,6 +31,8 @@ namespace TorchSharp
                 bool scale_each = false,
                 double pad_value = 0.0f)
             {
+                using var _ = torch.NewDisposeScope();
+
                 if (tensor.Dimensions == 2) // Single image H x W
                 {
                     tensor = tensor.unsqueeze(0);
@@ -107,7 +109,7 @@ namespace TorchSharp
                     }
                 }
 
-                return grid;
+                return grid.MoveToOuterDisposeScope();
             }
 
             public static void save_image(
@@ -140,8 +142,9 @@ namespace TorchSharp
             {
                 using var grid = make_grid(tensor, nrow, padding, normalize, value_range, scale_each, pad_value);
                 // Add 0.5 after unnormalizing to [0, 255] to round to nearest integer
-                using var narr = grid.mul_(255).add_(0.5).clamp_(0, 255).to(uint8, CPU);
-                (imager ?? DefaultImager).EncodeImage(narr, format, filestream);
+                using var narr0 = grid.mul(255).add_(0.5).clamp_(0, 255);
+                using var narr1 = narr0.to(uint8, CPU);
+                (imager ?? DefaultImager).EncodeImage(narr1, format, filestream);
             }
         }
     }

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -137,9 +137,9 @@ namespace TorchSharp
                 double pad_value = 0.0f,
                 Imager imager = null)
             {
-                var grid = make_grid(tensor, nrow, padding, normalize, value_range, scale_each, pad_value);
+                using var grid = make_grid(tensor, nrow, padding, normalize, value_range, scale_each, pad_value);
                 // Add 0.5 after unnormalizing to [0, 255] to round to nearest integer
-                var narr = grid.mul(255).add_(0.5).clamp_(0, 255).to(uint8, CPU);
+                using var narr = grid.mul_(255).add_(0.5).clamp_(0, 255).to(uint8, CPU);
                 (imager ?? DefaultImager).EncodeImage(narr, format, filestream);
             }
         }

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -10,6 +10,22 @@ namespace TorchSharp
     {
         public static class utils
         {
+            /// <summary>
+            /// Make a grid of images.
+            /// </summary>
+            /// <param name="tensors">A list of images all of the same size.</param>
+            /// <param name="nrow">Number of images displayed in each row of the grid.
+            /// The final grid size is (B / nrow, nrow). Default: 8.</param>
+            /// <param name="padding">Amount of padding. Default: 2.</param>
+            /// <param name="normalize">If true, shift the image to the range (0, 1),
+            /// by the min and max values specified by value_range. Default: false.</param>
+            /// <param name="value_range">Tuple (min, max) where min and max are numbers,
+            /// then these numbers are used to normalize the image. By default, min and max
+            /// are computed from the tensor.</param>
+            /// <param name="scale_each">If true, scale each image in the batch of
+            /// images separately rather than the (min, max) over all images. Default: false.</param>
+            /// <param name="pad_value">Value for the padded pixels. Default: 0.</param>
+            /// <returns>The tensor containing grid of images.</returns>
             public static Tensor make_grid(
                 IEnumerable<Tensor> tensors,
                 long nrow = 8,
@@ -22,6 +38,22 @@ namespace TorchSharp
                 return make_grid(torch.stack(tensors, dim: 0), nrow, padding, normalize, value_range, scale_each, pad_value);
             }
 
+            /// <summary>
+            /// Make a grid of images.
+            /// </summary>
+            /// <param name="tensor">4D mini-batch Tensor of shape (B x C x H x W).</param>
+            /// <param name="nrow">Number of images displayed in each row of the grid.
+            /// The final grid size is (B / nrow, nrow). Default: 8.</param>
+            /// <param name="padding">Amount of padding. Default: 2.</param>
+            /// <param name="normalize">If true, shift the image to the range (0, 1),
+            /// by the min and max values specified by value_range. Default: false.</param>
+            /// <param name="value_range">Tuple (min, max) where min and max are numbers,
+            /// then these numbers are used to normalize the image. By default, min and max
+            /// are computed from the tensor.</param>
+            /// <param name="scale_each">If true, scale each image in the batch of
+            /// images separately rather than the (min, max) over all images. Default: false.</param>
+            /// <param name="pad_value">Value for the padded pixels. Default: 0.</param>
+            /// <returns>The tensor containing grid of images.</returns>
             public static Tensor make_grid(
                 Tensor tensor,
                 long nrow = 8,
@@ -114,6 +146,26 @@ namespace TorchSharp
                 return grid.MoveToOuterDisposeScope();
             }
 
+            /// <summary>
+            /// Save a given Tensor into an image file.
+            /// </summary>
+            /// <param name="tensor">Image to be saved. If given a mini-batch tensor,
+            /// saves the tensor as a grid of images by calling make_grid.</param>
+            /// <param name="filename">A file name</param>
+            /// <param name="format">The format to use is not determined from the
+            /// filename extension this parameter should always be used.</param>
+            /// <param name="nrow">Number of images displayed in each row of the grid.
+            /// The final grid size is (B / nrow, nrow). Default: 8.</param>
+            /// <param name="padding">Amount of padding. Default: 2.</param>
+            /// <param name="normalize">If true, shift the image to the range (0, 1),
+            /// by the min and max values specified by value_range. Default: false.</param>
+            /// <param name="value_range">Tuple (min, max) where min and max are numbers,
+            /// then these numbers are used to normalize the image. By default, min and max
+            /// are computed from the tensor.</param>
+            /// <param name="scale_each">If true, scale each image in the batch of
+            /// images separately rather than the (min, max) over all images. Default: false.</param>
+            /// <param name="pad_value">Value for the padded pixels. Default: 0.</param>
+            /// <param name="imager">Imager to use instead of DefaultImager. Default: null</param>
             public static void save_image(
                 Tensor tensor,
                 string filename,
@@ -130,6 +182,26 @@ namespace TorchSharp
                 save_image(tensor, filestream, format, nrow, padding, normalize, value_range, scale_each, pad_value, imager);
             }
 
+            /// <summary>
+            /// Save a given Tensor into an image file.
+            /// </summary>
+            /// <param name="tensor">Image to be saved. If given a mini-batch tensor,
+            /// saves the tensor as a grid of images by calling make_grid.</param>
+            /// <param name="filestream">A file stream</param>
+            /// <param name="format">The format to use is not determined from the
+            /// filename extension this parameter should always be used.</param>
+            /// <param name="nrow">Number of images displayed in each row of the grid.
+            /// The final grid size is (B / nrow, nrow). Default: 8.</param>
+            /// <param name="padding">Amount of padding. Default: 2.</param>
+            /// <param name="normalize">If true, shift the image to the range (0, 1),
+            /// by the min and max values specified by value_range. Default: false.</param>
+            /// <param name="value_range">Tuple (min, max) where min and max are numbers,
+            /// then these numbers are used to normalize the image. By default, min and max
+            /// are computed from the tensor.</param>
+            /// <param name="scale_each">If true, scale each image in the batch of
+            /// images separately rather than the (min, max) over all images. Default: false.</param>
+            /// <param name="pad_value">Value for the padded pixels. Default: 0.</param>
+            /// <param name="imager">Imager to use instead of DefaultImager. Default: null</param>
             public static void save_image(
                 Tensor tensor,
                 Stream filestream,

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -86,7 +86,7 @@ namespace TorchSharp
                 }
 
                 if (tensor.size(0) == 1) {
-                    tensor = tensor.unsqueeze(0);
+                    tensor = tensor.squeeze(0);
                     return tensor.MoveToOuterDisposeScope();
                 }
 

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -50,6 +50,7 @@ namespace TorchSharp
 
                 if (normalize == true)
                 {
+                    tensor = tensor.clone();  // avoid modifying tensor in-place
                     void norm_ip(Tensor img, double low, double high)
                     {
                         img.clamp_(min: low, max: high);

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -140,11 +140,11 @@ namespace TorchSharp
                 double pad_value = 0.0f,
                 Imager imager = null)
             {
-                using var grid = make_grid(tensor, nrow, padding, normalize, value_range, scale_each, pad_value);
+                using var _ = torch.NewDisposeScope();
+                var grid = make_grid(tensor, nrow, padding, normalize, value_range, scale_each, pad_value);
                 // Add 0.5 after unnormalizing to [0, 255] to round to nearest integer
-                using var narr0 = grid.mul(255).add_(0.5).clamp_(0, 255);
-                using var narr1 = narr0.to(uint8, CPU);
-                (imager ?? DefaultImager).EncodeImage(narr1, format, filestream);
+                var narr = grid.mul(255).add_(0.5).clamp_(0, 255).to(uint8, CPU);
+                (imager ?? DefaultImager).EncodeImage(narr, format, filestream);
             }
         }
     }

--- a/src/TorchVision/Utils.cs
+++ b/src/TorchVision/Utils.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using TorchSharp;
+using static TorchSharp.torch;
+using static TorchSharp.torchvision.io;
+
+namespace TorchSharp
+{
+    public static partial class torchvision
+    {
+        public static class utils
+        {
+            public static Tensor make_grid(
+                IEnumerable<Tensor> tensors,
+                long nrow = 8,
+                int padding = 2,
+                bool normalize = false,
+                (float low, float high)? value_range = null,
+                bool scale_each = false,
+                float pad_value = 0.0f)
+            {
+                return make_grid(torch.stack(tensors, dim: 0), nrow, padding, normalize, value_range, scale_each, pad_value);
+            }
+
+            public static Tensor make_grid(
+                Tensor tensor,
+                long nrow = 8,
+                int padding = 2,
+                bool normalize = false,
+                (float low, float high)? value_range = null,
+                bool scale_each = false,
+                float pad_value = 0.0f)
+            {
+                if (tensor.Dimensions == 2) // Single image H x W
+                {
+                    tensor = tensor.unsqueeze(0);
+                }
+                if (tensor.Dimensions == 3) // Single image
+                {
+                    if (tensor.size(0) == 1) // Convert single channel to 3 channel
+                    {
+                        tensor = torch.cat(new[] { tensor, tensor, tensor }, 0);
+                    }
+                    tensor = tensor.unsqueeze(0);
+                }
+                if (tensor.Dimensions == 4 && tensor.size(1) == 1) // Single channel images
+                {
+                    tensor = torch.cat(new[] { tensor, tensor, tensor }, 1);
+                }
+
+                if (normalize == true)
+                {
+                    void norm_ip(Tensor img, float low, float high)
+                    {
+                        img.clamp_(min: low, max: high);
+                        img.sub_(low).div_(Math.Max(high - low, 1e-5));
+                    }
+
+                    void norm_range(Tensor t, (float low, float high)? range)
+                    {
+                        if (range.HasValue)
+                        {
+                            var (low, high) = value_range.Value;
+                            norm_ip(t, low, high);
+                        }
+                        else
+                        {
+                            norm_ip(t, t.min().ToSingle(), t.max().ToSingle());
+                        }
+                    }
+
+                    if (scale_each == true)
+                    {
+                        for (long i = 0; i < tensor.size(0); ++i)
+                        {
+                            norm_range(tensor[i], value_range);
+                        }
+                    }
+                    else
+                    {
+                        norm_range(tensor, value_range);
+                    }
+                }
+
+                if (tensor.size(0) == 1)
+                    return tensor.unsqueeze(0);
+
+                var nmaps = tensor.size(0);
+                var xmaps = Math.Min(nrow, nmaps);
+                var ymaps = (long)Math.Ceiling((float)nmaps / xmaps);
+                var width = tensor.size(3) + padding;
+                var height = tensor.size(2) + padding;
+                var num_channels = tensor.size(1);
+
+                var grid = tensor.new_full(new[] { num_channels, height * ymaps + padding, width * xmaps + padding }, pad_value);
+                var k = 0L;
+                for (long y = 0; y < ymaps; ++y)
+                {
+                    for (long x = 0; x < xmaps; ++x)
+                    {
+                        if (k > nmaps) break;
+                        grid.narrow(1, y * height, height - padding).narrow(
+                            2, x * width + padding, width - padding
+                            ).copy_(tensor[k]);
+                        ++k;
+                    }
+                }
+
+                return grid;
+            }
+
+            public static void save_image(
+                Tensor tensor,
+                string filename,
+                TorchSharp.torchvision.ImageFormat format,
+                long nrow = 8,
+                int padding = 2,
+                bool normalize = false,
+                (float low, float high)? value_range = null,
+                bool scale_each = false,
+                float pad_value = 0.0f,
+                Imager imager = null)
+            {
+                var grid = make_grid(tensor, nrow, padding, normalize, value_range, scale_each, pad_value);
+                // Add 0.5 after unnormalizing to [0, 255] to round to nearest integer
+                var narr = grid.mul(255).add_(0.5).clamp_(0, 255).to(uint8, CPU);
+                using (var filestream = new FileStream(filename, FileMode.OpenOrCreate))
+                    (imager ?? DefaultImager).EncodeImage(narr, format, filestream);
+            }
+        }
+    }
+}

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -37,6 +37,7 @@
     <Compile Include="..\TorchSharpTest\TestTorchTensor.cs" Link="TestTorchTensor.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchTensorBugs.cs" Link="TestTorchTensorBugs.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchVision.cs" Link="TestTorchVision.cs" />
+    <Compile Include="..\TorchSharpTest\TestTorchVisionUtils.cs" Link="TestTorchVisionUtils.cs" />
     <Compile Include="..\TorchSharpTest\TestTorchVisionOps.cs" Link="TestTorchVisionOps.cs" />
     <Compile Include="..\TorchSharpTest\TestTraining.cs" Link="TestTraining.cs" />
     <Compile Include="..\TorchSharpTest\TestDisposeScopes.cs" Link="TestDisposeScopes.cs" />

--- a/test/TorchSharpTest/TestTorchVisionUtils.cs
+++ b/test/TorchSharpTest/TestTorchVisionUtils.cs
@@ -5,7 +5,7 @@ namespace TorchSharp
 {
     public class TestTorchVisionUtils
     {
-        [Fact(Skip = "Intermittent fail")]
+        [Fact]
         public void Save_Image_TestMemoryUsage()
         {
             var imager = new torchvision.io.SkiaImager();

--- a/test/TorchSharpTest/TestTorchVisionUtils.cs
+++ b/test/TorchSharpTest/TestTorchVisionUtils.cs
@@ -5,7 +5,7 @@ namespace TorchSharp
 {
     public class TestTorchVisionUtils
     {
-        [Fact]
+        [Fact(Skip = "Intermittent fail")]
         public void Save_Image_TestMemoryUsage()
         {
             var imager = new torchvision.io.SkiaImager();

--- a/test/TorchSharpTest/TestTorchVisionUtils.cs
+++ b/test/TorchSharpTest/TestTorchVisionUtils.cs
@@ -14,7 +14,16 @@ namespace TorchSharp
             using (var d = torch.NewDisposeScope()) {
                 torchvision.utils.save_image(image, ms, torchvision.ImageFormat.Png, imager: imager);
                 Assert.Equal(0, d.DisposablesCount);
-            } 
+            }
+        }
+
+        [Fact]
+        public void Make_Grid_IncorrectInput()
+        {
+            Assert.Throws<System.Runtime.InteropServices.ExternalException>(() => {
+                using var image = torch.tensor(new[] { 1.0f, 0.0f });
+                using var result = torchvision.utils.make_grid(image);
+            });
         }
     }
 }

--- a/test/TorchSharpTest/TestTorchVisionUtils.cs
+++ b/test/TorchSharpTest/TestTorchVisionUtils.cs
@@ -33,5 +33,35 @@ namespace TorchSharp
             using var result = torchvision.utils.make_grid(image);
             Assert.Equal(new long[] { 3, 2, 2 }, result.shape);
         }
+
+        [Fact]
+        public void Make_Grid_ColorImageInput()
+        {
+            using var image = torch.tensor(new[, ,] {
+                { { 1.0f, 0.0f }, { 0.0f, 1.0f } },
+                { { 1.0f, 0.0f }, { 0.0f, 1.0f } },
+                { { 1.0f, 0.0f }, { 0.0f, 1.0f } }
+            });
+            using var result = torchvision.utils.make_grid(image);
+            Assert.Equal(new long[] { 3, 2, 2 }, result.shape);
+        }
+
+        [Fact]
+        public void Make_Grid_BatchColorImageInput()
+        {
+            using var image = torch.tensor(new[, , ,] {{
+                    { { 1.0f, 0.0f }, { 0.0f, 1.0f } },
+                    { { 1.0f, 0.0f }, { 0.0f, 1.0f } },
+                    { { 1.0f, 0.0f }, { 0.0f, 1.0f } }
+                },
+                {
+                    { { 1.0f, 0.0f }, { 0.0f, 1.0f } },
+                    { { 1.0f, 0.0f }, { 0.0f, 1.0f } },
+                    { { 1.0f, 0.0f }, { 0.0f, 1.0f } }
+                }
+            });
+            using var result = torchvision.utils.make_grid(image, padding: 0);
+            Assert.Equal(new long[] { 3, 2, 4 }, result.shape);
+        }
     }
 }

--- a/test/TorchSharpTest/TestTorchVisionUtils.cs
+++ b/test/TorchSharpTest/TestTorchVisionUtils.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using Xunit;
+
+namespace TorchSharp
+{
+    public class TestTorchVisionUtils
+    {
+        [Fact]
+        public void Save_Image_TestMemoryUsage()
+        {
+            var imager = new torchvision.io.SkiaImager();
+            using var ms = new MemoryStream();
+            using var image = torch.randn(32, 3, 32, 32);
+            using (var d = torch.NewDisposeScope()) {
+                torchvision.utils.save_image(image, ms, torchvision.ImageFormat.Png, imager: imager);
+                Assert.Equal(0, d.DisposablesCount);
+            } 
+        }
+    }
+}

--- a/test/TorchSharpTest/TestTorchVisionUtils.cs
+++ b/test/TorchSharpTest/TestTorchVisionUtils.cs
@@ -32,6 +32,14 @@ namespace TorchSharp
             using var image = torch.tensor(new[,] { { 1.0f, 0.0f }, { 0.0f, 1.0f } });
             using var result = torchvision.utils.make_grid(image);
             Assert.Equal(new long[] { 3, 2, 2 }, result.shape);
+
+            using var expected = torch.tensor(new[, ,] {
+                { { 1.0f, 0.0f }, { 0.0f, 1.0f } },
+                { { 1.0f, 0.0f }, { 0.0f, 1.0f } },
+                { { 1.0f, 0.0f }, { 0.0f, 1.0f } }
+            });
+
+            Assert.Equal(expected, result);
         }
 
         [Fact]
@@ -44,6 +52,8 @@ namespace TorchSharp
             });
             using var result = torchvision.utils.make_grid(image);
             Assert.Equal(new long[] { 3, 2, 2 }, result.shape);
+
+            Assert.Equal(image, result);
         }
 
         [Fact]
@@ -62,6 +72,14 @@ namespace TorchSharp
             });
             using var result = torchvision.utils.make_grid(image, padding: 0);
             Assert.Equal(new long[] { 3, 2, 4 }, result.shape);
+
+            using var expected = torch.tensor(new[, ,] {
+                { { 1.0f, 0.0f, 1.0f, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+                { { 1.0f, 0.0f, 1.0f, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+                { { 1.0f, 0.0f, 1.0f, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+            });
+
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/test/TorchSharpTest/TestTorchVisionUtils.cs
+++ b/test/TorchSharpTest/TestTorchVisionUtils.cs
@@ -25,5 +25,13 @@ namespace TorchSharp
                 using var result = torchvision.utils.make_grid(image);
             });
         }
+
+        [Fact]
+        public void Make_Grid_ImageInput()
+        {
+            using var image = torch.tensor(new[,] { { 1.0f, 0.0f }, { 0.0f, 1.0f } });
+            using var result = torchvision.utils.make_grid(image);
+            Assert.Equal(new long[] { 3, 2, 2 }, result.shape);
+        }
     }
 }


### PR DESCRIPTION
I find the make_grid/save_image functions in torchvision.utils a quick and easy way to save an image batch to png/jpg...etc.

The code might need some additional TorchSharp specific changes. 