### PR TITLE
Added a fix for LinearLR scheduler, and updated behavior of all schedulers to match PyTorch

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,11 @@ __API Changes__:
 
 #1219: Added support for loading and saving tensors that are >2GB.<br/> 
 
+__Bug Fixes__:
+
+Fixed LinearLR scheduler calculation with misplaced parentheses<br/>
+Added `get_closed_form_lr` to scheduler to match PyTorch behavior when specifying epoch in `.step()`<br/>
+
 ## NuGet Version 0.101.6
 
 __API Changes__:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,10 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 ## NuGet Version 0.101.7
 
+__Breaking Changes__:
+
+The default value for the `end_factor` argument in the constructor for `LinearLR` was changed to 1.0 to match PyTorch.<br/>
+
 __API Changes__:
 
 #1219: Added support for loading and saving tensors that are >2GB.<br/> 

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -1613,5 +1613,25 @@ namespace TorchSharp
             Assert.NotNull(module.ln.bias!.grad());
             
         }
+
+        [Fact]
+        public void ValidateLinearLR()
+        {
+            var lin = Linear(5, 5, hasBias: false);
+            var optim = torch.optim.SGD(lin.parameters(), 0.05);
+            var scheduler = torch.optim.lr_scheduler.LinearLR(optim, 0.5, 1.0, 4);
+
+            Assert.Equal(0.025, Math.Round(scheduler.get_last_lr().First(), 3));
+            scheduler.step();
+            Assert.Equal(0.03125, Math.Round(scheduler.get_last_lr().First(), 5));
+            scheduler.step();
+            Assert.Equal(0.0375, Math.Round(scheduler.get_last_lr().First(), 4));
+            scheduler.step();
+            Assert.Equal(0.04375, Math.Round(scheduler.get_last_lr().First(), 5));
+            scheduler.step();
+            Assert.Equal(0.05, Math.Round(scheduler.get_last_lr().First(), 2));
+            scheduler.step();
+            Assert.Equal(0.05, Math.Round(scheduler.get_last_lr().First(), 2));
+        }
     }
 }

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -1585,9 +1585,9 @@ namespace TorchSharp
             var optimizer = torch.optim.SGD(seq.parameters(), learning_rate);
             var scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, end_factor: 0.75, total_iters: 10);
 
-            var loss = TrainLoop(seq, x, y, optimizer, scheduler);
+            var loss = TrainLoop(seq, x, y, optimizer, scheduler, false);
 
-            LossIsClose(209.71f, loss);
+            LossIsClose(101.83f, loss);
         }
 
         [Fact]
@@ -1607,7 +1607,33 @@ namespace TorchSharp
 
             var loss = TrainLoop(seq, x, y, optimizer, scheduler, false, iters: 20);
 
-            LossIsClose(240.24f, loss);
+            LossIsClose(67.5635f, loss);
+        }
+
+        [Fact]
+        public void TrainingSGDSequentialLRWithAllClosedFormSchedulers()
+        {
+            var gen = new Generator(4711);
+            CreateLinearLayers(gen, out var lin1, out var lin2);
+            CreateDataAndLabels(gen, out var x, out var y);
+
+            var seq = Sequential(("lin1", lin1), ("relu1", ReLU()), ("lin2", lin2));
+
+            double learning_rate = 0.00004f;
+            var optimizer = torch.optim.SGD(seq.parameters(), learning_rate);
+            var scheduler0 = torch.optim.lr_scheduler.LinearLR(optimizer, end_factor: 0.75, total_iters: 10);
+            var scheduler1 = torch.optim.lr_scheduler.ConstantLR(optimizer);
+            var scheduler2 = torch.optim.lr_scheduler.StepLR(optimizer, 2);
+            var scheduler3 = torch.optim.lr_scheduler.MultiStepLR(optimizer, new[] { 2, 4 });
+            var scheduler4 = torch.optim.lr_scheduler.ExponentialLR(optimizer);
+            var scheduler5 = torch.optim.lr_scheduler.PolynomialLR(optimizer, power: 2);
+            var scheduler6 = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, 5, 0.1);
+            var scheduler7 = torch.optim.lr_scheduler.LinearLR(optimizer, end_factor: 0.75);
+            var scheduler = torch.optim.lr_scheduler.SequentialLR(optimizer, new[] { scheduler0, scheduler1, scheduler2, scheduler3, scheduler4, scheduler5, scheduler6, scheduler7}, new[] { 5, 5, 5, 5, 5, 5, 5 });
+
+            var loss = TrainLoop(seq, x, y, optimizer, scheduler, false, iters: 35);
+
+            LossIsClose(52.36025f, loss);
         }
 
         [Fact]


### PR DESCRIPTION
When playing with the schedulers, I noticed that they didn't match the results coming from PyTorch, so I updated the behavior. 

Justifications:
- Fixing the parentheses in the LinearLR `get_lr` function: https://github.com/pytorch/pytorch/blob/HEAD/torch/optim/lr_scheduler.py#L590-L591

- Removing the loop which sets the InitialLearningRate in the `LRScheduler` constructor: In the PyTorch code [here](https://github.com/pytorch/pytorch/blob/HEAD/torch/optim/lr_scheduler.py#L45-L46) they don't force-set the initial_lr, but rather set it if it wasn't there yet. In TorchSharp the initial_lr value is always set, and therefore that loop shouldn't be called. With one scheduler it isn't an issue, but with multiple you have the issue that each scheduler re-sets the initial_lr, and then sets the `lr`, so we end up having an issue. 

- Introducing `get_closed_form_lr()` as per the PyTorch code: https://github.com/pytorch/pytorch/blob/HEAD/torch/optim/lr_scheduler.py#L158-L159

- Adjusting the scores on the tests - replicated using PyTorch: https://gist.github.com/shaltielshmid/ebf01989367709a9feac88e076dd312b

- Disabling the `check_lr` flag on the Test `TrainingSGDLinearLR`: The start_factor is 0.333, and the end_factor is 0.75, which means the LR should be increasing, not decreasing. 

Breaking changes (kind of):
- The LinearLR default value for `end_factor` was modified to `1.0` , to match PyTorch
- When calling `.step()` with an epoch number, the behavior will used the closed form LR instead of regular LR - to match PyTorch, but it will result in changes for anyone using the library. 

Wasn't sure which of these breaking changes to put in the release notes. 