### PR TITLE
BugFix: When loading non-strict, make sure to read in the tensor bytes

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,12 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+## NuGet Version 0.101.2
+
+__Bug Fixes__:
+
+Fixed byte stream advancement issue in non-strict mode, ensuring proper skipping of non-existent parameters while loading models.
+
 ## NuGet Version 0.101.1
 
 This is a fast-follower bug fix release, addressing persistent issues with stability of using TorchScript from TorchSharp.

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>101</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -997,8 +997,13 @@ namespace TorchSharp
                             if (!found && strict)
                                 throw new ArgumentException($"Mismatched module state names: the target modules does not have a submodule or buffer named '{key}'");
 
-                            if (found) {
-                                sd[key].Load(reader, skip: skip.Contains(key));
+                            if (found && !skip.Contains(key)) {
+                                sd[key].Load(reader);
+                            }
+                            else {
+                                // Even if we are skipping this tensor, we need to load it in so that
+                                // the BinaryReader seeks forward in the input stream.
+                                TensorExtensionMethods.Load(reader, skip: true);
                             }
 
                             loadedParameters?.Add(key, found);

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -377,7 +377,12 @@ namespace TorchSharp
         /// </summary>
         /// <param name="tensor">The tensor into which to load serialized data.</param>
         /// <param name="reader">A BinaryReader instance</param>
-        public static void Load(this Tensor tensor, System.IO.BinaryReader reader)
+        /// <param name="skip">If true, the data will be read from the stream, but not copied to the target tensor.</param>
+        /// <remarks>
+        /// Using a skip list only prevents tensors in the target module from being modified, it
+        /// does not alter the logic related to checking for matching tensor element types.
+        /// </remarks>
+        public static void Load(this Tensor tensor, System.IO.BinaryReader reader, bool skip = false)
         {
             // First, read the type
             var type = (ScalarType)reader.Decode();
@@ -395,7 +400,7 @@ namespace TorchSharp
                 totalSize *= loadedShape[i];
             }
 
-            if (!loadedShape.SequenceEqual(tensor.shape))
+            if (!skip && !loadedShape.SequenceEqual(tensor.shape))
                 // We only care about this if the bytes will be written to the tensor.
                 throw new ArgumentException("Mismatched tensor shape while loading. Make sure that the model you are loading into is exactly the same as the origin.");
 

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -413,10 +413,12 @@ namespace TorchSharp
             // This needs to be done even if the tensor is skipped, since we have to advance the input stream.
             var bytes = reader.ReadBytes((int)(totalSize * tensor.ElementSize));
 
-            var device = tensor.device;
-            if (device.type != DeviceType.CPU) tensor.to(CPU);
-            tensor.bytes = bytes;
-            tensor.to(device);
+            if (!skip) {
+                var device = tensor.device;
+                if (device.type != DeviceType.CPU) tensor.to(CPU);
+                tensor.bytes = bytes;
+                tensor.to(device);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added a bug fix where when you load in a model in non-strict mode, if it skips a parameter load it still reads it in so that the BinaryReader can seek forwards to the next tensor. 

NOTE: I also modified the behavior so that if you specify a parameter in the "skip" list, then it no longer requires the dimensions to match. 

I haven't updated the release notes either, what version should I list this bugfix under? 

Also, as part of this feature I wrote a unit test which covers the unit test from the previous PR, so I removed the old one. 