### PR TITLE
Fixed issue #1116, where gradients were not tracked after moving a tensor to CUDA.

### DIFF
--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -1796,7 +1796,7 @@ Tensor THSTensor_to_device(const Tensor tensor, const int device_type, const int
 {
     CATCH_RETURN_Tensor(
         auto device = c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index);
-    res = ResultTensor(tensor->to(device, false, copy));
+        res = ResultTensor(tensor->to(device, false, copy));
     );
 }
 

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -919,6 +919,8 @@ EXPORT_API(Tensor) THSTensor_new(
     const int64_t* sizes,
     const int szlength,
     int8_t scalar_type,
+    const int device_type,
+    const int device_index,
     const bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_frombuffer(
@@ -927,6 +929,8 @@ EXPORT_API(Tensor) THSTensor_frombuffer(
     const int64_t count,
     const ptrdiff_t offset,
     int8_t scalar_type,
+    const int device_type,
+    const int device_index,
     const bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_newInt64(
@@ -934,6 +938,8 @@ EXPORT_API(Tensor) THSTensor_newInt64(
     void (*deleter)(void*),
     const int64_t* sizes,
     const int szlength,
+    const int device_type,
+    const int device_index,
     const bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_newFloat16(
@@ -942,6 +948,8 @@ EXPORT_API(Tensor) THSTensor_newFloat16(
     void (*deleter)(void*),
     const int64_t* sizes,
     const int szlength,
+    const int device_type,
+    const int device_index,
     const bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_newBFloat16(
@@ -950,6 +958,8 @@ EXPORT_API(Tensor) THSTensor_newBFloat16(
     void (*deleter)(void*),
     const int64_t* sizes,
     const int szlength,
+    const int device_type,
+    const int device_index,
     const bool requires_grad);
 
 EXPORT_API(Tensor) THSTensor_newInt8Scalar(int8_t data, const int device_type, const int device_index, bool requires_grad);

--- a/src/Native/LibTorchSharp/THSTensorFactories.cpp
+++ b/src/Native/LibTorchSharp/THSTensorFactories.cpp
@@ -153,7 +153,14 @@ Tensor THSTensor_logspace(const double start, const double end, const int64_t st
 }
 
 
-Tensor THSTensor_from_file(const char* filename, const int8_t shared, const int64_t size, const int8_t scalar_type, const int device_type, const int device_index, const bool requires_grad)
+Tensor THSTensor_from_file(
+    const char* filename,
+    const int8_t shared,
+    const int64_t size,
+    const int8_t scalar_type,
+    const int device_type,
+    const int device_index,
+    const bool requires_grad)
 {
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(scalar_type))
@@ -171,13 +178,26 @@ Tensor THSTensor_new(
     const int64_t* sizes,
     const int szlength,
     int8_t scalar_type,
+    const int device_type,
+    const int device_index,
     const bool requires_grad)
 {
+    bool move = device_type != 0;
+
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(scalar_type))
-        .requires_grad(requires_grad);
+        .requires_grad(requires_grad && !move);
 
-    CATCH_TENSOR(torch::from_blob(data, at::ArrayRef<int64_t>(sizes, szlength), deleter, options));
+    CATCH(
+        auto res = torch::from_blob(data, at::ArrayRef<int64_t>(sizes, szlength), deleter, options);
+        if (move) // Not CPU
+        {
+            auto device = c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index);
+            res = res.to(device, false, false).set_requires_grad(requires_grad);
+        }
+        return ResultTensor(res);
+    );
+    return nullptr;
 }
 
 Tensor THSTensor_frombuffer(
@@ -186,14 +206,27 @@ Tensor THSTensor_frombuffer(
     const int64_t count,
     const ptrdiff_t offset,
     int8_t scalar_type,
+    const int device_type,
+    const int device_index,
     const bool requires_grad)
 {
+    bool move = device_type != 0;
+
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(scalar_type))
-        .requires_grad(requires_grad);
+        .requires_grad(requires_grad && !move);
 
     auto dataPtr = reinterpret_cast<char*>(data);
-    CATCH_TENSOR(torch::from_blob(dataPtr+offset, at::ArrayRef<int64_t>(count), deleter, options));
+    CATCH(
+        auto res = torch::from_blob(dataPtr + offset, at::ArrayRef<int64_t>(count), deleter, options);
+        if (move) // Not CPU
+        {
+            auto device = c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index);
+            res = res.to(device, false, false).set_requires_grad(requires_grad);
+        }
+        return ResultTensor(res);
+    );
+    return nullptr;
 }
 
 Tensor THSTensor_newInt64(
@@ -201,12 +234,27 @@ Tensor THSTensor_newInt64(
     void (*deleter)(void*),
     const int64_t* sizes,
     const int szlength,
+    const int device_type,
+    const int device_index,
     const bool requires_grad)
 {
+    bool move = device_type != 0;
+
     auto options = at::TensorOptions()
         .dtype(at::ScalarType(at::kLong))
-        .requires_grad(requires_grad);
-    CATCH_TENSOR(torch::from_blob(data, at::ArrayRef<int64_t>(sizes, szlength), deleter, options));
+        .requires_grad(requires_grad && !move);
+
+    auto dataPtr = reinterpret_cast<char*>(data);
+    CATCH(
+        auto res = torch::from_blob(data, at::ArrayRef<int64_t>(sizes, szlength), deleter, options);
+        if (move) // Not CPU
+        {
+            auto device = c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index);
+            res = res.to(device, false, false).set_requires_grad(requires_grad);
+        }
+        return ResultTensor(res);
+    );
+    return nullptr;
 }
 
 // The data is passed in as float and copied into the array of Half in the C++ code
@@ -217,18 +265,28 @@ Tensor THSTensor_newFloat16(
     void (*deleter)(void*),
     const int64_t* sizes,
     const int szlength,
+    const int device_type,
+    const int device_index,
     const bool requires_grad)
 {
+    bool move = device_type != 0;
     CATCH_RETURN_Tensor(
         int64_t sz = 1;
         for (int k = 0; k < szlength; k++)
             sz *= sizes[k];
         for (int64_t i = 0; i < sz; i++)
             dataArray[i] = (c10::Half)rawArray[i];
+
         auto options = at::TensorOptions()
-            .dtype(at::ScalarType(at::kHalf))
-            .requires_grad(requires_grad);
-        res = ResultTensor(torch::from_blob(dataArray, at::ArrayRef<int64_t>(sizes, szlength), deleter, options));
+            .dtype(at::ScalarType(at::kLong))
+            .requires_grad(requires_grad && !move);
+        auto r = torch::from_blob(dataArray, at::ArrayRef<int64_t>(sizes, szlength), deleter, options);
+        if (move) // Not CPU
+        {
+            auto device = c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index);
+            r = r.to(device, false, false).set_requires_grad(requires_grad);
+        }
+        res = ResultTensor(r);
     )
 }
 
@@ -240,19 +298,29 @@ Tensor THSTensor_newBFloat16(
     void (*deleter)(void*),
     const int64_t* sizes,
     const int szlength,
+    const int device_type,
+    const int device_index,
     const bool requires_grad)
 {
+    bool move = device_type != 0;
     CATCH_RETURN_Tensor(
         int64_t sz = 1;
         for (int k = 0; k < szlength; k++)
             sz *= sizes[k];
         for (int64_t i = 0; i < sz; i++)
             dataArray[i] = (c10::BFloat16)rawArray[i];
+
         auto options = at::TensorOptions()
-            .dtype(at::ScalarType(at::kBFloat16))
-            .requires_grad(requires_grad);
-        res = ResultTensor(torch::from_blob(dataArray, at::ArrayRef<int64_t>(sizes, szlength), deleter, options));
-    )
+            .dtype(at::ScalarType(at::kLong))
+            .requires_grad(requires_grad && !move);
+        auto r = torch::from_blob(dataArray, at::ArrayRef<int64_t>(sizes, szlength), deleter, options);
+        if (move) // Not CPU
+        {
+            auto device = c10::Device((c10::DeviceType)device_type, (c10::DeviceIndex)device_index);
+            r = r.to(device, false, false).set_requires_grad(requires_grad);
+        }
+        res = ResultTensor(r);
+        )
 }
 
 Tensor THSTensor_newInt8Scalar(int8_t data, const int device_type, const int device_index, bool requires_grad)

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSTensor.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSTensor.cs
@@ -1372,13 +1372,13 @@ namespace TorchSharp.PInvoke
         internal static extern IntPtr THSTensor_newComplexFloat64Scalar(double real, double imaginary, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         [DllImport("LibTorchSharp")]
-        internal static extern IntPtr THSTensor_frombuffer(IntPtr rawArray, GCHandleDeleter deleter, long count, long offset, sbyte type, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+        internal static extern IntPtr THSTensor_frombuffer(IntPtr rawArray, GCHandleDeleter deleter, long count, long offset, sbyte type, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         [DllImport("LibTorchSharp")]
-        internal static extern IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, sbyte type, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+        internal static extern IntPtr THSTensor_new(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, sbyte type, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         [DllImport("LibTorchSharp")]
-        internal static extern IntPtr THSTensor_newInt64(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
+        internal static extern IntPtr THSTensor_newInt64(IntPtr rawArray, GCHandleDeleter deleter, IntPtr dimensions, int numDimensions, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);
 
         [DllImport("LibTorchSharp")]
         internal static extern IntPtr THSTensor_rand(IntPtr generator, IntPtr psizes, int length, sbyte scalarType, int deviceType, int deviceIndex, [MarshalAs(UnmanagedType.U1)] bool requires_grad);

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -1900,6 +1900,12 @@ namespace TorchSharp
             var x = torch.randn(new long[] { 64, 1000 }, requires_grad: true);
             var y = torch.randn(new long[] { 64, 10 }, requires_grad: true);
 
+            if (torch.cuda.is_available()) {
+                x = x.cuda();
+                y = y.cuda();
+                seq = seq.cuda();
+            }
+
             var eval = seq.call(x);
             var loss = MSELoss(Reduction.Sum);
             var output = loss.call(eval, y);

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -1180,5 +1180,117 @@ namespace TorchSharp
             Assert.Equal(expectedShape, functional.max_pool3d(t, new long[] { 2, 2, 2 }).shape);
             Assert.Equal(expectedShape, functional.max_pool3d_with_indices(t, new long[] { 2, 2, 2 }).output.shape);
         }
+
+        [Fact]
+        public void Validate1116_1()
+        {
+            foreach (var device in TestUtils.AvailableDevices()) {
+                var x1 = torch.tensor(new double[] { 1.0, 3.0 }, device: device, requires_grad: true);
+                Assert.True(x1.requires_grad);
+                Assert.Equal(device.type, x1.device.type);
+
+                var x2 = x1 * x1;
+                var example = x2.sum();
+
+                example.backward();
+
+                var grads = x1.grad();
+                Assert.True(x1.requires_grad);
+                Assert.NotNull(grads);
+            }
+        }
+
+        [Fact]
+        public void Validate1116_2()
+        {
+            foreach (var device in TestUtils.AvailableDevices()) {
+                var x1 = torch.arange(1, 10, dtype: torch.float32, device: device, requires_grad: true);
+                Assert.True(x1.requires_grad);
+                Assert.Equal(device.type, x1.device.type);
+
+                var x2 = x1 * x1;
+                var example = x2.sum();
+
+                example.backward();
+
+                var grads = x1.grad();
+                Assert.True(x1.requires_grad);
+                Assert.NotNull(grads);
+            }
+        }
+
+        [Fact]
+        public void Validate1116_3()
+        {
+            var x1 = torch.frombuffer(new double[] { 1.0, 3.0 }, torch.float64, requires_grad: true);
+            Assert.True(x1.requires_grad);
+            Assert.Equal(DeviceType.CPU, x1.device.type);
+
+            var x2 = x1 * x1;
+            var example = x2.sum();
+
+            example.backward();
+
+            var grads = x1.grad();
+            Assert.True(x1.requires_grad);
+            Assert.NotNull(grads);
+        }
+
+        [Fact]
+        public void Validate1116_4()
+        {
+            foreach (var device in TestUtils.AvailableDevices()) {
+                var x1 = torch.linspace(1, 10, 5, dtype: torch.float32, device: device, requires_grad: true);
+                Assert.True(x1.requires_grad);
+                Assert.Equal(device.type, x1.device.type);
+
+                var x2 = x1 * x1;
+                var example = x2.sum();
+
+                example.backward();
+
+                var grads = x1.grad();
+                Assert.True(x1.requires_grad);
+                Assert.NotNull(grads);
+            }
+        }
+
+        [Fact]
+        public void Validate1116_5()
+        {
+            foreach (var device in TestUtils.AvailableDevices()) {
+                var x1 = torch.logspace(1, 10, 5, dtype: torch.float32, device: device, requires_grad: true);
+                Assert.True(x1.requires_grad);
+                Assert.Equal(device.type, x1.device.type);
+
+                var x2 = x1 * x1;
+                var example = x2.sum();
+
+                example.backward();
+
+                var grads = x1.grad();
+                Assert.True(x1.requires_grad);
+                Assert.NotNull(grads);
+            }
+        }
+
+        [Fact]
+        public void Validate1116_6()
+        {
+            foreach (var device in TestUtils.AvailableDevices()) {
+                var x1 = torch.eye(1, 10, dtype: torch.float32, device: device, requires_grad: true);
+                Assert.True(x1.requires_grad);
+                Assert.Equal(device.type, x1.device.type);
+
+                var x2 = x1 * x1;
+                var example = x2.sum();
+
+                example.backward();
+
+                var grads = x1.grad();
+                Assert.True(x1.requires_grad);
+                Assert.NotNull(grads);
+            }
+        }
     }
 }


### PR DESCRIPTION
The problem was that if a tensor was first created with 'requires_grad' on CPU, the moved to GPU, the gradient tensor would remain on CPU as far as the C++ object was concerned but remained uninitialized and therefore appear as 'null' in C#. 

The fix is not to set `requires_grad` on the tensor until it has already been moved to GPU.