### PR TITLE
Fix semantic error in THSTensor.cpp

### DIFF
--- a/src/Native/LibTorchSharp/THSJIT.cpp
+++ b/src/Native/LibTorchSharp/THSJIT.cpp
@@ -514,7 +514,7 @@ void* THSJIT_Type_cast(const JITType type)
     case c10::TypeKind::TensorType:
         return new std::shared_ptr<torch::jit::TensorType>((*type)->cast<c10::TensorType>());
     default:
-        return NULL;
+        return nullptr;
     }
 }
 

--- a/src/Native/LibTorchSharp/THSLoss.cpp
+++ b/src/Native/LibTorchSharp/THSLoss.cpp
@@ -20,7 +20,7 @@ Tensor THSNN_binary_cross_entropy(const Tensor input, const Tensor target, const
     CATCH_RETURN_Tensor(
         auto opts = torch::nn::functional::BinaryCrossEntropyFuncOptions();
         ApplyReduction(opts, reduction);
-        if (weight != NULL)
+        if (weight != nullptr)
             opts = opts.weight(*weight);
         res = ResultTensor(torch::nn::functional::binary_cross_entropy(*input, *target, opts));
     )
@@ -56,7 +56,7 @@ Tensor THSNN_cross_entropy(const Tensor input, const Tensor target, const Tensor
         opts.label_smoothing(smoothing);
         if (has_ii)
             opts = opts.ignore_index(ignore_index);
-        if (weight != NULL)
+        if (weight != nullptr)
             opts = opts.weight(*weight);
         res = ResultTensor(torch::nn::functional::cross_entropy(*input, *target, opts));
     )
@@ -125,7 +125,7 @@ Tensor THSNN_nll_loss(const Tensor input, const Tensor target, const Tensor weig
     CATCH_RETURN_Tensor(
         auto opts = torch::nn::functional::NLLLossFuncOptions();
         ApplyReduction(opts, reduction);
-        if (weight != NULL)
+        if (weight != nullptr)
             opts = opts.weight(*weight);
 
         res = ResultTensor(torch::nn::functional::nll_loss(*input, *target, opts));
@@ -187,7 +187,7 @@ Tensor THSNN_multilabel_soft_margin_loss(const Tensor input, const Tensor target
     CATCH_RETURN_Tensor(
         auto opts = torch::nn::functional::MultilabelSoftMarginLossFuncOptions();
         ApplyReduction(opts, reduction);
-        if (weight != NULL)
+        if (weight != nullptr)
             opts = opts.weight(*weight);
 
         res = ResultTensor(torch::nn::functional::multilabel_soft_margin_loss(*input, *target, opts));
@@ -201,7 +201,7 @@ Tensor THSNN_multi_margin_loss(const Tensor input, const Tensor target, const in
         .p(p)
         .margin(margin);
         ApplyReduction(opts, reduction);
-        if (weight != NULL)
+        if (weight != nullptr)
             opts = opts.weight(*weight);
 
         res = ResultTensor(torch::nn::functional::multi_margin_loss(*input, *target, opts));

--- a/src/Native/LibTorchSharp/THSModule.cpp
+++ b/src/Native/LibTorchSharp/THSModule.cpp
@@ -221,7 +221,7 @@ NNModule THSNN_custom_module(const char* name,
 
     // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
     // a Module can only be boxed to AnyModule at the point its static type is known).
-    if (outAsAnyModule != NULL)
+    if (outAsAnyModule != nullptr)
     {
         auto modShared = new std::shared_ptr<CustomModule>(mod);
         auto wrapped = std::make_shared<torch::nn::AnyModule>(torch::nn::ModuleHolder<CustomModule>(*modShared));

--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -458,7 +458,7 @@ NNModule THSNN_Embedding_from_pretrained(const Tensor embeddings, const bool fre
 
         // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
         // a Module can only be boxed to AnyModule at the point its static type is known).
-        if (outAsAnyModule != NULL)
+        if (outAsAnyModule != nullptr)
         {
             auto wrapped = std::make_shared<torch::nn::AnyModule>(torch::nn::ModuleHolder<torch::nn::EmbeddingImpl>(*mod));
             *outAsAnyModule = new std::shared_ptr<torch::nn::AnyModule>(wrapped);
@@ -545,7 +545,7 @@ NNModule THSNN_EmbeddingBag_from_pretrained(const Tensor embeddings, const bool 
 
         // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
         // a Module can only be boxed to AnyModule at the point its static type is known).
-        if (outAsAnyModule != NULL)
+        if (outAsAnyModule != nullptr)
         {
             auto wrapped = std::make_shared<torch::nn::AnyModule>(torch::nn::ModuleHolder<torch::nn::EmbeddingBagImpl>(*mod));
             *outAsAnyModule = new std::shared_ptr<torch::nn::AnyModule>(wrapped);

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -606,7 +606,7 @@ Tensor THSTensor_grad(const Tensor tensor)
     Tensor res;
     CATCH(
         torch::Tensor grad = tensor->grad();
-        res = grad.defined() ? new torch::Tensor(grad) : NULL;
+        res = grad.defined() ? new torch::Tensor(grad) : nullptr;
     );
     return res;
 }
@@ -770,8 +770,8 @@ void completeTensorIndices(const int64_t* indexStarts,
         {
             // slice
             auto start = (n == INT64_MIN + 6) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(n - INT64_MIN / 2);
-            auto end = (indexEnds == NULL || indexEnds[i] == INT64_MIN) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(indexEnds[i]);
-            auto step = (indexSteps == NULL || indexSteps[i] == INT64_MIN) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(indexSteps[i]);
+            auto end = (indexEnds == 0 || indexEnds[i] == INT64_MIN) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(indexEnds[i]);
+            auto step = (indexSteps == 0 || indexSteps[i] == INT64_MIN) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(indexSteps[i]);
             at::indexing::TensorIndex idx(at::indexing::Slice(start, end, step));
             memcpy(&indicesArray[i], &idx, sizeof(at::indexing::TensorIndex));
         }
@@ -885,7 +885,7 @@ int THSTensor_is_sparse(const Tensor tensor)
 
 Scalar THSTensor_item(const Tensor tensor)
 {
-    CATCH_RETURN(Scalar, NULL, new torch::Scalar(tensor->item()));
+    CATCH_RETURN(Scalar, nullptr, new torch::Scalar(tensor->item()));
 }
 
 Tensor THSTensor_leaky_relu(const Tensor tensor, const Scalar negative_slope)

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -770,8 +770,8 @@ void completeTensorIndices(const int64_t* indexStarts,
         {
             // slice
             auto start = (n == INT64_MIN + 6) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(n - INT64_MIN / 2);
-            auto end = (indexEnds == 0 || indexEnds[i] == INT64_MIN) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(indexEnds[i]);
-            auto step = (indexSteps == 0 || indexSteps[i] == INT64_MIN) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(indexSteps[i]);
+            auto end = (indexEnds == nullptr || indexEnds[i] == INT64_MIN) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(indexEnds[i]);
+            auto step = (indexSteps == nullptr || indexSteps[i] == INT64_MIN) ? c10::optional<c10::SymInt>() : c10::optional<c10::SymInt>(indexSteps[i]);
             at::indexing::TensorIndex idx(at::indexing::Slice(start, end, step));
             memcpy(&indicesArray[i], &idx, sizeof(at::indexing::TensorIndex));
         }

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -381,17 +381,17 @@ Tensor THSTensor_cumsum(const Tensor tensor, const int64_t dim, bool has_type, c
 
 void* THSTensor_data(const Tensor tensor)
 {
-    CATCH_RETURN(void*, NULL, tensor->data_ptr());
+    CATCH_RETURN(void*, nullptr, tensor->data_ptr());
 }
 
 float THSTensor_data_idx_float16(const Tensor tensor, const int64_t i)
 {
-    CATCH_RETURN(float, NULL, (float)(tensor->data_ptr<c10::Half>())[i]);
+    CATCH_RETURN(float, 0.0f, (float)(tensor->data_ptr<c10::Half>())[i]);
 }
 
 float THSTensor_data_idx_bfloat16(const Tensor tensor, const int64_t i)
 {
-    CATCH_RETURN(float, NULL, (float)(tensor->data_ptr<c10::BFloat16>())[i]);
+    CATCH_RETURN(float, 0.0f, (float)(tensor->data_ptr<c10::BFloat16>())[i]);
 }
 
 const char* THSTensor_device_str(const Tensor tensor)

--- a/src/Native/LibTorchSharp/Utils.cpp
+++ b/src/Native/LibTorchSharp/Utils.cpp
@@ -10,7 +10,7 @@
 #define TP_CoTaskMemAlloc(t) malloc(t)
 #endif
 
-thread_local char * torch_last_err = NULL;
+thread_local char * torch_last_err = nullptr;
 
 const char * make_sharable_string(const std::string str)
 {

--- a/src/Native/LibTorchSharp/Utils.h
+++ b/src/Native/LibTorchSharp/Utils.h
@@ -45,16 +45,16 @@ typedef std::shared_ptr<c10::TensorType>* JITTensorType;
     return res;
 
 #define CATCH_RETURN(ty, dflt, expr) CATCH_RETURN_RES(ty, dflt, res = expr)
-#define CATCH_RETURN_NNModule(stmt) CATCH_RETURN_RES(NNModule, NULL, stmt)
-#define CATCH_RETURN_Tensor(stmt) CATCH_RETURN_RES(Tensor, NULL, stmt)
+#define CATCH_RETURN_NNModule(stmt) CATCH_RETURN_RES(NNModule, nullptr, stmt)
+#define CATCH_RETURN_Tensor(stmt) CATCH_RETURN_RES(Tensor, nullptr, stmt)
 
-// Return undefined tensors as NULL to C#
+// Return undefined tensors as nullptr to C#
 inline Tensor ResultTensor(const at::Tensor & res)
 {
     if (res.defined())
         return new torch::Tensor(res);
     else
-        return NULL;
+        return nullptr;
 }
 
 #define CATCH_TENSOR(expr) \
@@ -253,7 +253,7 @@ NNModule create_module(NNAnyModule* outAsAnyModule)
 
     // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
     // a Module can only be boxed to AnyModule at the point its static type is known).
-    if (outAsAnyModule != NULL)
+    if (outAsAnyModule != nullptr)
     {
         auto wrapped = std::make_shared<torch::nn::AnyModule>(torch::nn::ModuleHolder<TImpl>(*mod));
         *outAsAnyModule = new std::shared_ptr<torch::nn::AnyModule>(wrapped);
@@ -269,7 +269,7 @@ NNModule create_module(const TOptions& opts, NNAnyModule* outAsAnyModule)
 
     // Keep a boxed version of the module in case we add it to a Sequential later (the C++ templating means
     // a Module can only be boxed to AnyModule at the point its static type is known).
-    if (outAsAnyModule != NULL)
+    if (outAsAnyModule != nullptr)
     {
         auto wrapped = std::make_shared<torch::nn::AnyModule>(torch::nn::ModuleHolder<TImpl>(*mod));
         *outAsAnyModule = new std::shared_ptr<torch::nn::AnyModule>(wrapped);


### PR DESCRIPTION
While NULL is defined as 0 which is a valid default value for the float, the default value should be 0.0f

This fixes the compiler warning:
```
TorchSharp/src/Native/LibTorchSharp/THSTensor.cpp(389,5): error G13A67890: converting to non-pointer type ‘float’ from NULL [-Werror=conversion-null] [TorchSharp/src/Native/build.proj]
    389 |     CATCH_RETURN(float, NULL, (float)(tensor->data_ptr<c10::Half>())[i]);
        |     ^~~~~~~~~~~~
```