### PR TITLE
Added state index ref to optimizer state dict

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,13 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 ## NuGet Version 0.101.3
 
+__Breaking Changes__:
+
+The base `OptimizerState` class was modified and includes two changes:
+
+1. Custom optimizer state objects derived from `OptimizerState` must now explicitly pass the related `torch.nn.Parameter` object to the `OptimizerState` base constructor to maintain correct linkage.
+2. Custom state objects must implement an Initialize function. This function is responsible for initializing the properties of the state. Note that this function can be called as a re-intialization, so proper disposal of the previous tensor objects should be handled.
+
 __API Changes__:
 
 Introduced `InferenceMode`, a block-based scoping class for optimizing TorchSharp model inference by disabling gradient computation and enhancing performance.<br/>

--- a/src/Python/exportsd.py
+++ b/src/Python/exportsd.py
@@ -85,6 +85,10 @@ def _write_conditional_state_tensor(name, state, stream):
             _write_bool(True, stream)
             _write_tensor(buf, stream)
 
+def _check_state_existance(state, p):
+    if not p in state:
+        raise KeyError("Identified a parameter with no initalized state. Please make sure to run `optim.step()` for all the parameters at least once.")
+
 def save_sgd(optim, stream):
 
     sd = optim.state_dict()
@@ -110,6 +114,7 @@ def save_sgd(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_conditional_state_tensor('momentum_buffer', st, stream)           
 
@@ -140,6 +145,7 @@ def save_asgd(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(int(st["step"].item()), stream)
             floats = np.empty(2,dtype=np.float64)
@@ -177,6 +183,7 @@ def save_rprop(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(st["step"], stream)
             _write_tensor(st['prev'], stream)
@@ -210,6 +217,7 @@ def save_rmsprop(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(st["step"], stream)
             _write_tensor(st['square_avg'], stream)
@@ -243,6 +251,7 @@ def save_adam(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(int(st["step"].item()), stream)
             _write_tensor(st['exp_avg'], stream)
@@ -276,6 +285,7 @@ def save_adamw(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(int(st["step"].item()), stream)
             _write_tensor(st['exp_avg'], stream)
@@ -308,6 +318,7 @@ def save_nadam(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(int(st["step"].item()), stream)
             floats = np.empty(1,dtype=np.float64)
@@ -341,6 +352,7 @@ def save_radam(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(int(st["step"].item()), stream)
             _write_tensor(st['exp_avg'], stream)
@@ -371,6 +383,7 @@ def save_adamax(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(int(st["step"].item()), stream)
             _write_tensor(st['exp_avg'], stream)
@@ -400,6 +413,7 @@ def save_adadelta(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(st["step"], stream)
             _write_tensor(st['square_avg'], stream)
@@ -429,6 +443,7 @@ def save_adagrad(optim, stream):
     # Write state
     for group in optim.param_groups:
         for p in group['params']:
+            _check_state_existance(optim.state, p)
             st = optim.state[p]
             _write_int64(int(st["step"].item()), stream)
             _write_tensor(st['sum'], stream)

--- a/src/TorchSharp/Optimizers/ASGD.cs
+++ b/src/TorchSharp/Optimizers/ASGD.cs
@@ -192,6 +192,10 @@ namespace TorchSharp
                 public double mu;
                 public Tensor ax;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -266,9 +270,8 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.ax?.Dispose();
@@ -276,7 +279,7 @@ namespace TorchSharp
                     this.step = 0;
                     this.eta = options.LearningRate.Value;
                     this.mu = 1;
-                    this.ax = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.ax = torch.zeros_like(_parameter).DetachFromDisposeScope();
                 }
             }
 
@@ -307,9 +310,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, opt);
+                    state.Initialize(opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/Adadelta.cs
+++ b/src/TorchSharp/Optimizers/Adadelta.cs
@@ -176,6 +176,10 @@ namespace TorchSharp
                 public Tensor square_avg;
                 public Tensor acc_delta;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -248,17 +252,16 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.square_avg?.Dispose();
                     this.acc_delta?.Dispose();
 
                     this.step = 0;
-                    this.square_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.acc_delta = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.square_avg = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.acc_delta = torch.zeros_like(_parameter).DetachFromDisposeScope();
                 }
             }
 
@@ -288,9 +291,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, param_group.Options);
+                    state.Initialize(param_group.Options);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/Adadelta.cs
+++ b/src/TorchSharp/Optimizers/Adadelta.cs
@@ -244,6 +244,22 @@ namespace TorchSharp
                         square_avg.allclose(rhs.square_avg) &&
                         acc_delta.allclose(rhs.acc_delta);
                 }
+
+                /// <summary>
+                /// Initialize the values of the state to the initial values.
+                /// </summary>
+                /// <param name="p">The parameter the state is attached to</param>
+                /// <param name="options">The optimizer options</param>
+                public override void Initialize(Parameter p, OptimizerOptions options)
+                {
+                    // Dispose the old tensors, if this is a re-initialization.
+                    this.square_avg?.Dispose();
+                    this.acc_delta?.Dispose();
+
+                    this.step = 0;
+                    this.square_avg = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.acc_delta = torch.zeros_like(p).DetachFromDisposeScope();
+                }
             }
 
             /// <summary>
@@ -274,9 +290,7 @@ namespace TorchSharp
                 foreach (var p in param_group.Parameters) {
                     var state = new State();
                     _state[p.Handle] = state;
-                    state.step = 0;
-                    state.square_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    state.acc_delta = torch.zeros_like(p).DetachFromDisposeScope();
+                    state.Initialize(p, param_group.Options);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/Adagrad.cs
+++ b/src/TorchSharp/Optimizers/Adagrad.cs
@@ -186,6 +186,10 @@ namespace TorchSharp
                 public long step;
                 public Tensor sum;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -254,18 +258,17 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.sum?.Dispose();
 
                     this.step = 0;
-                    var init_value = torch.is_complex(p.dtype)
+                    var init_value = torch.is_complex(_parameter.dtype)
                         ? (Scalar)new System.Numerics.Complex((options as Options).initial_accumulator_value.Value, (options as Options).initial_accumulator_value.Value)
                         : (Scalar)(options as Options).initial_accumulator_value.Value;
-                    this.sum = torch.full_like(p, init_value).DetachFromDisposeScope();
+                    this.sum = torch.full_like(_parameter, init_value).DetachFromDisposeScope();
                 }
             }
 
@@ -295,9 +298,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, param_group.Options);
+                    state.Initialize(param_group.Options);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/Adagrad.cs
+++ b/src/TorchSharp/Optimizers/Adagrad.cs
@@ -250,6 +250,23 @@ namespace TorchSharp
                     var rhs = other as State;
                     return (rhs is not null) && step == rhs.step && sum.allclose(rhs.sum);
                 }
+
+                /// <summary>
+                /// Initialize the values of the state to the initial values.
+                /// </summary>
+                /// <param name="p">The parameter the state is attached to</param>
+                /// <param name="options">The optimizer options</param>
+                public override void Initialize(Parameter p, OptimizerOptions options)
+                {
+                    // Dispose the old tensors, if this is a re-initialization.
+                    this.sum?.Dispose();
+
+                    this.step = 0;
+                    var init_value = torch.is_complex(p.dtype)
+                        ? (Scalar)new System.Numerics.Complex((options as Options).initial_accumulator_value.Value, (options as Options).initial_accumulator_value.Value)
+                        : (Scalar)(options as Options).initial_accumulator_value.Value;
+                    this.sum = torch.full_like(p, init_value).DetachFromDisposeScope();
+                }
             }
 
             /// <summary>
@@ -280,11 +297,7 @@ namespace TorchSharp
                 foreach (var p in param_group.Parameters) {
                     var state = new State();
                     _state[p.Handle] = state;
-                    state.step = 0;
-                    var init_value = torch.is_complex(p.dtype)
-                        ? (Scalar)new System.Numerics.Complex((param_group.Options as Options).initial_accumulator_value.Value, (param_group.Options as Options).initial_accumulator_value.Value)
-                        : (Scalar)(param_group.Options as Options).initial_accumulator_value.Value;
-                    state.sum = torch.full_like(p, init_value).DetachFromDisposeScope();
+                    state.Initialize(p, param_group.Options);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/Adam.cs
+++ b/src/TorchSharp/Optimizers/Adam.cs
@@ -211,6 +211,10 @@ namespace TorchSharp
                 public Tensor exp_avg_sq;
                 public Tensor max_exp_avg_sq;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -303,9 +307,8 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values. 
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.exp_avg?.Dispose();
@@ -313,11 +316,11 @@ namespace TorchSharp
                     this.max_exp_avg_sq?.Dispose();
 
                     this.step = 0;
-                    this.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.exp_avg = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.exp_avg_sq = torch.zeros_like(_parameter).DetachFromDisposeScope();
                     this.max_exp_avg_sq = null;
                     if ((options as Options).amsgrad.Value) 
-                        this.max_exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                        this.max_exp_avg_sq = torch.zeros_like(_parameter).DetachFromDisposeScope();
                 }
             }
 
@@ -349,9 +352,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, opt);
+                    state.Initialize(opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/Adam.cs
+++ b/src/TorchSharp/Optimizers/Adam.cs
@@ -299,6 +299,26 @@ namespace TorchSharp
                         exp_avg_sq.allclose(rhs.exp_avg_sq) &&
                         (max_exp_avg_sq is null || max_exp_avg_sq.allclose(rhs.max_exp_avg_sq));
                 }
+
+                /// <summary>
+                /// Initialize the values of the state to the initial values. 
+                /// </summary>
+                /// <param name="p">The parameter the state is attached to</param>
+                /// <param name="options">The optimizer options</param>
+                public override void Initialize(Parameter p, OptimizerOptions options)
+                {
+                    // Dispose the old tensors, if this is a re-initialization.
+                    this.exp_avg?.Dispose();
+                    this.exp_avg_sq?.Dispose();
+                    this.max_exp_avg_sq?.Dispose();
+
+                    this.step = 0;
+                    this.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.max_exp_avg_sq = null;
+                    if ((options as Options).amsgrad.Value) 
+                        this.max_exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                }
             }
 
             /// <summary>
@@ -331,12 +351,7 @@ namespace TorchSharp
                 foreach (var p in param_group.Parameters) {
                     var state = new State();
                     _state[p.Handle] = state;
-                    state.step = 0;
-                    state.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    state.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
-                    if (opt.amsgrad.Value) {
-                        state.max_exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
-                    }
+                    state.Initialize(p, opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/AdamW.cs
+++ b/src/TorchSharp/Optimizers/AdamW.cs
@@ -209,6 +209,10 @@ namespace TorchSharp
                 public Tensor exp_avg_sq;
                 public Tensor max_exp_avg_sq;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -304,9 +308,8 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.exp_avg?.Dispose();
@@ -314,11 +317,11 @@ namespace TorchSharp
                     this.max_exp_avg_sq?.Dispose();
 
                     this.step = 0;
-                    this.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.exp_avg = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.exp_avg_sq = torch.zeros_like(_parameter).DetachFromDisposeScope();
                     this.max_exp_avg_sq = null;
                     if ((options as Options).amsgrad.Value) 
-                        this.max_exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                        this.max_exp_avg_sq = torch.zeros_like(_parameter).DetachFromDisposeScope();
                 }
             }
 
@@ -350,9 +353,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, opt);
+                    state.Initialize(opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/Adamax.cs
+++ b/src/TorchSharp/Optimizers/Adamax.cs
@@ -194,6 +194,10 @@ namespace TorchSharp
                 public Tensor exp_avg;
                 public Tensor exp_inf;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -266,17 +270,16 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.exp_avg?.Dispose();
                     this.exp_inf?.Dispose();
 
                     this.step = 0;
-                    this.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.exp_inf = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.exp_avg = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.exp_inf = torch.zeros_like(_parameter).DetachFromDisposeScope();
                 }
             }
 
@@ -306,9 +309,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, param_group.Options);
+                    state.Initialize(param_group.Options);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/NAdam.cs
+++ b/src/TorchSharp/Optimizers/NAdam.cs
@@ -282,6 +282,23 @@ namespace TorchSharp
                         exp_avg.allclose(rhs.exp_avg) &&
                         exp_avg_sq.allclose(rhs.exp_avg_sq);
                 }
+
+                /// <summary>
+                /// Initialize the values of the state to the initial values.
+                /// </summary>
+                /// <param name="p">The parameter the state is attached to</param>
+                /// <param name="options">The optimizer options</param>
+                public override void Initialize(Parameter p, OptimizerOptions options)
+                {
+                    // Dispose the old tensors, if this is a re-initialization.
+                    this.exp_avg?.Dispose();
+                    this.exp_avg_sq?.Dispose();
+
+                    this.step = 0;
+                    this.mu_product = 1;
+                    this.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                }
             }
 
             /// <summary>
@@ -313,9 +330,7 @@ namespace TorchSharp
                 foreach (var p in param_group.Parameters) {
                     var state = new State();
                     _state[p.Handle] = state;
-                    state.step = 0;
-                    state.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    state.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                    state.Initialize(p, opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/NAdam.cs
+++ b/src/TorchSharp/Optimizers/NAdam.cs
@@ -205,6 +205,10 @@ namespace TorchSharp
                 public Tensor exp_avg;
                 public Tensor exp_avg_sq;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -286,9 +290,8 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.exp_avg?.Dispose();
@@ -296,8 +299,8 @@ namespace TorchSharp
 
                     this.step = 0;
                     this.mu_product = 1;
-                    this.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.exp_avg = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.exp_avg_sq = torch.zeros_like(_parameter).DetachFromDisposeScope();
                 }
             }
 
@@ -328,9 +331,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, opt);
+                    state.Initialize(opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/Optimizer.cs
+++ b/src/TorchSharp/Optimizers/Optimizer.cs
@@ -507,6 +507,15 @@ namespace TorchSharp
         /// </summary>
         public abstract class OptimizerState
         {
+            protected Parameter _parameter;
+            /// <summary>
+            /// Create a new OptimizerState instance linked to a specific parameter
+            /// </summary>
+            /// <param name="parameter">The parameter linked to this state</param>
+            protected OptimizerState(Parameter parameter) {
+                _parameter = parameter;
+            }
+
             /// <summary>
             /// Save the optimizer parameter state to a stream.
             /// </summary>
@@ -538,9 +547,8 @@ namespace TorchSharp
             /// <summary>
             /// Initialize the values of the state to the initial values.
             /// </summary>
-            /// <param name="p">The parameter the state is attached to</param>
             /// <param name="options">The optimizer options</param>
-            public abstract void Initialize(Parameter p, OptimizerOptions options);
+            public abstract void Initialize(OptimizerOptions options);
             
             /// <summary>
             /// Move all the state to the indicated device.

--- a/src/TorchSharp/Optimizers/Optimizer.cs
+++ b/src/TorchSharp/Optimizers/Optimizer.cs
@@ -536,6 +536,13 @@ namespace TorchSharp
             }
 
             /// <summary>
+            /// Initialize the values of the state to the initial values.
+            /// </summary>
+            /// <param name="p">The parameter the state is attached to</param>
+            /// <param name="options">The optimizer options</param>
+            public abstract void Initialize(Parameter p, OptimizerOptions options);
+            
+            /// <summary>
             /// Move all the state to the indicated device.
             /// </summary>
             /// <param name="device">The device to move all state to.</param>

--- a/src/TorchSharp/Optimizers/Optimizer.cs
+++ b/src/TorchSharp/Optimizers/Optimizer.cs
@@ -356,7 +356,6 @@ namespace TorchSharp
             public virtual StateDictionary state_dict()
             {
                 var dict = new StateDictionary();
-
                 int pgidx = -1;
                 int pridx = 0;
                 foreach (var pg in _parameter_groups) {
@@ -367,7 +366,7 @@ namespace TorchSharp
                     dict.StateIndexRef.Add(indexRef);
 
                     foreach (var p in pg.Parameters) {
-                        indexRef.Add(dict.State.Count);
+                        indexRef.Add(pridx);
                         dict.State.Add(_state[p.Handle]);
                         pridx++;
                     }

--- a/src/TorchSharp/Optimizers/Optimizer.cs
+++ b/src/TorchSharp/Optimizers/Optimizer.cs
@@ -149,11 +149,13 @@ namespace TorchSharp
 
                 public class StateDictionary
                 {
-                    internal StateDictionary() { Options = new List<OptimizerOptions>(); State = new List<OptimizerState>(); }
+                    internal StateDictionary() { Options = new List<OptimizerOptions>(); State = new List<OptimizerState>(); StateIndexRef = new List<List<int>>(); }
 
                     public List<OptimizerOptions> Options { get; private set; }
 
                     public List<OptimizerState> State { get; private set; }
+
+                    public List<List<int>> StateIndexRef { get; private set; }
                 }
 
                 public virtual IEnumerable<ILearningRateController> ParamGroups {
@@ -361,11 +363,15 @@ namespace TorchSharp
 
                     dict.Options.Add(pg.Options);
 
-                    foreach (var p in pg.Parameters) {
+                    var indexRef = new List<int>();
+                    dict.StateIndexRef.Add(indexRef);
 
+                    foreach (var p in pg.Parameters) {
+                        indexRef.Add(dict.State.Count);
                         dict.State.Add(_state[p.Handle]);
                         pridx++;
                     }
+
                     pgidx--;
                 }
                 return dict;

--- a/src/TorchSharp/Optimizers/RAdam.cs
+++ b/src/TorchSharp/Optimizers/RAdam.cs
@@ -273,6 +273,22 @@ namespace TorchSharp
                         exp_avg.allclose(rhs.exp_avg) &&
                         exp_avg_sq.allclose(rhs.exp_avg_sq);
                 }
+
+                /// <summary>
+                /// Initialize the values of the state to the initial values.
+                /// </summary>
+                /// <param name="p">The parameter the state is attached to</param>
+                /// <param name="options">The optimizer options</param>
+                public override void Initialize(Parameter p, OptimizerOptions options)
+                {
+                    // Dispose the old tensors, if this is a re-initialization.
+                    this.exp_avg?.Dispose();
+                    this.exp_avg_sq?.Dispose();
+
+                    this.step = 0;
+                    this.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                }
             }
 
             /// <summary>
@@ -303,9 +319,7 @@ namespace TorchSharp
                 foreach (var p in param_group.Parameters) {
                     var state = new State();
                     _state[p.Handle] = state;
-                    state.step = 0;
-                    state.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    state.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                    state.Initialize(p, opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/RAdam.cs
+++ b/src/TorchSharp/Optimizers/RAdam.cs
@@ -201,6 +201,10 @@ namespace TorchSharp
                 public Tensor exp_avg;
                 public Tensor exp_avg_sq;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -277,17 +281,16 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.exp_avg?.Dispose();
                     this.exp_avg_sq?.Dispose();
 
                     this.step = 0;
-                    this.exp_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.exp_avg_sq = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.exp_avg = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.exp_avg_sq = torch.zeros_like(_parameter).DetachFromDisposeScope();
                 }
             }
 
@@ -317,9 +320,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, opt);
+                    state.Initialize(opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/RMSprop.cs
+++ b/src/TorchSharp/Optimizers/RMSprop.cs
@@ -213,6 +213,10 @@ namespace TorchSharp
                 public Tensor momentum_buffer;
                 public Tensor grad_avg;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -296,9 +300,8 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.square_avg?.Dispose();
@@ -306,9 +309,9 @@ namespace TorchSharp
                     this.momentum_buffer?.Dispose();
 
                     this.step = 0;
-                    this.square_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.grad_avg = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.momentum_buffer = torch.zeros_like(p).DetachFromDisposeScope();
+                    this.square_avg = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.grad_avg = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.momentum_buffer = torch.zeros_like(_parameter).DetachFromDisposeScope();
                 }
             }
 
@@ -340,9 +343,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, opt);
+                    state.Initialize(opt);
                 }
             }
             public class Options : Modules.OptimizerOptions

--- a/src/TorchSharp/Optimizers/Rprop.cs
+++ b/src/TorchSharp/Optimizers/Rprop.cs
@@ -213,9 +213,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, opt);
+                    state.Initialize(opt);
                 }
             }
 
@@ -224,6 +224,10 @@ namespace TorchSharp
                 public long step;
                 public Tensor prev;
                 public Tensor step_size;
+
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
 
                 public void Dispose()
                 {
@@ -299,17 +303,16 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     // Dispose the old tensors, if this is a re-initialization.
                     this.prev?.Dispose();
                     this.step_size?.Dispose();
 
                     this.step = 0;
-                    this.prev = torch.zeros_like(p).DetachFromDisposeScope();
-                    this.step_size = p.new_empty(p.shape).fill_((options as Options).LearningRate).DetachFromDisposeScope();
+                    this.prev = torch.zeros_like(_parameter).DetachFromDisposeScope();
+                    this.step_size = _parameter.new_empty(_parameter.shape).fill_((options as Options).LearningRate).DetachFromDisposeScope();
                 }
             }
 

--- a/src/TorchSharp/Optimizers/SGD.cs
+++ b/src/TorchSharp/Optimizers/SGD.cs
@@ -263,6 +263,17 @@ namespace TorchSharp
                     var rhs = other as State;
                     return (rhs is not null) && (momentum_buffer is null || momentum_buffer.allclose(rhs.momentum_buffer));
                 }
+
+                /// <summary>
+                /// Initialize the values of the state to the initial values.
+                /// </summary>
+                /// <param name="p">The parameter the state is attached to</param>
+                /// <param name="options">The optimizer options</param>
+                public override void Initialize(Parameter p, OptimizerOptions options)
+                {
+                    this.momentum_buffer?.Dispose();
+                    this.momentum_buffer = null;
+                }
             }
 
             /// <summary>
@@ -293,8 +304,8 @@ namespace TorchSharp
 
                 foreach (var p in param_group.Parameters) {
                     var state = new State();
-                    _state.Add((p.Handle,state));
-                    state.momentum_buffer = null;
+                    _state[p.Handle] = state;
+                    state.Initialize(p, opt);
                 }
             }
 

--- a/src/TorchSharp/Optimizers/SGD.cs
+++ b/src/TorchSharp/Optimizers/SGD.cs
@@ -200,6 +200,10 @@ namespace TorchSharp
             {
                 public Tensor momentum_buffer;
 
+                public State(Parameter parameter) : base(parameter)
+                {
+                }
+
                 public void Dispose()
                 {
                     Dispose(true);
@@ -267,9 +271,8 @@ namespace TorchSharp
                 /// <summary>
                 /// Initialize the values of the state to the initial values.
                 /// </summary>
-                /// <param name="p">The parameter the state is attached to</param>
                 /// <param name="options">The optimizer options</param>
-                public override void Initialize(Parameter p, OptimizerOptions options)
+                public override void Initialize(OptimizerOptions options)
                 {
                     this.momentum_buffer?.Dispose();
                     this.momentum_buffer = null;
@@ -303,9 +306,9 @@ namespace TorchSharp
                 _parameter_groups.Add(param_group);
 
                 foreach (var p in param_group.Parameters) {
-                    var state = new State();
+                    var state = new State(p);
                     _state[p.Handle] = state;
-                    state.Initialize(p, opt);
+                    state.Initialize(opt);
                 }
             }
 


### PR DESCRIPTION
While adding the functionality for saving the optimizer state_dict in the pytorch format, I encountered an issue that I couldn't resolve externally. 

When looking at an optimizer state_dict in Python, they have an index mapping between the parameter_group and the state group. 

E.g., see here a sample state_dict of an Adam optimizer:

```json
{
  "state": {
      0: {
        "step": tensor(1.),
        "exp_avg": tensor(...),
        "exp_avg_seq": tensor(...)
      },
      1: {
        "step": tensor(1.),
        "exp_avg": tensor(...),
        "exp_avg_seq": tensor(...)
      },
   },
  "param_groups": [
    {
      "lr": 0.001,
      "betas": [
        0.8,
        0.9
      ],
      "eps": 1e-08,
      "weight_decay": 0,
      "amsgrad": false,
      "maximize": false,
      "foreach": null,
      "capturable": false,
      "differentiable": false,
      "fused": null,
      "params": [
        0,
        1
      ]
    }
  ]
}
```

For TorchSharp, there is no need for the params, but PyTorch requires the Params object which maps between the params and the states to be included. 

Therefore, I propose this addition which will include the mapping between parameters the state, without inserting any breaking changes. 