### PR TITLE
Added to type alias for short, half, bfloat16, cfloat, cdouble

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,12 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+## NuGet Version 0.101.3
+
+__API Changes__:
+
+Added `Tensor.to_type()` conversion aliases for short, half, bfloat16, cfloat, and cdouble.<br/>
+
 ## NuGet Version 0.101.2
 
 __API Changes__:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 __API Changes__:
 
 Added `Tensor.to_type()` conversion aliases for short, half, bfloat16, cfloat, and cdouble.<br/>
+Added `Module.to()` conversion aliases for all the scalar types.<br/>
 
 ## NuGet Version 0.101.2
 

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>101</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>3</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -1728,6 +1728,78 @@ namespace TorchSharp
         /// <param name="module">The module to move</param>
         /// <param name="deviceIndex">If specified, all parameters will be copied to that device</param>
         public static T cuda<T>(this T module, int deviceIndex = -1) where T : torch.nn.Module => (T)module._to(DeviceType.CUDA, deviceIndex);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Bool`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T @bool<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Bool);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Byte`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T @byte<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Byte);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Int8`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T @char<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Int8);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Int16`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T @short<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Int16);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Int32`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T @int<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Int32);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Int64`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T @long<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Int64);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Float16`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T half<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Float16);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.BFloat16`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T bfloat16<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.BFloat16);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Float32`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T @float<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Float32);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.Float64`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T @double<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.Float64);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.ComplexFloat32`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T cfloat<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.ComplexFloat32);
+
+        /// <summary>
+        /// Converts all model parameters and buffers to `ScalarType.ComplexFloat64`.
+        /// </summary>
+        /// <param name="module">The module to convert</param>
+        public static T cdouble<T>(this T module) where T : torch.nn.Module => module.to(ScalarType.ComplexFloat64);
     }
 
     public static class FieldInfoExtensionMethods

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -2967,13 +2967,23 @@ namespace TorchSharp
 
             public Tensor @char() => this.to_type(ScalarType.Int8);
 
+            public Tensor @short() => this.to_type(ScalarType.Int16);
+
             public Tensor @int() => this.to_type(ScalarType.Int32);
 
             public Tensor @long() => this.to_type(ScalarType.Int64);
 
+            public Tensor half() => this.to_type(ScalarType.Float16);
+
+            public Tensor bfloat16() => this.to_type(ScalarType.BFloat16);
+
             public Tensor @float() => this.to_type(ScalarType.Float32);
 
             public Tensor @double() => this.to_type(ScalarType.Float64);
+
+            public Tensor cfloat() => this.to_type(ScalarType.ComplexFloat32);
+
+            public Tensor cdouble() => this.to_type(ScalarType.ComplexFloat64);
 
 
             /// <summary>


### PR DESCRIPTION
Added to_type alias for converting types to `short`, `half`, `bfloat16`, `cfloat`, `cdouble`.