### PR TITLE
Added to always initialize CUDA 

### DIFF
--- a/src/TorchSharp/Device.cs
+++ b/src/TorchSharp/Device.cs
@@ -4,7 +4,7 @@ using System;
 namespace TorchSharp
 {
     public static partial class torch
-    {
+    {        
         /// <summary>
         /// A torch.Device is an object representing the device on which a torch.Tensor is or will be allocated.
         /// </summary>
@@ -85,12 +85,12 @@ namespace TorchSharp
         /// <summary>
         /// Convenience declaration of a CPU device accessible everywhere.
         /// </summary>
-        public static Device CPU = InitializeDevice(new Device(DeviceType.CPU, -1));
+        public static readonly Device CPU = InitializeDevice(new Device(DeviceType.CPU, -1));
 
         /// <summary>
         /// Convenience declaration of a META device accessible everywhere.
         /// </summary>
-        public static Device META = InitializeDevice(new Device(DeviceType.META, -1));
+        public static readonly Device META = InitializeDevice(new Device(DeviceType.META, -1));
 
         /// <summary>
         /// Factory for a device object, following the Pytorch API.

--- a/src/TorchSharp/Device.cs
+++ b/src/TorchSharp/Device.cs
@@ -80,17 +80,17 @@ namespace TorchSharp
         /// <summary>
         /// Convenience declaration of a CUDA device accessible everywhere.
         /// </summary>
-        public static Device CUDA => InitializeDevice(new Device(DeviceType.CUDA, -1));
+        public static readonly Device CUDA = cuda.is_available() ? new Device(DeviceType.CUDA, -1) : null;
 
         /// <summary>
         /// Convenience declaration of a CPU device accessible everywhere.
         /// </summary>
-        public static Device CPU = InitializeDevice(new Device(DeviceType.CPU, -1));
+        public static readonly Device CPU = InitializeDevice(new Device(DeviceType.CPU, -1));
 
         /// <summary>
         /// Convenience declaration of a META device accessible everywhere.
         /// </summary>
-        public static Device META = InitializeDevice(new Device(DeviceType.META, -1));
+        public static readonly Device META = InitializeDevice(new Device(DeviceType.META, -1));
 
         /// <summary>
         /// Factory for a device object, following the Pytorch API.

--- a/src/TorchSharp/Device.cs
+++ b/src/TorchSharp/Device.cs
@@ -80,17 +80,17 @@ namespace TorchSharp
         /// <summary>
         /// Convenience declaration of a CUDA device accessible everywhere.
         /// </summary>
-        public static readonly Device CUDA = cuda.is_available() ? new Device(DeviceType.CUDA, -1) : null;
+        public static Device CUDA => InitializeDevice(new Device(DeviceType.CUDA, -1));
 
         /// <summary>
         /// Convenience declaration of a CPU device accessible everywhere.
         /// </summary>
-        public static readonly Device CPU = InitializeDevice(new Device(DeviceType.CPU, -1));
+        public static Device CPU = InitializeDevice(new Device(DeviceType.CPU, -1));
 
         /// <summary>
         /// Convenience declaration of a META device accessible everywhere.
         /// </summary>
-        public static readonly Device META = InitializeDevice(new Device(DeviceType.META, -1));
+        public static Device META = InitializeDevice(new Device(DeviceType.META, -1));
 
         /// <summary>
         /// Factory for a device object, following the Pytorch API.

--- a/src/TorchSharp/Device.cs
+++ b/src/TorchSharp/Device.cs
@@ -77,10 +77,11 @@ namespace TorchSharp
             }
         }
 
+        private static Device _CUDA;
         /// <summary>
         /// Convenience declaration of a CUDA device accessible everywhere.
         /// </summary>
-        public static Device CUDA => InitializeDevice(new Device(DeviceType.CUDA, -1));
+        public static Device CUDA => _CUDA ??= InitializeDevice(new Device(DeviceType.CUDA, -1)); 
 
         /// <summary>
         /// Convenience declaration of a CPU device accessible everywhere.

--- a/src/TorchSharp/Tensor/Factories/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Factories/Tensor.Factories.cs
@@ -585,6 +585,7 @@ namespace TorchSharp
         static torch()
         {
             deleters = new ConcurrentDictionary<TorchSharp.PInvoke.GCHandleDeleter, TorchSharp.PInvoke.GCHandleDeleter>();
+            TryInitializeDeviceType(DeviceType.CUDA);
         }
         #endregion
     }

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -3755,7 +3755,7 @@ namespace TorchSharp
                     Assert.Equal(1, data[i]);
                 }
             } else {
-                Assert.Null(torch.CUDA);
+                Assert.Throws<InvalidOperationException>((Action)(() => { torch.ones(new long[] { 2, 2 }, device: torch.CUDA); }));
             }
         }
 

--- a/test/TorchSharpTest/TestTorchTensor.cs
+++ b/test/TorchSharpTest/TestTorchTensor.cs
@@ -3755,7 +3755,7 @@ namespace TorchSharp
                     Assert.Equal(1, data[i]);
                 }
             } else {
-                Assert.Throws<InvalidOperationException>((Action)(() => { torch.ones(new long[] { 2, 2 }, device: torch.CUDA); }));
+                Assert.Null(torch.CUDA);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/TorchSharp/issues/1198.

I tested it out locally - I added the DLL and the libtorch-cuda package, and it worked. I then tried it with the libtorch-cpu package and I confirmed that it didn't crash. 

I was going to add a test for it - but in our CUDA tests we always check that cuda is available, and then that defeats the purpose since checking if it is available initializes it. 
Do you have any suggestions?