### PR TITLE
Fixed gradients moving and zeroing

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,13 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 ## NuGet Version 0.101.4
 
+__Bug Fixes__:
+
+#1191 : Having trouble moving a module from one GPU to another with gradients.<br/>
+
+
+## NuGet Version 0.101.4
+
 A fast-follow release addressing a regression in v0.101.3
 
 __Bug Fixes__:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
-## NuGet Version 0.101.4
+## NuGet Version 0.101.5
 
 __Bug Fixes__:
 

--- a/src/Native/LibTorchSharp/THSModule.cpp
+++ b/src/Native/LibTorchSharp/THSModule.cpp
@@ -20,9 +20,9 @@ const char* THSNN_Module_name(const NNModule module)
     return make_sharable_string((*module)->name());
 }
 
-void THSNN_Module_zero_grad(const NNModule module)
+void THSNN_Module_zero_grad(const NNModule module, bool set_to_none)
 {
-    (*module)->zero_grad();
+    (*module)->zero_grad(set_to_none);
 }
 
 void THSNN_Module_to_device(NNModule module, int64_t device, int64_t index)

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -21,7 +21,7 @@ EXPORT_API(void)        THSNN_Module_train(NNModule module, bool on);
 EXPORT_API(long)        THSNN_Module_children_size(const NNModule module);
 EXPORT_API(NNModule)    THSNN_Module_child(const NNModule module, const int index);
 EXPORT_API(const char*) THSNN_Module_name(const NNModule module);
-EXPORT_API(void)        THSNN_Module_zero_grad(const NNModule module);
+EXPORT_API(void)        THSNN_Module_zero_grad(const NNModule module, bool set_to_none);
 EXPORT_API(void)        THSNN_Module_save(const NNModule module, const char* location);
 EXPORT_API(NNModule)    THSNN_Module_load(const char* location);
 EXPORT_API(void)        THSNN_Module_register_buffer(const NNModule module, const char* name, const Tensor submodule);

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -611,6 +611,13 @@ Tensor THSTensor_grad(const Tensor tensor)
     return res;
 }
 
+void THSTensor_set_grad(const Tensor tensor, const Tensor grad)
+{
+    CATCH(
+        tensor->mutable_grad() = *grad;
+    )
+}
+
 Tensor THSTensor_hardsigmoid(const Tensor tensor)
 {
     CATCH_TENSOR(torch::hardsigmoid(*tensor));

--- a/src/Native/LibTorchSharp/THSTensor.cpp
+++ b/src/Native/LibTorchSharp/THSTensor.cpp
@@ -614,7 +614,9 @@ Tensor THSTensor_grad(const Tensor tensor)
 void THSTensor_set_grad(const Tensor tensor, const Tensor grad)
 {
     CATCH(
-        tensor->mutable_grad() = *grad;
+        if (grad == nullptr)
+            tensor->mutable_grad().reset();
+        else tensor->mutable_grad() = *grad;
     )
 }
 

--- a/src/Native/LibTorchSharp/THSTensor.h
+++ b/src/Native/LibTorchSharp/THSTensor.h
@@ -574,6 +574,8 @@ EXPORT_API(void) THSTensor_gcd_(const Tensor tensor, const Tensor other);
 
 EXPORT_API(Tensor) THSTensor_grad(const Tensor tensor);
 
+EXPORT_API(void) THSTensor_set_grad(const Tensor tensor, const Tensor grad);
+
 EXPORT_API(Tensor) THSTensor_gt(const Tensor left, const Tensor right);
 
 EXPORT_API(void) THSTensor_gt_(const Tensor left, const Tensor right);

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -364,7 +364,7 @@ namespace TorchSharp
                         if (grad is not null) {
                             if (set_to_none) {
                                 p.set_grad(null);
-                                grad.Dispose();
+                                grad.DetachFromDisposeScope().Dispose();
                             } else {
                                 grad.zero_();
                             }

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -239,10 +239,10 @@ namespace TorchSharp
                                                             .ToDictionary(field => field.ComponentName());
 
                     foreach (var (name, param) in named_parameters(false).ToList()) {
-                        if (!param.toWillCopy(dtype ?? param.dtype, device ?? param.device)) continue;
+                        if (!param.toWillCopy(dtype ?? param.dtype, device ?? param.device) &&
+                            (param.grad() is null || !param.grad().toWillCopy(dtype ?? param.dtype, device ?? param.device)))
+                            continue;
 
-                        // Store the requires_grad flag ahead, since we dispose the parameter after moving
-                        bool requiresGrad = param.requires_grad;
                         Parameter p;
                         ScalarType paramType =
                             dtype != null && (param.dtype.IsFloatingPoint() || param.dtype.IsComplex()) ? dtype.Value : param.dtype;
@@ -250,10 +250,23 @@ namespace TorchSharp
                         // When moving the parameter, we don't want the autograd to track this movement on the graph.
                         // In addition, we need the new tensor to be a leaf to accumulate gradients, so if we didn't
                         // disable grad we would need to call .detach() on the moved tensor.
-                        using (var d = torch.no_grad())
+                        using (var d = torch.no_grad()) {
                             p = new Parameter(
-                                param.to(paramType, device ?? param.device, disposeAfter: true).DetachFromDisposeScope(), requiresGrad)
+                                param.to(paramType, device ?? param.device).DetachFromDisposeScope(), param.requires_grad)
                                 .DetachFromDisposeScope() as Parameter;
+
+                            // Copy the gradient over as well, if it exists
+                            var grad = param.grad();
+                            if (grad is not null) {
+                                p.set_grad(grad.to(paramType, device ?? param.device)
+                                                .with_requires_grad(grad.requires_grad)
+                                                .DetachFromDisposeScope());
+                            }
+
+                            // Dispose the param and gradient
+                            param.Dispose();
+                            grad?.Dispose();
+                        }
                         ConditionallyRegisterParameter(name, p);
 
                         // If this parameter is a field, set it

--- a/src/TorchSharp/NN/Module.cs
+++ b/src/TorchSharp/NN/Module.cs
@@ -354,15 +354,20 @@ namespace TorchSharp
                     }
                 }
 
-                public virtual void zero_grad()
+                public virtual void zero_grad(bool set_to_none = true)
                 {
-                    THSNN_Module_zero_grad(handle);
+                    THSNN_Module_zero_grad(handle, set_to_none);
                     CheckForErrors();
 
                     foreach (var (_, p) in named_parameters()) {
                         var grad = p.grad();
                         if (grad is not null) {
-                            grad.zero_();
+                            if (set_to_none) {
+                                p.set_grad(null);
+                                grad.Dispose();
+                            } else {
+                                grad.zero_();
+                            }
                         }
                     }
                 }

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSNN.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSNN.cs
@@ -264,7 +264,7 @@ namespace TorchSharp.PInvoke
         internal static extern bool THSNN_Module_is_training(torch.nn.Module.HType module);
 
         [DllImport("LibTorchSharp")]
-        internal static extern void THSNN_Module_zero_grad(torch.nn.Module.HType module);
+        internal static extern void THSNN_Module_zero_grad(torch.nn.Module.HType module, [MarshalAs(UnmanagedType.U1)] bool set_to_none);
 
         [DllImport("LibTorchSharp")]
         internal static extern void THSNN_Module_get_named_parameters(torch.nn.Module.HType module, AllocatePinnedArray allocator1, AllocatePinnedArray allocator2);

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSTensor.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSTensor.cs
@@ -368,6 +368,9 @@ namespace TorchSharp.PInvoke
         internal static extern IntPtr THSTensor_grad(IntPtr handle);
 
         [DllImport("LibTorchSharp")]
+        internal static extern void THSTensor_set_grad(IntPtr handle, IntPtr grad);
+
+        [DllImport("LibTorchSharp")]
         internal static extern IntPtr THSTensor_index(IntPtr tensor, IntPtr indexStarts, IntPtr indexEnds, IntPtr indexSteps, IntPtr indexTensors, int indicesLength);
 
         [DllImport("LibTorchSharp")]

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -1247,13 +1247,12 @@ namespace TorchSharp
             }
 
             /// <summary>
-            /// This function will set the `tensor.grad()` attribute to a custom tensor. Make sure to detach the tensor from
-            /// the dispose scope so it doesn't get disposed early.
+            /// This function will set the `tensor.grad()` attribute to a custom tensor. 
             /// </summary>
             /// <param name="grad">The new gradient tensor</param>
             public void set_grad(Tensor grad)
             {
-                NativeMethods.THSTensor_set_grad(Handle, grad?.Handle ?? IntPtr.Zero);
+                NativeMethods.THSTensor_set_grad(Handle, grad?.DetachFromDisposeScope().Handle ?? IntPtr.Zero);
                 CheckForErrors();
             }
 

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -1253,7 +1253,7 @@ namespace TorchSharp
             /// <param name="grad">The new gradient tensor</param>
             public void set_grad(Tensor grad)
             {
-                NativeMethods.THSTensor_set_grad(Handle, grad.Handle);
+                NativeMethods.THSTensor_set_grad(Handle, grad?.Handle ?? IntPtr.Zero);
                 CheckForErrors();
             }
 

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -1246,6 +1246,17 @@ namespace TorchSharp
                 return new Tensor(res);
             }
 
+            /// <summary>
+            /// This function will set the `tensor.grad()` attribute to a custom tensor. Make sure to detach the tensor from
+            /// the dispose scope so it doesn't get disposed early.
+            /// </summary>
+            /// <param name="grad">The new gradient tensor</param>
+            public void set_grad(Tensor grad)
+            {
+                NativeMethods.THSTensor_set_grad(Handle, grad.Handle);
+                CheckForErrors();
+            }
+
             internal void EncodeIndices(TensorIndex[] indices,
                 out long[] arrKindAndStarts,
                 out long[]? arrStops,


### PR DESCRIPTION
Fixing https://github.com/dotnet/TorchSharp/issues/1191

Modified to behave like PyTorch / LibTorch, see here: https://github.com/pytorch/pytorch/blob/main/torch/csrc/api/src/nn/module.cpp#L253 and https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/module.py#L836

Important to note: This introduces a breaking change, as calling zero_grad() by default now converts gradients to null. 
This is probably a good breaking change, because up until now it wasn't consistent and modules that were managed by LibTorch (like Linear) had their gradients set to null whereas the modules managed by TorchSharp had their gradients set to zero. 