### PR TITLE
Fixed `Module.to()` bugs with `ParameterList` and `ParameterDict`, and with autograd tracking movements between CPU & GPU

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -25,6 +25,8 @@ __Bug Fixes__:
 #1172 : `optim.LoadStateDict` from an existing `StateDictionary` updated to make sure to copy value and to the right device.
 #1176 : When specific `Optimizers` load in a conditional tensor, made sure to copy to the right device.
 #1174 : Loading CUDA tensor from stream threw an error
+#1179 : Calling `Module.to()` with the `ParameterList` and `ParameterDict` module didn't move the parameters stored in the field.
+
 
 ## NuGet Version 0.101.2
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,13 +20,13 @@ All distribution classes now implement IDisposable.<br/>
 
 __Bug Fixes__:
 
-#1154 : `mu_product` was not initialized in `NAdam` optimizer
-#1170 : Calling `torch.nn.rnn.utils.pad_packed_sequence` with a CUDA tensor and unsorted_indices threw an error
-#1172 : `optim.LoadStateDict` from an existing `StateDictionary` updated to make sure to copy value and to the right device.
-#1176 : When specific `Optimizers` load in a conditional tensor, made sure to copy to the right device.
-#1174 : Loading CUDA tensor from stream threw an error
-#1179 : Calling `Module.to()` with the `ParameterList` and `ParameterDict` module didn't move the parameters stored in the field.
-#1148 : Calling `Module.to()` shouldn't be differentiable
+#1154 : `mu_product` was not initialized in `NAdam` optimizer<br/>
+#1170 : Calling `torch.nn.rnn.utils.pad_packed_sequence` with a CUDA tensor and unsorted_indices threw an error<br/>
+#1172 : `optim.LoadStateDict` from an existing `StateDictionary` updated to make sure to copy value and to the right device.<br/>
+#1176 : When specific `Optimizers` load in a conditional tensor, made sure to copy to the right device.<br/>
+#1174 : Loading CUDA tensor from stream threw an error<br/>
+#1179 : Calling `Module.to()` with the `ParameterList` and `ParameterDict` module didn't move the parameters stored in the field.<br/>
+#1148 : Calling `Module.to()` shouldn't be differentiable<br/>
 
 ## NuGet Version 0.101.2
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -26,7 +26,7 @@ __Bug Fixes__:
 #1176 : When specific `Optimizers` load in a conditional tensor, made sure to copy to the right device.
 #1174 : Loading CUDA tensor from stream threw an error
 #1179 : Calling `Module.to()` with the `ParameterList` and `ParameterDict` module didn't move the parameters stored in the field.
-
+#1148 : Calling `Module.to()` shouldn't be differentiable
 
 ## NuGet Version 0.101.2
 

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -268,6 +268,10 @@ namespace TorchSharp
                             field.SetValue(this, t);
                     }
 
+                    if (device is not null) {
+                        _deviceType = device.type;
+                        _deviceIndex = device.index;
+                    }
                 }
 
                 /// <summary>

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -163,66 +163,6 @@ namespace TorchSharp
                     return this;
                 }
 
-                protected void _toEpilog(Device device, ScalarType dtype)
-                {
-                    foreach (var (_, sm) in named_children()) sm._to(device, dtype);
-
-                    var alreadyHandled = new HashSet<IntPtr>();
-
-                    foreach (var field in GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)) {
-
-                        var fieldName = field.ComponentName();
-                        var value = field.GetValue(this);
-
-                        switch (value) {
-                        // This order in which these cases are arranged is significant.
-                        case Parameter param when dtype == param.dtype && device.type == param.device_type && device.index == param.device_index:
-                            alreadyHandled.Add(param.handle);
-                            continue;
-
-                        case Parameter param: {
-                                var t = param.to(dtype, device);
-                                t.retain_grad();
-                                var p = new Parameter(t, param.requires_grad);
-                                field.SetValue(this, p);
-                                ConditionallyRegisterParameter(fieldName, p);
-                                alreadyHandled.Add(p.handle);
-                                break;
-                            }
-
-                        case Tensor tensor when (device.type != tensor.device_type || device.index != tensor.device_index): {
-                                var t = tensor.to(dtype, device);
-                                field.SetValue(this, t);
-                                ConditionallyRegisterBuffer(fieldName, t);
-                                alreadyHandled.Add(t.handle);
-                                break;
-                            }
-
-                        case Tensor tensor:
-                            alreadyHandled.Add(tensor.handle);
-                            break;
-                        }
-                    }
-
-                    foreach (var (name, param) in named_parameters(false).ToList()) {
-                        if (alreadyHandled.Contains(param.handle)) continue;
-                        var t = param.to(dtype, device);
-                        ConditionallyRegisterParameter(name, t);
-                    }
-
-                    foreach (var (name, buffer) in named_buffers(false).ToList()) {
-                        if (alreadyHandled.Contains(buffer.handle)) continue;
-                        var t = buffer.to(dtype, device);
-                        ConditionallyRegisterBuffer(name, t);
-                    }
-
-                    _deviceType = device.type;
-                    _deviceIndex = device.index;
-
-                    Debug.Assert(_deviceType == DeviceType.CUDA || _deviceIndex == -1);
-                }
-
-
                 /// <summary>
                 /// Moves the parameters and buffers.
                 /// </summary>
@@ -249,63 +189,6 @@ namespace TorchSharp
                     return this;
                 }
 
-                protected void _toEpilog(DeviceType deviceType, int deviceIndex)
-                {
-                    foreach (var (_, sm) in named_children()) sm._to(deviceType, deviceIndex);
-
-                    var alreadyHandled = new HashSet<IntPtr>();
-
-                    foreach (var field in GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)) {
-
-                        var fieldName = field.ComponentName();
-                        var value = field.GetValue(this);
-
-                        switch (value) {
-                        // This order in which these cases are arranged is significant.
-                        case Parameter param when deviceType == param.device_type && deviceIndex == param.device_index:
-                            alreadyHandled.Add(param.handle);
-                            continue;
-
-                        case Parameter param: {
-                                var t = param.to(deviceType, deviceIndex);
-                                t.retain_grad();
-                                var p = new Parameter(t, param.requires_grad);
-                                field.SetValue(this, p);
-                                ConditionallyRegisterParameter(fieldName, p);
-                                alreadyHandled.Add(p.handle);
-                                break;
-                            }
-
-                        case Tensor tensor when (deviceType != tensor.device_type || deviceIndex != tensor.device_index): {
-                                var t = tensor.to(deviceType, deviceIndex);
-                                field.SetValue(this, t);
-                                ConditionallyRegisterBuffer(fieldName, t);
-                                alreadyHandled.Add(t.handle);
-                                break;
-                            }
-
-                        case Tensor tensor:
-                            alreadyHandled.Add(tensor.handle);
-                            break;
-                        }
-                    }
-
-                    foreach (var (name, param) in named_parameters(false).ToList()) {
-                        if (alreadyHandled.Contains(param.handle)) continue;
-                        var t = param.to(deviceType, deviceIndex);
-                        ConditionallyRegisterParameter(name, t);
-                    }
-
-                    foreach (var (name, buffer) in named_buffers(false).ToList()) {
-                        if (alreadyHandled.Contains(buffer.handle)) continue;
-                        var t = buffer.to(deviceType, deviceIndex);
-                        ConditionallyRegisterBuffer(name, t);
-                    }
-
-                    _deviceType = deviceType;
-                    _deviceIndex = deviceIndex;
-                }
-
                 private DeviceType _deviceType = DeviceType.CPU;
                 private int _deviceIndex = -1;
 
@@ -325,56 +208,75 @@ namespace TorchSharp
 
                 protected void _toEpilog(ScalarType dtype)
                 {
-                    foreach (var (_, sm) in named_children()) sm._to(dtype);
+                    _toEpilog(dtype, null);
+                }
 
-                    var alreadyHandled = new HashSet<IntPtr>();
+                protected void _toEpilog(Device device, ScalarType dtype)
+                {
+                    _toEpilog(dtype, device);
+                }
 
-                    foreach (var field in GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)) {
+                protected void _toEpilog(DeviceType deviceType, int deviceIndex)
+                {
+                    _toEpilog(null, new Device(deviceType, deviceIndex));
+                }
 
-                        var fieldName = field.ComponentName();
-                        var value = field.GetValue(this);
-
-                        switch (value) {
-                        // This order in which these cases are arranged is significant.
-                        case Parameter param when dtype == param.dtype:
-                            alreadyHandled.Add(param.handle);
-                            continue;
-
-                        case Parameter param: {
-                                var t = param.to(dtype);
-                                t.retain_grad();
-                                var p = new Parameter(t, param.requires_grad);
-                                field.SetValue(this, p);
-                                ConditionallyRegisterParameter(fieldName, p);
-                                alreadyHandled.Add(p.handle);
-                                break;
-                            }
-
-                        case Tensor tensor when dtype == tensor.dtype:
-                            alreadyHandled.Add(tensor.handle);
-                            continue;
-
-                        case Tensor tensor: {
-                                var t = tensor.to(dtype);
-                                field.SetValue(this, t);
-                                ConditionallyRegisterBuffer(fieldName, t);
-                                alreadyHandled.Add(t.handle);
-                                break;
-                            }
-                        }
+                private void _toEpilog(ScalarType? dtype, Device device)
+                {
+                    foreach (var (_, sm) in named_children()) {
+                        if (device is null) sm._to(dtype.Value);
+                        else if (dtype is null) sm._to(device.type, device.index);
+                        else sm._to(device, dtype.Value);
                     }
 
+                    // Define our validation function
+                    bool willMove(Tensor tensor)
+                    {
+                        return (dtype is not null && dtype.Value != tensor.dtype) ||
+                            (device is not null && (device.type != tensor.device_type || device.index != tensor.device_index));
+                    }
+                    // Define our to function
+                    Tensor toFunc(Tensor tensor)
+                    {
+                        if (device is null)
+                            return tensor.to(dtype.Value, disposeAfter: true);
+                        else if (dtype is null)
+                            return tensor.to(device.type, device.index, disposeAfter: true);
+                        else return tensor.to(dtype.Value, device, disposeAfter: true);
+                    }
+
+                    var fieldsByComponentName = GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+                                                            .ToDictionary(field => field.ComponentName());
+
                     foreach (var (name, param) in named_parameters(false).ToList()) {
-                        if (alreadyHandled.Contains(param.handle)) continue;
-                        var t = param.to(dtype);
-                        ConditionallyRegisterParameter(name, t);
+                        if (!willMove(param)) continue;
+                        
+                        // Store the requires_grad flag ahead, since we dispose the parameter after moving
+                        bool requiresGrad = param.requires_grad;
+                        Parameter p;
+                        // When moving the parameter, we don't want the autograd to track this movement on the graph.
+                        // In addition, we need the new tensor to be a leaf to accumulate gradients, so if we didn't
+                        // disable grad we would need to call .detach() on the moved tensor.
+                        using (var d = torch.no_grad())
+                            p = new Parameter(toFunc(param), requiresGrad);
+                        ConditionallyRegisterParameter(name, p);
+
+                        // If this parameter is a field, set it
+                        if (fieldsByComponentName.TryGetValue(name, out var field))
+                            field.SetValue(this, p);
                     }
 
                     foreach (var (name, buffer) in named_buffers(false).ToList()) {
-                        if (alreadyHandled.Contains(buffer.handle)) continue;
-                        var t = buffer.to(dtype);
+                        if (!willMove(buffer)) continue;
+                        
+                        // Buffers don't get grads so we don't need to detach them afterwards
+                        var t = toFunc(buffer);
                         ConditionallyRegisterBuffer(name, t);
+
+                        if (fieldsByComponentName.TryGetValue(name, out var field))
+                            field.SetValue(this, t);
                     }
+
                 }
 
                 /// <summary>

--- a/src/TorchSharp/NN/ParameterDict.cs
+++ b/src/TorchSharp/NN/ParameterDict.cs
@@ -60,6 +60,37 @@ namespace TorchSharp
 
             private bool _registered = false;
 
+            protected internal override Module _to(DeviceType deviceType, int deviceIndex = -1)
+            {
+                base._to(deviceType, deviceIndex);
+                _toEpilog();
+                return this;
+            }
+
+            protected internal override Module _to(torch.Device device, torch.ScalarType dtype)
+            {
+                base._to(device, dtype);
+                _toEpilog();
+                return this;
+            }
+
+            protected internal override Module _to(torch.ScalarType dtype)
+            {
+                base._to(dtype);
+                _toEpilog();
+                return this;
+            }
+
+            void _toEpilog()
+            {
+                for (int i = 0; i < _list.Count; i++) {
+                    string name = _list[i].Item1;
+                    var param = base.get_parameter(name);
+                    _list[i] = (name, param);
+                    _dict[name] = param;
+                }
+            }
+
             /// <summary>
             /// Return the ParameterDict values.
             /// </summary>

--- a/src/TorchSharp/NN/ParameterList.cs
+++ b/src/TorchSharp/NN/ParameterList.cs
@@ -33,6 +33,35 @@ namespace TorchSharp
                 _registered = true;
             }
 
+
+            protected internal override Module _to(DeviceType deviceType, int deviceIndex = -1)
+            {
+                base._to(deviceType, deviceIndex);
+                _toEpilog();
+                return this;
+            }
+
+            protected internal override Module _to(torch.Device device, torch.ScalarType dtype)
+            {
+                base._to(device, dtype);
+                _toEpilog();
+                return this;
+            }
+
+            protected internal override Module _to(torch.ScalarType dtype)
+            {
+                base._to(dtype);
+                _toEpilog();
+                return this;
+            }
+
+            void _toEpilog()
+            {
+                for (int i = 0; i < _list.Count; i++) {
+                    _list[i] = base.get_parameter($"{i}");
+                }
+            }
+
             public override IEnumerable<(string name, Parameter parameter)> named_parameters(bool recurse = true)
             {
                 return Enumerable.Range(0, _list.Count).Select(i => ($"{i}", _list[i]));

--- a/src/TorchSharp/Tensor/TensorExtensionMethods.cs
+++ b/src/TorchSharp/Tensor/TensorExtensionMethods.cs
@@ -704,5 +704,66 @@ namespace TorchSharp
             }
             return result;
         }
+
+        /// <summary>
+        /// Checks if calling `Tensor.to()` with the parameters will result in actually copying the tensor.
+        /// </summary>
+        /// <param name="tensor">The tensor</param>
+        /// <param name="device">The device to move to</param>
+        /// <returns>True if the tensor will be copied</returns>
+        internal static bool toWillCopy(this Tensor tensor, Device device)
+        {
+            return tensor.toWillCopy(device.type, device.index);
+        }
+
+        /// <summary>
+        /// Checks if calling `Tensor.to()` with the parameters will result in actually copying the tensor.
+        /// </summary>
+        /// <param name="tensor">The tensor</param>
+        /// <param name="deviceType">The device type to move to</param>
+        /// <param name="deviceIndex">The device index to move to</param>
+        /// <returns>True if the tensor will be copied</returns>
+        internal static bool toWillCopy(this Tensor tensor, DeviceType deviceType, int deviceIndex)
+        {
+            return tensor.device_index != deviceIndex || tensor.device_type != deviceType;
+        }
+
+        /// <summary>
+        /// Checks if calling `Tensor.to()` with the parameters will result in actually copying the tensor.
+        /// </summary>
+        /// <param name="tensor">The tensor</param>
+        /// <param name="dtype">The dtype to move to</param>
+        /// <returns>True if the tensor will be copied</returns>
+        internal static bool toWillCopy(this Tensor tensor, ScalarType dtype)
+        {
+            return tensor.dtype != dtype;
+        }
+
+        /// <summary>
+        /// Checks if calling `Tensor.to()` with the parameters will result in actually copying the tensor.
+        /// </summary>
+        /// <param name="tensor">The tensor</param>
+        /// <param name="dtype">The dtype to move to</param>
+        /// <param name="device">The device to move to</param>
+        /// <returns>True if the tensor will be copied</returns>
+        internal static bool toWillCopy(this Tensor tensor, ScalarType dtype, Device device)
+        {
+            return tensor.toWillCopy(dtype, device.type, device.index);
+        }
+
+        /// <summary>
+        /// Checks if calling `Tensor.to()` with the parameters will result in actually copying the tensor.
+        /// </summary>
+        /// <param name="tensor">The tensor</param>
+        /// <param name="dtype">The dtype to move to</param>
+        /// <param name="deviceType">The device type to move to</param>
+        /// <param name="deviceIndex">The device index to move to</param>
+        /// <returns>True if the tensor will be copied</returns>
+        internal static bool toWillCopy(this Tensor tensor, ScalarType dtype, DeviceType deviceType, int deviceIndex)
+        {
+            return tensor.device_index != deviceIndex || tensor.device_type != deviceType || tensor.dtype != dtype;
+        }
+
+
     }
 }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -3079,9 +3079,9 @@ namespace TorchSharp
             var module = new TestModule1(torch.randn(2, 2), true);
 
             // Move the module to 16-bit floats, and make sure gradients are calculated for all the parameters
-            module.half();
-            var x = torch.randn(2, 2, float16);
-            var y = torch.randn(2, float16);
+            module.@double();
+            var x = torch.randn(2, 2, float64);
+            var y = torch.randn(2, float64);
             torch.nn.functional.mse_loss(module.call(x), y).backward();
             foreach (var (pName, parm) in module.named_parameters()) {
                 var grad = parm.grad();

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -3042,6 +3042,117 @@ namespace TorchSharp
             }
         }
 
+        [Fact]
+        public void TestCustomModuleWithDeviceMove()
+        {
+            if (torch.cuda.is_available()) {
+                var module = new TestModule1(torch.randn(2, 2), true);
+
+                // Move the device to cuda, and make sure gradients are calculated for all the parameters
+                module.to(torch.CUDA);
+                var x = torch.randn(2, 2, device: torch.CUDA);
+                var y = torch.randn(2, device: torch.CUDA);
+                torch.nn.functional.mse_loss(module.call(x), y).backward();
+                foreach (var (pName, parm) in module.named_parameters()) {
+                    var grad = parm.grad();
+                    Assert.NotNull(grad);
+                }
+
+                // Reset and then try again with moving back to CPU
+                module.zero_grad();
+
+                // Try moving back to CPU
+                module.to(torch.CPU);
+                x = torch.randn(2, 2);
+                y = torch.randn(2);
+                torch.nn.functional.mse_loss(module.call(x), y).backward();
+                foreach (var (pName, parm) in module.named_parameters()) {
+                    var grad = parm.grad();
+                    Assert.NotNull(grad);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestCustomModuleWithTypeMove()
+        {
+            var module = new TestModule1(torch.randn(2, 2), true);
+
+            // Move the module to 16-bit floats, and make sure gradients are calculated for all the parameters
+            module.half();
+            var x = torch.randn(2, 2, float16);
+            var y = torch.randn(2, float16);
+            torch.nn.functional.mse_loss(module.call(x), y).backward();
+            foreach (var (pName, parm) in module.named_parameters()) {
+                var grad = parm.grad();
+                Assert.NotNull(grad);
+            }
+
+            // Reset and then try again with moving back to float 32
+            module.zero_grad();
+
+            // Try moving back to float 32
+            module.@float();
+            x = torch.randn(2, 2);
+            y = torch.randn(2);
+            torch.nn.functional.mse_loss(module.call(x), y).backward();
+            foreach (var (pName, parm) in module.named_parameters()) {
+                var grad = parm.grad();
+                Assert.NotNull(grad);
+            }
+        }
+        [Fact]
+        public void TestCustomModuleWithDeviceAndTypeMove()
+        {
+            if (torch.cuda.is_available()) {
+                var module = new TestModule1(torch.randn(2, 2), true);
+
+                // Move the device to cuda & float 16, and make sure gradients are calculated for all the parameters
+                module.to(torch.CUDA, float16);
+                var x = torch.randn(2, 2, float16, torch.CUDA);
+                var y = torch.randn(2, float16, torch.CUDA);
+                torch.nn.functional.mse_loss(module.call(x), y).backward();
+                foreach (var (pName, parm) in module.named_parameters()) {
+                    var grad = parm.grad();
+                    Assert.NotNull(grad);
+                }
+
+                // Reset and then try again with moving back to CPU & float 32
+                module.zero_grad();
+
+                // Try moving back to CPU & float 32
+                module.to(torch.CPU, float32);
+                x = torch.randn(2, 2);
+                y = torch.randn(2);
+                torch.nn.functional.mse_loss(module.call(x), y).backward();
+                foreach (var (pName, parm) in module.named_parameters()) {
+                    var grad = parm.grad();
+                    Assert.NotNull(grad);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestCustomModuleWithMoveAndDisabledGradOnParameter()
+        {
+            var module = new TestModule1(torch.randn(2, 2), true);
+            // Disable grad on test, and make sure that it is able to move and retains the gradient state
+            module.get_parameter("test").requires_grad = false;
+
+            // Move the module to 16-bit floats
+            module.half();
+            Assert.False(module.get_parameter("test").requires_grad);
+
+            // Move to a different device
+            if (torch.cuda.is_available()) {
+                module.cuda();
+                Assert.False(module.get_parameter("test").requires_grad);
+
+                // Try a different device & type
+                module.to(torch.CPU, float32);
+                Assert.False(module.get_parameter("test").requires_grad);
+            }
+        }
 
         [Fact]
         public void TestCustomComponentName()


### PR DESCRIPTION
Fixes https://github.com/dotnet/TorchSharp/issues/1148 and https://github.com/dotnet/TorchSharp/issues/1179.

I went on a whim and attempted to make a style change on the _toEpilog method. If you see a fatal error or prefer to leave it as it used to be - no problem, I'll revert that change.

Main changes:
1] Merged the three _toEpilog methods into one method.
2] Instead of re-iterating the fields every time and reassigning the parameters, I build a dictionary of the fields and as we go through the registered parameters we check if they have a field, and if so - assign it. Saves us from duplicating the code which handles the moving of the parameters.
3] When moving Parameters, we do it in a "torch.no_grad()" scope to avoid having autograd track the movement and so that the resulting tensor will be a leaf.
4] After moving the parameters and buffers, the old ones are disposed. 
5] Overrode the `_to()` method in the `ParameterList` and `ParameterDict` classes. I didn't do it in the `ModuleDict` and `ModuleList` methods since modules themselves don't get a new reference, only their parameters and buffers, and `_toEpilog()` iterates through every registered module.
6] Added `Tensor` extension method `toWillCopy()` which given a set of arguments to `to()` will return whether the tensor will be copied.

Question about the memo properties `_deviceType` and `_deviceIndex`. I see the value in having them, but that can cause an issue if someone calls `.to()` on a sub module, and then tries to call it on the main module() to make sure all the submodules() are aligned, it wont work. Same thing if any of the parameters are moved separately, then calling `Module.to()` wont behave as people expect. 
 
