### PR TITLE
Update to SkiaSharp 2.88.6

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,13 +2,17 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+## NuGet Version 0.100.6
+
+__Bug Fixes__:
+
+Update to SkiaSharp 2.88.6 to avoid the libwebp vulnerability.<br/>
+
 ## NuGet Version 0.100.5
 
 __Breaking Changes__:
 
 Inplace operators no longer create an alias, but instead return 'this'. This change will impact any code that explicitly calls `Dispose` on a tensor after the operation.
-
-__API Changes__:
 
 __Bug Fixes__:
 

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>100</MinorVersion>
-    <PatchVersion>5</PatchVersion>
+    <PatchVersion>6</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -26,7 +26,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="SharpZipLib" Version="1.4.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 

--- a/src/TorchSharp/TorchSharp.csproj
+++ b/src/TorchSharp/TorchSharp.csproj
@@ -30,7 +30,8 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.21.9" />
     <PackageReference Include="SharpZipLib" Version="1.4.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 

--- a/src/TorchVision/TorchVision.csproj
+++ b/src/TorchVision/TorchVision.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TorchSharpTest/TestJIT.cs
+++ b/test/TorchSharpTest/TestJIT.cs
@@ -6,7 +6,6 @@ using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using Xunit;
 
-#if false
 #nullable enable
 
 namespace TorchSharp
@@ -14,6 +13,7 @@ namespace TorchSharp
     [Collection("Sequential")]
     public class TestJIT
     {
+#if false
         [Fact]
         public void TestLoadJIT_Func()
         {
@@ -445,6 +445,6 @@ namespace TorchSharp
                 Assert.Equal(w, zArr[3]);
             }
         }
+#endif
     }
 }
-#endif


### PR DESCRIPTION
SkiaSharp was affected by the WEBP vulnerability, which was addressed in v2.88.6