### PR TITLE
Added extension method ScalarType.ElementSize()

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,10 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 ## NuGet Version 0.101.2
 
+__API Changes__:
+
+Added extension method `ScalarType.ElementSize()` to get the size of each element of a given ScalarType.
+
 __Bug Fixes__:
 
 Fixed byte stream advancement issue in non-strict mode, ensuring proper skipping of non-existent parameters while loading models.

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -283,6 +283,31 @@ namespace TorchSharp
         }
 
         /// <summary>
+        /// Get the size of each element of this ScalarType.
+        /// </summary>
+        /// <param name="type">The input type.</param>
+        /// <returns>The element size</returns>
+        /// <exception cref="NotImplementedException">Invalid ScalarType</exception>
+        public static int ElementSize(this ScalarType type)
+        {
+            return type switch {
+                ScalarType.Byte => 1,
+                ScalarType.Int8 => 1,
+                ScalarType.Int16 => 2,
+                ScalarType.Int32 => 4,
+                ScalarType.Int64 => 8,
+                ScalarType.Float16 => 2,
+                ScalarType.Float32 => 4,
+                ScalarType.Float64 => 8,
+                ScalarType.ComplexFloat32 => 8,
+                ScalarType.ComplexFloat64 => 16,
+                ScalarType.Bool => 1,
+                ScalarType.BFloat16 => 2,
+                _ => throw new NotImplementedException()
+            };
+        }
+
+        /// <summary>
         /// Indicates whether a given element type is integral.
         /// </summary>
         /// <param name="type">The input type.</param>


### PR DESCRIPTION
Following the other PR, I wrote an extension method which returns the size of a ScalarType using a big switch. 

Niklas - you initially wrote to write it in ScalarExtensionMethods, but I saw that there were other extension methods written for ScalarType in TensorExtensionMethods, so I thought it more appropriate to be there. If you think otherwise, let me know and I'll move it back to ScalarExtensionMethods. 