### PR TITLE
Implementation of jacobian method, based on PyTorch implementation

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,6 +13,7 @@ __API Changes__:
 
 #1201: How to access the attributes of a model?<br/>
 #1094: ScriptModule from Stream / ByteArray<br/>
+#1149: Implementation for `torch.autograd.functional.jacobian` to compute Jacobian of a function<br/>
 
 ## NuGet Version 0.101.5
 

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>101</MinorVersion>
-    <PatchVersion>4</PatchVersion>
+    <PatchVersion>5</PatchVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/TorchSharp/Functional.cs
+++ b/src/TorchSharp/Functional.cs
@@ -106,6 +106,40 @@ namespace TorchSharp
                     }
                 }
 
+                /// <summary>
+                /// Computes the jacobian of a given function with one input and one output.
+                /// </summary>
+                /// <param name="function">The function to compute the jacobian for. It has a single input and single output.</param>
+                /// <param name="inputs">The value for the input at which to compute the jacobian.</param>
+                /// <returns>A single tensor containing the jacobian.</returns>
+                public static Tensor jacobian(Func<Tensor, Tensor> function, Tensor inputs)
+                {
+                    var wrapper = new Func<Tensor[], Tensor[]>((Tensor[] x) => {
+                        return new Tensor[] { function(x.Single()) };
+                    });
+                    return jacobian(wrapper, new Tensor[] { inputs }).Single();
+                }
+
+                /// <summary>
+                /// Computes the jacobian of a given function with one input and multiple outputs.
+                /// </summary>
+                /// <param name="function">The function to compute the jacobian for. It has a single input and multiple outputs.</param>
+                /// <param name="inputs">The value for the input at which to compute the jacobian.</param>
+                /// <returns>A list of tensors containing the jacobian for each output.</returns>
+                public static IEnumerable<Tensor> jacobian(Func<Tensor, Tensor[]> function, Tensor inputs)
+                {
+                    var wrapper = new Func<Tensor[], Tensor[]>((Tensor[] x) => {
+                        return function(x.Single());
+                    });
+                    return jacobian(wrapper, new Tensor[] { inputs });
+                }
+
+                /// <summary>
+                /// Computes the jacobian of a given function with multiple inputs and one output.
+                /// </summary>
+                /// <param name="function">The function to compute the jacobian for. It has multiple inputs and single output.</param>
+                /// <param name="inputs">The values for the inputs at which to compute the jacobian.</param>
+                /// <returns>A list of tensors containing the jacobian for the output with respect to each input.</returns>
                 public static IEnumerable<Tensor> jacobian(Func<Tensor[], Tensor> function, params Tensor[] inputs)
                 {
                     var wrapper = new Func<Tensor[], Tensor[]>((Tensor[] x) => {

--- a/src/TorchSharp/Functional.cs
+++ b/src/TorchSharp/Functional.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using static TorchSharp.torch.autograd;
+
+namespace TorchSharp
+{
+    public static partial class torch
+    {
+        public static partial class autograd
+        {
+            public static partial class functional
+            {
+                /// <summary>
+                /// Preprocesses the inputs to make sure they require gradient.
+                /// </summary>
+                /// <param name="need_graph">Specifies if we internally want gradients to flow back to the Tensors in the result.</param>
+                /// <param name="inputs">The tensors to preprocess.</param>
+                /// <returns>The same tensors as inputs, but requiring grad.</returns>
+                private static Tensor[] _grad_preprocess(bool need_graph=true, params Tensor[] inputs)
+                {
+                    List<Tensor> result = new List<Tensor>();
+                    foreach (var input in inputs)
+                    {
+                        result.Add(input.detach().requires_grad_(need_graph));
+                    }
+                    return result.ToArray();
+                }
+
+                /// <summary>
+                /// Wrapper function around torch.autograd.grad.
+                /// </summary>
+                /// <param name="output">The output tensor to compute gradients for.</param>
+                /// <param name="retain_graph">Whether the gradient computation graph should be kept.</param>
+                /// <param name="inputs">The input tensors at which to evaluate the gradients.</param>
+                /// <returns>A collection of gradient tensors for the output with respect to each input.</returns>
+                private static IEnumerable<Tensor> _autograd_grad(Tensor output, bool retain_graph=false, params Tensor[] inputs)
+                {
+                    var outputs = new List<Tensor>
+                    {
+                        output
+                    };
+                    var inputList = new List<torch.Tensor>(inputs);
+                    return torch.autograd.grad(outputs, inputList, retain_graph: retain_graph);
+                }
+
+                /// <summary>
+                /// Computes the jacobian of a given function.
+                /// 
+                /// Example:
+                /// torch.Tensor x1 = torch.tensor(new double[,] { { 1.0, 3.0 }, { 2.0, 4.0 } }, requires_grad: true);
+                /// torch.Tensor intercepts = torch.tensor(new double[] { 1.0, 5.0 }, requires_grad: true);
+                /// 
+                /// torch.Tensor[] jacFunc(torch.Tensor[] inputs)
+                /// {
+                ///     return new torch.Tensor[] { torch.einsum("ij,j->i", inputs[0], inputs[1]) };
+                /// }
+                ///
+                /// var jacobian = torch.autograd.functional.jacobian(jacFunc, x1, intercepts);
+                ///
+                /// jacobian[0] should be:
+                /// [[[1, 5],
+                ///   [0, 0]],
+                ///  [[0, 0],
+                ///   [1, 5]]]
+                /// And jacobian[1]:
+                /// [[1, 3],
+                ///  [2, 4]]
+                ///  
+                /// </summary>
+                /// <param name="function">The function to compute the jacobian for. It may have multiple inputs and multiple outputs.</param>
+                /// <param name="inputs">The values for the inputs at which to compute the jacobian.</param>
+                /// <returns>A list of tensors, one for each output value of each output. For example, a single output with two elements yields two jacobian tensors.</returns>
+                public static IEnumerable<Tensor> jacobian(Func<Tensor[], Tensor[]> function, params Tensor[] inputs)
+                {
+                    List<Tensor> jacobians = new List<Tensor>();
+                    using (enable_grad())
+                    {
+                        inputs = _grad_preprocess(need_graph: true, inputs);
+                        var output = function(inputs);
+                        for (int i = 0; i < output.Length; i++) // i is output variable
+                        {
+                            var jacobian_i = new List<Tensor>[inputs.Length]; // going to have as many elements as there are input variables
+                            for (int k = 0; k < inputs.Length; k++)
+                                jacobian_i[k] = new List<Tensor>();
+                            
+                            for (int j = 0; j < output[i].NumberOfElements; j++)
+                            {
+                                var vj = _autograd_grad(output[i].reshape(-1)[j], retain_graph: true, inputs);
+                                foreach ((List<Tensor> jac_i_el, Tensor vj_el, Tensor inp_el) combi in jacobian_i.Zip(vj, inputs))
+                                {
+                                    if (ReferenceEquals(combi.vj_el, null))
+                                        combi.jac_i_el.Add(zeros_like(combi.inp_el));
+                                    else
+                                        combi.jac_i_el.Add(combi.vj_el);
+                                }
+                            }
+                            foreach ((List<Tensor> jac_i_el, Tensor inp_el) row in jacobian_i.Zip(inputs))
+                            {
+                                jacobians.Add(
+                                    stack(row.jac_i_el, dim: 0)
+                                            .view(output[i].size().Concat(row.inp_el.size()).ToArray())
+                                            .detach() // this is from the _grad_postprocess because create_graph is always false in this implementation
+                                );
+                            }
+                            
+                        }
+                    }
+                    return jacobians;
+                }
+            }
+        }
+    }
+}

--- a/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
+++ b/test/TorchSharpTest.WithCudaBinaries/TorchSharpTest.WithCudaBinaries.csproj
@@ -27,6 +27,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
     <Compile Include="..\TorchSharpTest\TestDistributions.cs" Link="TestDistributions.cs" />
+    <Compile Include="..\TorchSharpTest\TestJacobian.cs" Link="TestJacobian.cs" />
     <Compile Include="..\TorchSharpTest\TestJIT.cs" Link="TestJIT.cs" />
     <Compile Include="..\TorchSharpTest\TestLoadSave.cs" Link="TestLoadSave.cs" />
     <Compile Include="..\TorchSharpTest\TestNNUtils.cs" Link="TestNNUtils.cs" />

--- a/test/TorchSharpTest/TestJacobian.cs
+++ b/test/TorchSharpTest/TestJacobian.cs
@@ -13,16 +13,15 @@ namespace TorchSharp
         {
             torch.Tensor x1 = torch.tensor(new double[,] { { 1.0, 3.0 }, { 2.0, 4.0 } }, requires_grad: true);
 
-            torch.Tensor jacFunc(torch.Tensor[] inputs)
+            torch.Tensor jacFunc(torch.Tensor inputs)
             {
-                return torch.sum(inputs[0] * inputs[0]);
+                return torch.sum(inputs * inputs);
             }
 
-            torch.Tensor[] jacobian = torch.autograd.functional.jacobian(jacFunc, x1).ToArray();
+            torch.Tensor jacobian = torch.autograd.functional.jacobian(jacFunc, x1);
 
-            Assert.Single(jacobian);
-            Assert.Equal(new long[] { 2, 2 }, jacobian[0].shape);
-            Assert.Equal(new double[] { 2.0, 6.0, 4.0, 8.0 }, jacobian[0].data<double>());
+            Assert.Equal(new long[] { 2, 2 }, jacobian.shape);
+            Assert.Equal(new double[] { 2.0, 6.0, 4.0, 8.0 }, jacobian.data<double>());
 
         }
 
@@ -31,9 +30,9 @@ namespace TorchSharp
         {
             torch.Tensor x1 = torch.tensor(new double[,] { { 1.0, 3.0 }, { 2.0, 4.0 } }, requires_grad: true);
 
-            torch.Tensor[] jacFunc(torch.Tensor[] inputs)
+            torch.Tensor[] jacFunc(torch.Tensor inputs)
             {
-                return new torch.Tensor[] { torch.sum(inputs[0]), torch.sum(inputs[0] * inputs[0]) };
+                return new torch.Tensor[] { torch.sum(inputs), torch.sum(inputs * inputs) };
             }
 
             torch.Tensor[] jacobian = torch.autograd.functional.jacobian(jacFunc, x1).ToArray();

--- a/test/TorchSharpTest/TestJacobian.cs
+++ b/test/TorchSharpTest/TestJacobian.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Collections.Generic;
 using Xunit;
 
@@ -8,15 +9,94 @@ namespace TorchSharp
     public class TestJacobian
     {
         [Fact]
-        public void EnumEquivalence()
+        public void OneInputOneOutput()
         {
-            Assert.Equal((int)InterpolationMode.Nearest, (int)UpsampleMode.Nearest);
-            Assert.Equal((int)InterpolationMode.Linear, (int)UpsampleMode.Linear);
-            Assert.Equal((int)InterpolationMode.Bilinear, (int)UpsampleMode.Bilinear);
-            Assert.Equal((int)InterpolationMode.Bicubic, (int)UpsampleMode.Bicubic);
-            Assert.Equal((int)InterpolationMode.Trilinear, (int)UpsampleMode.Trilinear);
-            Assert.Equal((int)InterpolationMode.Nearest, (int)GridSampleMode.Nearest);
-            Assert.Equal((int)InterpolationMode.Bilinear, (int)GridSampleMode.Bilinear);
+            torch.Tensor x1 = torch.tensor(new double[,] { { 1.0, 3.0 }, { 2.0, 4.0 } }, requires_grad: true);
+
+            torch.Tensor jacFunc(torch.Tensor[] inputs)
+            {
+                return torch.sum(inputs[0] * inputs[0]);
+            }
+
+            torch.Tensor[] jacobian = torch.autograd.functional.jacobian(jacFunc, x1).ToArray();
+
+            Assert.Single(jacobian);
+            Assert.Equal(new long[] { 2, 2 }, jacobian[0].shape);
+            Assert.Equal(new double[] { 2.0, 6.0, 4.0, 8.0 }, jacobian[0].data<double>());
+
+        }
+
+        [Fact]
+        public void OneInputMultipleOutputs()
+        {
+            torch.Tensor x1 = torch.tensor(new double[,] { { 1.0, 3.0 }, { 2.0, 4.0 } }, requires_grad: true);
+
+            torch.Tensor[] jacFunc(torch.Tensor[] inputs)
+            {
+                return new torch.Tensor[] { torch.sum(inputs[0]), torch.sum(inputs[0] * inputs[0]) };
+            }
+
+            torch.Tensor[] jacobian = torch.autograd.functional.jacobian(jacFunc, x1).ToArray();
+
+            Assert.Equal(2, jacobian.Length);
+            Assert.Equal(new long[] { 2, 2 }, jacobian[0].shape);
+            Assert.Equal(new double[] { 1.0, 1.0, 1.0, 1.0 }, jacobian[0].data<double>());
+            Assert.Equal(new long[] { 2, 2 }, jacobian[1].shape);
+            Assert.Equal(new double[] { 2.0, 6.0, 4.0, 8.0 }, jacobian[1].data<double>());
+        }
+
+        [Fact]
+        public void MultipleInputsOneOutput()
+        {
+            torch.Tensor x1 = torch.tensor(new double[,] { { 1.0, 3.0 }, { 2.0, 4.0 } }, requires_grad: true);
+            torch.Tensor intercepts = torch.tensor(new double[] { 1.0, 5.0 }, requires_grad: true);
+
+            torch.Tensor jacFunc(torch.Tensor[] inputs)
+            {
+                return torch.einsum("ij,j->i", inputs[0], inputs[1]);
+            }
+
+            torch.Tensor[] jacobian = torch.autograd.functional.jacobian(jacFunc, x1, intercepts).ToArray();
+
+            // jacobian[0] should be:
+            // [[[1, 5],
+            // [0, 0]],
+            // [[0, 0],
+            // [1, 5]]]
+            // And jacobian[1]:
+            // [[1, 3],
+            // [2, 4]]
+
+            Assert.Equal(2, jacobian.Length);
+            Assert.Equal(new long[] { 2, 2, 2 }, jacobian[0].shape);
+            Assert.Equal(new double[] { 1.0, 5.0, 0.0, 0.0, 0.0, 0.0, 1.0, 5.0 }, jacobian[0].data<double>());
+            Assert.Equal(new long[] { 2, 2 }, jacobian[1].shape);
+            Assert.Equal(new double[] { 1.0, 3.0, 2.0, 4.0 }, jacobian[1].data<double>());
+        }
+
+        [Fact]
+        public void MultipleInputsMultipleOutputs()
+        {
+            torch.Tensor x1 = torch.tensor(new double[,] { { 1.0, 3.0 }, { 2.0, 4.0 } }, requires_grad: true);
+            torch.Tensor intercepts = torch.tensor(new double[] { 1.0, 5.0 }, requires_grad: true);
+
+            torch.Tensor[] jacFunc(torch.Tensor[] inputs)
+            {
+                return new torch.Tensor[] { torch.sum(inputs[0] * inputs[0]), torch.einsum("ij,j->i", inputs[0], inputs[1]) };
+            }
+
+            torch.Tensor[] jacobian = torch.autograd.functional.jacobian(jacFunc, x1, intercepts).ToArray();
+
+            Assert.Equal(4, jacobian.Length);
+            Assert.Equal(new long[] { 2, 2 }, jacobian[0].shape);
+            Assert.Equal(new double[] { 2.0, 6.0, 4.0, 8.0 }, jacobian[0].data<double>());
+            Assert.Equal(new long[] { 2 }, jacobian[1].shape);
+            Assert.Equal(new double[] { 0.0, 0.0 }, jacobian[1].data<double>());
+            Assert.Equal(new long[] { 2, 2, 2 }, jacobian[2].shape);
+            Assert.Equal(new double[] { 1.0, 5.0, 0.0, 0.0, 0.0, 0.0, 1.0, 5.0 }, jacobian[2].data<double>());
+            Assert.Equal(new long[] { 2, 2 }, jacobian[3].shape);
+            Assert.Equal(new double[] { 1.0, 3.0, 2.0, 4.0 }, jacobian[3].data<double>());
+
         }
     }
 }

--- a/test/TorchSharpTest/TestJacobian.cs
+++ b/test/TorchSharpTest/TestJacobian.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Xunit;
+
+using static TorchSharp.torch;
+
+namespace TorchSharp
+{
+    public class TestJacobian
+    {
+        [Fact]
+        public void EnumEquivalence()
+        {
+            Assert.Equal((int)InterpolationMode.Nearest, (int)UpsampleMode.Nearest);
+            Assert.Equal((int)InterpolationMode.Linear, (int)UpsampleMode.Linear);
+            Assert.Equal((int)InterpolationMode.Bilinear, (int)UpsampleMode.Bilinear);
+            Assert.Equal((int)InterpolationMode.Bicubic, (int)UpsampleMode.Bicubic);
+            Assert.Equal((int)InterpolationMode.Trilinear, (int)UpsampleMode.Trilinear);
+            Assert.Equal((int)InterpolationMode.Nearest, (int)GridSampleMode.Nearest);
+            Assert.Equal((int)InterpolationMode.Bilinear, (int)GridSampleMode.Bilinear);
+        }
+    }
+}


### PR DESCRIPTION
Initial implementation of the jacobian method, based on https://pytorch.org/docs/stable/_modules/torch/autograd/functional.html#jacobian .
Resolves #1149.

Omits several options from the PyTorch implementation, such as `create_graph`, `strict`, `vectorize` and `strategy`.
It behaves as if `create_graph=False`, `strict=False`, `vectorize=False` and `strategy="reverse-mode"`.

I added an example of usage in the documentation of the method itself.

@NiklasGustafsson 