### PR TITLE
Validate the target data type when converting a Module using `to()`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -27,6 +27,7 @@ __Bug Fixes__:
 #1174 : Loading CUDA tensor from stream threw an error<br/>
 #1179 : Calling `Module.to()` with the `ParameterList` and `ParameterDict` module didn't move the parameters stored in the field.<br/>
 #1148 : Calling `Module.to()` shouldn't be differentiable<br/>
+#1180 : Module.to(ScalarType) has restrictions in PyTorch which aren't restricted in TorchSharp.<br/>
 
 ## NuGet Version 0.101.2
 

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -150,6 +150,9 @@ namespace TorchSharp
                 /// <param name="dtype">The target element type.</param>
                 protected internal virtual Module _to(Device device, ScalarType dtype)
                 {
+                    if (!dtype.IsFloatingPoint() && !dtype.IsComplex())
+                        throw new ArgumentException($"nn.Module.to only accepts floating point or complex types, but got desired dtype={dtype.ToString()}");
+
                     if (device.type != DeviceType.CUDA) { device = new Device(device.type, -1); };
 
                     if (device.type == DeviceType.CUDA && !torch.cuda.is_available()) throw new InvalidOperationException("CUDA is not available.");
@@ -198,6 +201,9 @@ namespace TorchSharp
                 /// <returns></returns>
                 protected internal virtual Module _to(ScalarType dtype)
                 {
+                    if (!dtype.IsFloatingPoint() && !dtype.IsComplex())
+                        throw new ArgumentException($"nn.Module.to only accepts floating point or complex types, but got desired dtype={dtype.ToString()}");
+
                     THSNN_Module_to_dtype(handle, (sbyte)dtype);
                     CheckForErrors();
 

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -3015,6 +3015,20 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestDatatypeToFail()
+        {
+            var mod = new TestModule3();
+            mod.ValidateDtype(torch.float32);
+            Assert.Multiple(
+            () => Assert.Throws<ArgumentException>(() => mod.to(torch.uint8)),
+            () => Assert.Throws<ArgumentException>(() => mod.to(torch.int8)),
+            () => Assert.Throws<ArgumentException>(() => mod.to(torch.int16)),
+            () => Assert.Throws<ArgumentException>(() => mod.to(torch.int32)),
+            () => Assert.Throws<ArgumentException>(() => mod.to(torch.int64))
+            );
+        }
+
+        [Fact]
         public void TestDeviceTo()
         {
             if (torch.cuda.is_available()) {


### PR DESCRIPTION
See #1180 