### PR TITLE
Added tensor extension ToArray

### DIFF
--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -699,9 +699,12 @@ namespace TorchSharp
             if (torch.ToScalarType(typeof(T)) != tensor.dtype)
                 throw new ArgumentException("Tensor type different from requested array type");
 
-            using torch.Tensor tmp = tensor.detach();
+            using var d = torch.NewDisposeScope();
+
+            // always move it to the cpu, we can't read gpu bytes
+            tensor = tensor.detach().cpu();
             // Convert the bytes to a float
-            return MemoryMarshal.Cast<byte, T>(tmp.bytes).ToArray();
+            return MemoryMarshal.Cast<byte, T>(tensor.bytes).ToArray();
         }
 
         /// <summary>

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -80,6 +80,138 @@ namespace TorchSharp
         }
 
         [Fact]
+        [TestOf(nameof(TensorExtensionMethods.ToArray))]
+        public void Test1DToArray()
+        {
+            Tensor t = torch.arange(4);
+            // Run the test with int, bool, float
+            {
+                // int test: (0, 1, 2, 3)
+                using var tint = t.@int();
+                int[] arr = tint.ToArray<int>();
+
+                Assert.Equal(4, arr.Length);
+                Assert.Equal(0, arr[0]);
+                Assert.Equal(1, arr[1]);
+                Assert.Equal(2, arr[2]);
+                Assert.Equal(3, arr[3]);
+            }
+            {
+                // bool test: (F, T, T, T)
+                using var tbool = t.@bool();
+                bool[] arr = tbool.ToArray<bool>();
+
+                Assert.Equal(4, arr.Length);
+                Assert.False(arr[0]);
+                Assert.True(arr[1]);
+                Assert.True(arr[2]);
+                Assert.True(arr[3]);
+            }
+            {
+                // float test: multiply by 0.5 to get floating point values (0, 0.5, 1, 1.5)
+                using var tfloat = t.@float() * 0.5;
+                float[] arr = tfloat.ToArray<float>();
+
+                Assert.Equal(4, arr.Length);
+                Assert.Equal(0f, arr[0]);
+                Assert.Equal(0.5f, arr[1]);
+                Assert.Equal(1f, arr[2]);
+                Assert.Equal(1.5f, arr[3]);
+            }
+        }
+
+        [Fact]
+        [TestOf(nameof(TensorExtensionMethods.To2DArray))]
+        public void Test2DToArray()
+        {
+            Tensor t = torch.arange(4).reshape(2, 2);
+            // Run the test with int, bool, float
+            {
+                // int test: (0, 1), (2, 3)
+                using var tint = t.@int();
+                int[,] arr = tint.To2DArray<int>();
+
+                Assert.Equal(2, arr.GetLength(0));
+                Assert.Equal(2, arr.GetLength(1));
+                Assert.Equal(0, arr[0, 0]);
+                Assert.Equal(1, arr[0, 1]);
+                Assert.Equal(2, arr[1, 0]);
+                Assert.Equal(3, arr[1, 1]);
+            }
+            {
+                // bool test: (F, T), (T, T)
+                using var tbool = t.@bool();
+                bool[,] arr = tbool.To2DArray<bool>();
+
+                Assert.Equal(2, arr.GetLength(0));
+                Assert.Equal(2, arr.GetLength(1));
+                Assert.False(arr[0, 0]);
+                Assert.True(arr[0, 1]);
+                Assert.True(arr[1, 0]);
+                Assert.True(arr[1, 1]);
+            }
+            {
+                // float test: multiply by 0.5 to get floating point values (0, 0.5), (1, 1.5)
+                using var tfloat = t.@float() * 0.5;
+                float[,] arr = tfloat.To2DArray<float>();
+
+                Assert.Equal(2, arr.GetLength(0));
+                Assert.Equal(2, arr.GetLength(1));
+                Assert.Equal(0f, arr[0, 0]);
+                Assert.Equal(0.5f, arr[0, 1]);
+                Assert.Equal(1f, arr[1, 0]);
+                Assert.Equal(1.5f, arr[1, 1]);
+            }
+        }
+
+        [Fact]
+        [TestOf(nameof(TensorExtensionMethods.To2DJaggedArray))]
+        public void Test2DToJaggedArray()
+        {
+            Tensor t = torch.arange(4).reshape(2, 2);
+            // Run the test with int, bool, float
+            {
+                // int test: (0, 1), (2, 3)
+                using var tint = t.@int();
+                int[][] arr = tint.To2DJaggedArray<int>();
+
+                Assert.Equal(2, arr.Length);
+                Assert.Equal(2, arr[0].Length);
+                Assert.Equal(2, arr[1].Length);
+                Assert.Equal(0, arr[0][0]);
+                Assert.Equal(1, arr[0][1]);
+                Assert.Equal(2, arr[1][0]);
+                Assert.Equal(3, arr[1][1]);
+            }
+            {
+                // bool test: (F, T), (T, T)
+                using var tbool = t.@bool();
+                bool[][] arr = tbool.To2DJaggedArray<bool>();
+
+                Assert.Equal(2, arr.Length);
+                Assert.Equal(2, arr[0].Length);
+                Assert.Equal(2, arr[1].Length);
+                Assert.False(arr[0][0]);
+                Assert.True(arr[0][1]);
+                Assert.True(arr[1][0]);
+                Assert.True(arr[1][1]);
+            }
+            {
+                // float test: multiply by 0.5 to get floating point values (0, 0.5), (1, 1.5)
+                using var tfloat = t.@float() * 0.5;
+                float[][] arr = tfloat.To2DJaggedArray<float>();
+
+                Assert.Equal(2, arr.Length);
+                Assert.Equal(2, arr[0].Length);
+                Assert.Equal(2, arr[1].Length);
+                Assert.Equal(0f, arr[0][0]);
+                Assert.Equal(0.5f, arr[0][1]);
+                Assert.Equal(1f, arr[1][0]);
+                Assert.Equal(1.5f, arr[1][1]);
+            }
+        }
+
+        [Fact]
         [TestOf(nameof(Tensor.ToString))]
         [TestOf(nameof(TensorExtensionMethods.jlstr))]
         public void ScalarToString()


### PR DESCRIPTION
When using the library, I encountered a need to get the actual content from the Tensor to regular C# arrays, so I wrote this extension - and I thought it could be a useful addition to the library.
As opposed to the .tolist function which is generic and works for any type, this is a strongly typed function which allows you to get the data easily in a strongly typed array without any type checks. 