### PR TITLE
Address issue with ordering of initializations in the torch cctor.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -16,6 +16,7 @@ __Bug Fixes__:
 #1250 cstr and npstr for 0d tensors <br/>
 #1249 torch.nn.functional.avg_pool1d is not working correctly<br/>
 `module.load()` with streams which don't read the requested # of bytes throws error. <br/>
+ #1246 Issue running in notebook on Apple Silicon<br/>
 
 ## NuGet Version 0.102.0
 

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -27,7 +27,9 @@ namespace TorchSharp
 #error "Please update cudaVersion to match CudaVersionDot"
 #endif
 
-        static bool isAppleSilicon = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.OSArchitecture == Architecture.Arm64;
+        static bool isAppleSilicon => 
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && 
+            RuntimeInformation.OSArchitecture == Architecture.Arm64;
         
         static string nativeRid =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"win-x64" :


### PR DESCRIPTION
There was an ordering error between segments of the static class initializer for the partial class 'torch' that impacted the loading of 