### PR TITLE
Fixed issue with Module.load() with deflate stream

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 __Bug Fixes__:
 
 `module.load_state_dict()` throws error for in-place operation on a leaf variable that requires grad. <br/>
+`module.load()` with streams which don't read the requested # of bytes throws error. <br/>
 
 ## NuGet Version 0.102.0
 

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -463,16 +463,15 @@ namespace TorchSharp
                     byte[] buffer = new byte[bufferSize];
                     while (totalSize > 0) {
                         // Read in the current buffer size
-                        int curBufferSize = (int)Math.Min(totalSize, bufferSize);
-                        stream.Read(buffer, 0, curBufferSize);
+                        int bytesRead = stream.Read(buffer, 0, (int)Math.Min(totalSize, bufferSize));
 
                         // Copy the contents over to the span
-                        var span = new Span<byte>((void*)ptr, curBufferSize);
-                        buffer.AsSpan(0, curBufferSize).CopyTo(span);
+                        var span = new Span<byte>((void*)ptr, bytesRead);
+                        buffer.AsSpan(0, bytesRead).CopyTo(span);
                         
                         // Increment our pointer and decrease the total size of elements we have to write
-                        ptr += curBufferSize;
-                        totalSize -= curBufferSize;
+                        ptr += bytesRead;
+                        totalSize -= bytesRead;
                     }
                 }
             }

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -465,6 +465,9 @@ namespace TorchSharp
                         // Read in the current buffer size
                         int bytesRead = stream.Read(buffer, 0, (int)Math.Min(totalSize, bufferSize));
 
+                        if (bytesRead == 0)
+                            throw new EndOfStreamException();
+
                         // Copy the contents over to the span
                         var span = new Span<byte>((void*)ptr, bytesRead);
                         buffer.AsSpan(0, bytesRead).CopyTo(span);

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -1638,6 +1638,7 @@ namespace TorchSharp
         [Fact]
         public void ValidateLoadWithDeflateStream()
         {
+#if NET6_0_OR_GREATER
             var seq = Sequential(Linear(100, 100), Linear(100, 100));
 
             var ms = new MemoryStream();
@@ -1653,6 +1654,7 @@ namespace TorchSharp
             using (var archive = new ZipArchive(ms)) {
                 seq.load(archive.GetEntry("seq")!.Open());
             }
+#endif
         }
     }
 }


### PR DESCRIPTION
I encountered a bug with Module.load(), when I gave it a deflate stream. Turns out that when you call `stream.Read(buffer, start, length)` there is no guarantee that it will read length even if there are more bytes in the stream. 

I had assumed that if there were bytes to read, then it would always read to the maximum. Turns out that `DeflateStream` it will sometimes return after having read a partial length, because of some internal logic. So even though I requested the next 1024 bytes, it can return 788 bytes and then in the next request return 1024 again. 