### PR TITLE
Fix cuda synchronize method

### DIFF
--- a/src/Native/LibTorchSharp/THSTorch.cpp
+++ b/src/Native/LibTorchSharp/THSTorch.cpp
@@ -140,7 +140,7 @@ int THSTorchCuda_device_count()
     return (int)torch::cuda::device_count();
 }
 
-EXPORT_API(void) THSTorchCuda_synchronize(const int64_t device_index)
+void THSTorchCuda_synchronize(const int64_t device_index)
 {
     CATCH(torch::cuda::synchronize(device_index);)
 }

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSCuda.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSCuda.cs
@@ -13,9 +13,6 @@ namespace TorchSharp.PInvoke
         internal static extern void THSCuda_manual_seed_all(long seed);
 
         [DllImport("LibTorchSharp")]
-        internal static extern void THSCuda_synchronize(long device_index);
-
-        [DllImport("LibTorchSharp")]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static extern bool THSBackend_cublas_get_allow_tf32();
         [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSTorchCuda.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSTorchCuda.cs
@@ -16,5 +16,8 @@ namespace TorchSharp.PInvoke
 
         [DllImport("LibTorchSharp")]
         internal static extern int THSTorchCuda_device_count();
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSTorchCuda_synchronize(long device_index);
     }
 }

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -465,12 +465,12 @@ namespace TorchSharp
             /// <summary>
             /// Waits for all kernels in all streams on a CUDA device to complete.
             /// </summary>
-            /// <param name="seed">Device for which to synchronize.
+            /// <param name="device">Device for which to synchronize.
             /// It uses the current device, given by current_device(), if a device is not provided.</param>
-            public static void synchronize(long seed = -1L)
+            public static void synchronize(Device? device = null)
             {
-                TryInitializeDeviceType(DeviceType.CUDA);
-                THSCuda_synchronize(seed);
+                TryInitializeDeviceType(device?.type ?? DeviceType.CUDA);
+                THSTorchCuda_synchronize(device?.index ?? -1);
             }
         }
 

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -42,6 +42,13 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestSynchronize()
+        {
+            // Will throw if the underlying native function fails to link at runtime
+            cuda.synchronize();
+        }
+
+        [Fact]
         public void ExplicitDisposal()
         {
             // Allocate many 256MB tensors. Without explicit disposal memory use relies on finalization.


### PR DESCRIPTION
The native function binding for `torch.cuda.synchronize` had a mismatched name, which resulted in a link error at runtime when the symbol could not be found. This commit fixes that by renaming the native binding in C# (from `THSCuda_synchronize`) to `THSTorchCuda_synchronize` as defined in the associated header file.