### PR TITLE
Use Mock Imager in TorchVisionUtils unit tests

### DIFF
--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -55,6 +55,12 @@
   </ItemGroup>
 
   <ItemGroup>
+      <AssemblyAttribute Include="Xunit.CollectionBehavior">
+          <_Parameter1>DisableTestParallelization=true</_Parameter1>
+      </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="..\TorchSharpTest\linrelu.script.dat" Link="linrelu.script.dat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
       <AssemblyAttribute Include="Xunit.CollectionBehavior">
           <_Parameter1>DisableTestParallelization=true</_Parameter1>
+          <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
       </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/TorchSharpTest/TestTorchVisionUtils.cs
+++ b/test/TorchSharpTest/TestTorchVisionUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Xunit;
 
@@ -5,14 +6,37 @@ namespace TorchSharp
 {
     public class TestTorchVisionUtils
     {
+        private class MockImager : torchvision.io.Imager
+        {
+#region " Mock implementation "
+            public override torch.Tensor DecodeImage(Stream stream, torchvision.io.ImageReadMode mode = torchvision.io.ImageReadMode.UNCHANGED)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override torch.Tensor DecodeImage(byte[] data, torchvision.io.ImageReadMode mode = torchvision.io.ImageReadMode.UNCHANGED)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void EncodeImage(torch.Tensor image, torchvision.ImageFormat format, Stream stream)
+            {
+            }
+
+            public override byte[] EncodeImage(torch.Tensor image, torchvision.ImageFormat format)
+            {
+                throw new NotImplementedException();
+            }
+#endregion
+        }
+
         [Fact]
         public void Save_Image_TestMemoryUsage()
         {
-            var imager = new torchvision.io.SkiaImager();
-            using var ms = new MemoryStream();
+            var imager = new MockImager();
             using var image = torch.randn(32, 3, 32, 32);
             using (var d = torch.NewDisposeScope()) {
-                torchvision.utils.save_image(image, ms, torchvision.ImageFormat.Png, imager: imager);
+                torchvision.utils.save_image(image, (Stream)null, torchvision.ImageFormat.Png, imager: imager);
                 Assert.Equal(0, d.DisposablesCount);
             }
         }

--- a/test/TorchSharpTest/TorchSharpTest.csproj
+++ b/test/TorchSharpTest/TorchSharpTest.csproj
@@ -110,6 +110,12 @@
   </ItemGroup>
 
   <ItemGroup>
+      <AssemblyAttribute Include="Xunit.CollectionBehavior">
+          <_Parameter1>DisableTestParallelization=true</_Parameter1>
+      </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.2.0" Condition="'$(TargetFramework)' != 'net472'" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Tensors" Version="7.0.0-rtm.22518.5" />

--- a/test/TorchSharpTest/TorchSharpTest.csproj
+++ b/test/TorchSharpTest/TorchSharpTest.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
       <AssemblyAttribute Include="Xunit.CollectionBehavior">
           <_Parameter1>DisableTestParallelization=true</_Parameter1>
+          <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
       </AssemblyAttribute>
   </ItemGroup>
 


### PR DESCRIPTION
This should make the `Save_Image_TestMemoryUsage` unit test more stable, the following error was observed in the CI build:

```
TorchSharp.TestTorchVisionUtils.Save_Image_TestMemoryUsage [FAIL]
  Failed TorchSharp.TestTorchVisionUtils.Save_Image_TestMemoryUsage [47 ms]
  Error Message:
   System.AccessViolationException : Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
  Stack Trace:
     at SkiaSharp.SKBitmap..ctor()
   at TorchSharp.torchvision.io.SkiaImager.EncodeImage(Tensor image, ImageFormat format, Stream stream) in D:\a\1\s\src\TorchVision\IO\SkiaSharpImager.cs:line 40
   at TorchSharp.torchvision.utils.save_image(Tensor tensor, Stream filestream, ImageFormat format, Int64 nrow, Int32 padding, Boolean normalize, Nullable`1 value_range, Boolean scale_each, Double pad_value, Imager imager) in D:\a\1\s\src\TorchVision\Utils.cs:line 221
   at TorchSharp.TestTorchVisionUtils.Save_Image_TestMemoryUsage() in D:\a\1\s\test\TorchSharpTest\TestTorchVisionUtils.cs:line 15
```