### PR TITLE
Added inference mode context manager

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,12 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+## NuGet Version 0.101.3
+
+__API Changes__:
+
+Introduced `InferenceMode`, a block-based scoping class for optimizing TorchSharp model inference by disabling gradient computation and enhancing performance.<br/>
+
 ## NuGet Version 0.101.2
 
 __API Changes__:

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>101</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>3</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Native/LibTorchSharp/THSAutograd.cpp
+++ b/src/Native/LibTorchSharp/THSAutograd.cpp
@@ -14,6 +14,23 @@ void THSAutograd_setGrad(bool enabled)
     torch::autograd::GradMode::set_enabled(enabled);
 }
 
+bool THSAutograd_isInferenceModeEnabled()
+{
+    bool result = torch::InferenceMode::is_enabled();
+    return result;
+}
+
+torch::InferenceMode* THSAutograd_getInferenceModeGuard(bool mode)
+{
+    auto ptr = new torch::InferenceMode(mode);
+    return ptr;
+}
+
+void THSAutograd_deleteInferenceModeGuard(torch::InferenceMode* ptr)
+{
+    delete ptr;
+}
+
 bool THSAutograd_isAnomalyEnabled()
 {
     bool result = torch::autograd::AnomalyMode::is_enabled();

--- a/src/Native/LibTorchSharp/THSAutograd.h
+++ b/src/Native/LibTorchSharp/THSAutograd.h
@@ -11,6 +11,15 @@ EXPORT_API(bool) THSAutograd_isGradEnabled();
 // Enables / disables grad.
 EXPORT_API(void) THSAutograd_setGrad(bool enabled);
 
+// Returns whether inference mode is enabled or not
+EXPORT_API(bool) THSAutograd_isInferenceModeEnabled();
+
+// Returns a pointer to an RAII guard for inference mode
+EXPORT_API(torch::InferenceMode*) THSAutograd_getInferenceModeGuard(bool mode);
+
+// Destroys the RAII guard and restores the original state
+EXPORT_API(void) THSAutograd_deleteInferenceModeGuard(torch::InferenceMode* ptr);
+
 // Returns whether the grad is enabled or not.
 EXPORT_API(bool) THSAutograd_isAnomalyEnabled();
 

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSAutograd.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSAutograd.cs
@@ -16,6 +16,16 @@ namespace TorchSharp.PInvoke
 
         [DllImport("LibTorchSharp")]
         [return: MarshalAs(UnmanagedType.U1)]
+        internal static extern bool THSAutograd_isInferenceModeEnabled();
+
+        [DllImport("LibTorchSharp")]
+        internal static extern IntPtr THSAutograd_getInferenceModeGuard([MarshalAs(UnmanagedType.U1)] bool mode);
+
+        [DllImport("LibTorchSharp")]
+        internal static extern void THSAutograd_deleteInferenceModeGuard(IntPtr guard);
+        
+        [DllImport("LibTorchSharp")]
+        [return: MarshalAs(UnmanagedType.U1)]
         internal static extern bool THSAutograd_isAnomalyEnabled();
 
         [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/Tensor/torch.LocallyDisablingGradientComputation.cs
+++ b/src/TorchSharp/Tensor/torch.LocallyDisablingGradientComputation.cs
@@ -37,11 +37,17 @@ namespace TorchSharp
         [Pure]public static bool is_grad_enabled() => AutoGradMode.IsEnabled;
 
         // https://pytorch.org/docs/stable/generated/torch.inference_mode
-        [Obsolete("not implemented", true)]
-        public static IDisposable inference_mode(bool mode = true) => throw new NotImplementedException();
+        /// <summary>
+        /// Context-manager that enables inference mode.
+        /// </summary>
+        /// <returns></returns>
+        public static IDisposable inference_mode(bool mode = true) => new InferenceMode(mode);
 
         // https://pytorch.org/docs/stable/generated/torch.is_inference_mode_enabled
-        [Obsolete("not implemented", true)]
-        [Pure]public static bool is_inference_mode_enabled() => throw new NotImplementedException();
+        /// <summary>
+        /// Returns true if inference mode mode is currently enabled.
+        /// </summary>
+        /// <returns></returns>
+        [Pure]public static bool is_inference_mode_enabled() => InferenceMode.IsEnabled;
     }
 }

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -259,6 +259,18 @@ namespace TorchSharp
             Assert.False(torch.backends.cuda.math_sdp_enabled());
         }
 
+        [Fact]
+        public void EnableInferenceMode()
+        {
+            Assert.False(torch.is_inference_mode_enabled());
+
+            using (var d = torch.inference_mode()) {
+                Assert.True(torch.is_inference_mode_enabled());
+            }
+
+            Assert.False(torch.is_inference_mode_enabled());
+        }
+
         [Fact(Skip ="Intermittently fails")]
         public void AllowFP16ReductionCuBLAS()
         {


### PR DESCRIPTION
Added support for torch.inference_mode() context manager, for faster evaluation.
In which should file should I add a unit test?

Also, does it make sense for a unit test where I enabled inference_mode, and then call torch.is_inference_mode_enabled() to confirm?