### PR TITLE
Fixing 1249 and 1250 (avg pool1d + 0D string conversion)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,9 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 __Breaking Changes__:
 
-The `stride` parameter in the `torch.nn.functional.avg_pool1d` call now defaults to `kernelSize` instead of 1, to match the PyTorch behavior. 
+The `kernelSize` parameter in the function and class of `AvgPool1D` was renamed to `kernel_size` to match PyTorch naming.
+The `stride` parameter in the `torch.nn.functional.avg_pool1d` call now defaults to `kernelSize` instead of 1, to match the PyTorch behavior.
+
 
 __Bug Fixes__:
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,9 +4,15 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 # NuGet Version 0.102.1
 
+__Breaking Changes__:
+
+The `stride` parameter in the `torch.nn.functional.avg_pool1d` call now defaults to `kernelSize` instead of 1, to match the PyTorch behavior. 
+
 __Bug Fixes__:
 
 `module.load_state_dict()` throws error for in-place operation on a leaf variable that requires grad. <br/>
+#1250 cstr and npstr for 0d tensors <br/>
+#1249 torch.nn.functional.avg_pool1d is not working correctly<br/>
 
 ## NuGet Version 0.102.0
 

--- a/src/TorchSharp/NN/Pooling/AvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool1D.cs
@@ -90,7 +90,7 @@ namespace TorchSharp
                     long? padding = null, bool ceil_mode = false, bool count_include_pad = true)
                 {
                     var kernelSizes = new long[] { kernelSize };
-                    var strides = new long[] { stride ?? 1 };
+                    var strides = new long[] { stride ?? kernelSize };
                     var paddings = new long[] { padding ?? 0 };
                     unsafe {
                         fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings) {

--- a/src/TorchSharp/NN/Pooling/AvgPool1D.cs
+++ b/src/TorchSharp/NN/Pooling/AvgPool1D.cs
@@ -40,32 +40,32 @@ namespace TorchSharp
             /// <summary>
             /// Applies a 1D average pooling over an input signal composed of several input planes.
             /// </summary>
-            /// <param name="kernelSize">The size of the window</param>
+            /// <param name="kernel_size">The size of the window</param>
             /// <param name="stride">The stride of the window. Default value is kernel_size</param>
             /// <param name="padding">implicit zero padding to be added on both sides</param>
             /// <param name="ceil_mode">Whether to use ceil instead of floor to compute the output shape</param>
             /// <param name="count_include_pad">Whether to include the zero-padding in the averaging calculation</param>
             /// <param name="divisor_override">If specified, it will be used as divisor, otherwise size of the pooling region will be used</param>
-            public static AvgPool1d AvgPool1d(long kernelSize, long? stride = null, long padding = 0, bool ceil_mode = false, bool count_include_pad = true, long? divisor_override = null)
+            public static AvgPool1d AvgPool1d(long kernel_size, long? stride = null, long padding = 0, bool ceil_mode = false, bool count_include_pad = true, long? divisor_override = null)
             {
                 return stride.HasValue ?
-                    AvgPool1d(new long[] { kernelSize }, new long[] { stride.Value }, new long[] { padding }, ceil_mode, count_include_pad, divisor_override.HasValue ? divisor_override.Value : 0) :
-                    AvgPool1d(new long[] { kernelSize }, null, new long[] { padding }, ceil_mode, count_include_pad, divisor_override.HasValue ? divisor_override.Value : 0);
+                    AvgPool1d(new long[] { kernel_size }, new long[] { stride.Value }, new long[] { padding }, ceil_mode, count_include_pad, divisor_override.HasValue ? divisor_override.Value : 0) :
+                    AvgPool1d(new long[] { kernel_size }, null, new long[] { padding }, ceil_mode, count_include_pad, divisor_override.HasValue ? divisor_override.Value : 0);
             }
 
             /// <summary>
             /// Applies a 1D average pooling over an input signal composed of several input planes.
             /// </summary>
-            /// <param name="kernelSize">The size of the window</param>
+            /// <param name="kernel_size">The size of the window</param>
             /// <param name="strides">The stride of the window. Default value is kernel_size</param>
             /// <param name="padding">implicit zero padding to be added on both sides</param>
             /// <param name="ceil_mode">Whether to use ceil instead of floor to compute the output shape</param>
             /// <param name="count_include_pad">Whether to include the zero-padding in the averaging calculation</param>
             /// <param name="divisor_override">If specified, it will be used as divisor, otherwise size of the pooling region will be used</param>
-            private static AvgPool1d AvgPool1d(long[] kernelSize, long[] strides = null, long[] padding = null, bool ceil_mode = false, bool count_include_pad = true, long? divisor_override = null)
+            private static AvgPool1d AvgPool1d(long[] kernel_size, long[] strides = null, long[] padding = null, bool ceil_mode = false, bool count_include_pad = true, long? divisor_override = null)
             {
                 unsafe {
-                    fixed (long* pkernelSize = kernelSize, pstrides = strides, ppadding = padding) {
+                    fixed (long* pkernelSize = kernel_size, pstrides = strides, ppadding = padding) {
                         var handle = THSNN_AvgPool1d_ctor((IntPtr)pkernelSize, (IntPtr)pstrides, (IntPtr)ppadding, ceil_mode, count_include_pad, divisor_override.HasValue ? divisor_override.Value : 0, out var boxedHandle);
                         if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
                         return new AvgPool1d(handle, boxedHandle);
@@ -80,17 +80,17 @@ namespace TorchSharp
                 /// Applies a 1D average pooling over an input signal composed of several input planes.
                 /// </summary>
                 /// <param name="input">The input tensor.</param>
-                /// <param name="kernelSize"></param>
+                /// <param name="kernel_size"></param>
                 /// <param name="stride"></param>
                 /// <param name="padding"></param>
                 /// <param name="ceil_mode"></param>
                 /// <param name="count_include_pad"></param>
                 /// <returns></returns>
-                public static Tensor avg_pool1d(Tensor input, long kernelSize, long? stride = null,
+                public static Tensor avg_pool1d(Tensor input, long kernel_size, long? stride = null,
                     long? padding = null, bool ceil_mode = false, bool count_include_pad = true)
                 {
-                    var kernelSizes = new long[] { kernelSize };
-                    var strides = new long[] { stride ?? kernelSize };
+                    var kernelSizes = new long[] { kernel_size };
+                    var strides = new long[] { stride ?? kernel_size };
                     var paddings = new long[] { padding ?? 0 };
                     unsafe {
                         fixed (long* pkernelSize = kernelSizes, pstrides = strides, ppadding = paddings) {

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -6496,11 +6496,18 @@ namespace TorchSharp
                 var leadingRows = torch.maxRows - trailingRows;
 
                 var dim = t.dim();
+
                 if (t.size().Length == 0) return "";
                 var sb = new StringBuilder(isFCreate ? string.Join("", Enumerable.Repeat(' ', (int)(mdim - dim))) : "");
                 sb.Append('[');
                 var currentSize = t.size()[0];
-                if (dim == 1) {
+                if (currentSize == 0) {
+                    // print nothing
+                }
+                else if (dim == 0) {
+                    PrintValue(sb, t.dtype, t.ToScalar(), fltFormat, actualCulturInfo);
+                }
+                else if (dim == 1) {
                     if (currentSize <= torch.maxColumns) {
                         for (var i = 0; i < currentSize - 1; i++) {
                             PrintValue(sb, t.dtype, t[i].ToScalar(), fltFormat, actualCulturInfo);
@@ -6572,7 +6579,6 @@ namespace TorchSharp
                 var leadingRows = torch.maxRows - trailingRows;
 
                 var dim = t.dim();
-                if (t.size().Length == 0) return "";
                 var sb = new StringBuilder();
 
                 if (top) {
@@ -6648,7 +6654,10 @@ namespace TorchSharp
                 }
 
                 var currentSize = t.size()[0];
-                if (dim == 1) {
+                if (currentSize == 0) {
+                    // do nothing
+                }
+                else if (dim == 1) {
                     if (currentSize <= torch.maxColumns) {
                         for (var i = 0; i < currentSize - 1; i++) {
                             PrintValue(sb, t.dtype, t[i].ToScalar(), fltFormat, actualCulturInfo);

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -1633,5 +1633,30 @@ namespace TorchSharp
             scheduler.step();
             Assert.Equal(0.05, Math.Round(scheduler.get_last_lr().First(), 2));
         }
+
+        [Fact]
+        public void Validate_1249()
+        {
+            var x = torch.zeros(5, 7, 128);
+            Console.WriteLine(x.metastr());
+            // [5x7x128], type = Float32, device = cpu
+
+            var y1 = torch.nn.functional.avg_pool1d(x, 2);
+            Console.WriteLine(y1.metastr());
+            Assert.Equal(64, y1.size(-1));
+            
+            var y2 = torch.nn.AvgPool1d(2).call(x);
+            Console.WriteLine(y2.metastr());
+            Assert.Equal(64, y1.size(-1));
+        }
+
+        [Fact]
+        public void Validate_1250()
+        {
+            Assert.Equal("[]", torch.zeros(0).npstr());
+            Assert.Equal("[0]", torch.zeros(1).npstr());
+            Assert.Equal("[0], type = Float32, device = cpu, value = float [] {}", torch.zeros(0).cstr());
+            Assert.Equal("[1], type = Float32, device = cpu, value = float [] {0f}", torch.zeros(1).cstr());
+        }
     }
 }

--- a/test/TorchSharpTest/TestTorchTensorBugs.cs
+++ b/test/TorchSharpTest/TestTorchTensorBugs.cs
@@ -1659,7 +1659,8 @@ namespace TorchSharp
             Assert.Equal("[0], type = Float32, device = cpu, value = float [] {}", torch.zeros(0).cstr());
             Assert.Equal("[1], type = Float32, device = cpu, value = float [] {0f}", torch.zeros(1).cstr());
         }
-      
+
+        [Fact]
         public void ValidateLoadWithDeflateStream()
         {
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
The modification of the AvgPool1D stride parameter defaulting to kernelSize is as per the documentation here:
https://github.com/pytorch/pytorch/blob/main/torch/nn/functional.py#L354-L355
And the implementation of the module here:
https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/pooling.py#L549-L550

On the way, I also fixed the 0D tensor string printing. 

Fixes: https://github.com/dotnet/TorchSharp/issues/1249 and https://github.com/dotnet/TorchSharp/issues/1250.

@NiklasGustafsson  Question: The PyTorch parameter is named `kernel_size` whereas in TorchSharp it's written as `kernelSize`. Is it worth at this point to change the naming to match PyTorch?