### PR TITLE
'fuse_conv_bn_weights' and 'fuse_linear_bn_weights' in 'torch.nn.utils'

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,7 +4,7 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 # NuGet Version 0.102.3
 
-__Breaking Changes__:
+__API Changes__:
 
 #1243 `fuse_conv_bn_weights` and `fuse_linear_bn_weights` are added.<br/>
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 __Breaking Changes__:
 
-#1243 `fuse_conv_bn_weights` and `fuse_linear_bn_weights` are added.
+#1243 `fuse_conv_bn_weights` and `fuse_linear_bn_weights` are added.<br/>
 
 # NuGet Version 0.102.2
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,12 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+# NuGet Version 0.102.3
+
+__Breaking Changes__:
+
+#1243 `fuse_conv_bn_weights` and `fuse_linear_bn_weights` are added.
+
 # NuGet Version 0.102.2
 
 __Bug Fixes__:

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -435,6 +435,8 @@ namespace TorchSharp
                     Tensor? bn_w, Tensor? bn_b,
                     bool transpose = false)
                 {
+                    using var scope = NewDisposeScope();
+
                     var conv_weight_dtype = conv_w.dtype;
                     var conv_bias_dtype = conv_b?.dtype ?? conv_weight_dtype;
                     conv_b ??= zeros_like(bn_rm);
@@ -455,7 +457,7 @@ namespace TorchSharp
                     var weight = new Parameter(fused_conv_w, conv_w.requires_grad);
                     var bias = new Parameter(fused_conv_b, conv_b.requires_grad);
 
-                    return (weight, bias);
+                    return scope.MoveToOuter(weight, bias);
                 }
 
                 /// <summary>
@@ -474,6 +476,8 @@ namespace TorchSharp
                     Tensor bn_rm, Tensor bn_rv, double bn_eps,
                     Tensor bn_w, Tensor bn_b)
                 {
+                    using var scope = NewDisposeScope();
+
                     linear_b ??= zeros_like(bn_rm);
 
                     var bn_scale = bn_w * rsqrt(bn_rv + bn_eps);
@@ -484,7 +488,7 @@ namespace TorchSharp
                     var weight = new Parameter(fused_w, linear_w.requires_grad);
                     var bias = new Parameter(fused_b, linear_b.requires_grad);
 
-                    return (weight, bias);
+                    return scope.MoveToOuter(weight, bias);
                 }
             }
         }

--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using TorchSharp.Modules;
 using TorchSharp.PInvoke;
 using static TorchSharp.PInvoke.NativeMethods;
 
@@ -414,6 +415,76 @@ namespace TorchSharp
                         THSTensor_vector_to_parameters(vec.Handle, tensorsRef, parray.Array.Length);
                         CheckForErrors();
                     }
+                }
+
+                /// <summary>
+                /// Fuse convolutional module parameters and BatchNorm module parameters into new convolutional module parameters.
+                /// </summary>
+                /// <param name="conv_w">Convolutional weight.</param>
+                /// <param name="conv_b">Convolutional bias.</param>
+                /// <param name="bn_rm">BatchNorm running mean.</param>
+                /// <param name="bn_rv">BatchNorm running variance.</param>
+                /// <param name="bn_eps">BatchNorm epsilon.</param>
+                /// <param name="bn_w">BatchNorm weight.</param>
+                /// <param name="bn_b">BatchNorm bias.</param>
+                /// <param name="transpose">If <c>true</c>, transpose the conv weight. Defaults to <c>false</c>.</param>
+                /// <returns>Fused convolutional weight and bias.</returns>
+                public static (Parameter weight, Parameter bias) fuse_conv_bn_weights(
+                    Tensor conv_w, Tensor? conv_b,
+                    Tensor bn_rm, Tensor bn_rv, double bn_eps,
+                    Tensor? bn_w, Tensor? bn_b,
+                    bool transpose = false)
+                {
+                    var conv_weight_dtype = conv_w.dtype;
+                    var conv_bias_dtype = conv_b?.dtype ?? conv_weight_dtype;
+                    conv_b ??= zeros_like(bn_rm);
+                    bn_w ??= ones_like(bn_rm);
+                    bn_b ??= zeros_like(bn_rm);
+                    var shape = conv_w.shape.Select(_ => 1L).ToArray();
+                    if (transpose)
+                        shape[1] = -1;
+                    else
+                        shape[0] = -1;
+
+                    var bn_var_rsqrt = rsqrt(bn_rv + bn_eps);
+                    var fused_conv_w = (conv_w * (bn_w * bn_var_rsqrt).reshape(shape))
+                        .to(conv_weight_dtype);
+                    var fused_conv_b = ((conv_b - bn_rm) * bn_var_rsqrt * bn_w + bn_b)
+                        .to(conv_bias_dtype);
+
+                    var weight = new Parameter(fused_conv_w, conv_w.requires_grad);
+                    var bias = new Parameter(fused_conv_b, conv_b.requires_grad);
+
+                    return (weight, bias);
+                }
+
+                /// <summary>
+                /// Fuse linear module parameters and BatchNorm module parameters into new linear module parameters.
+                /// </summary>
+                /// <param name="linear_w">Linear weight.</param>
+                /// <param name="linear_b">Linear bias.</param>
+                /// <param name="bn_rm">BatchNorm running mean.</param>
+                /// <param name="bn_rv">BatchNorm running variance.</param>
+                /// <param name="bn_eps">BatchNorm epsilon.</param>
+                /// <param name="bn_w">BatchNorm weight.</param>
+                /// <param name="bn_b">BatchNorm bias.</param>
+                /// <returns>Fused linear weight and bias.</returns>
+                public static (Parameter weight, Parameter bias) fuse_linear_bn_weights(
+                    Tensor linear_w, Tensor? linear_b,
+                    Tensor bn_rm, Tensor bn_rv, double bn_eps,
+                    Tensor bn_w, Tensor bn_b)
+                {
+                    linear_b ??= zeros_like(bn_rm);
+
+                    var bn_scale = bn_w * rsqrt(bn_rv + bn_eps);
+
+                    var fused_w = linear_w * bn_scale.unsqueeze(-1);
+                    var fused_b = (linear_b - bn_rm) * bn_scale + bn_b;
+
+                    var weight = new Parameter(fused_w, linear_w.requires_grad);
+                    var bias = new Parameter(fused_b, linear_b.requires_grad);
+
+                    return (weight, bias);
                 }
             }
         }

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -278,66 +278,62 @@ namespace TorchSharp
                 Assert.InRange(maxDifference, -tolerance, tolerance);
             }
 
-            {
-                // linear
-                var x = rand([20, 20]) * 100;
+            // linear
+            var x = rand([20, 20]) * 100;
 
-                var linear = nn.Linear(20, 5);
-                linear.eval();
-                SetRandomParameter(linear, x => x.weight!);
-                SetRandomParameter(linear, x => x.bias!);
+            var linear = nn.Linear(20, 5);
+            linear.eval();
+            SetRandomParameter(linear, x => x.weight!);
+            SetRandomParameter(linear, x => x.bias!);
 
-                var batchNorm1d = nn.BatchNorm1d(5, eps: 1);
-                batchNorm1d.eval();
-                SetRandomParameter(batchNorm1d, x => x.weight!);
-                SetRandomParameter(batchNorm1d, x => x.bias!);
-                SetRandomTensor(batchNorm1d, x => x.running_mean!);
-                SetRandomTensor(batchNorm1d, x => x.running_var!);
+            var batchNorm1d = nn.BatchNorm1d(5, eps: 1);
+            batchNorm1d.eval();
+            SetRandomParameter(batchNorm1d, x => x.weight!);
+            SetRandomParameter(batchNorm1d, x => x.bias!);
+            SetRandomTensor(batchNorm1d, x => x.running_mean!);
+            SetRandomTensor(batchNorm1d, x => x.running_var!);
 
-                (var weight, var bias) = nn.utils.fuse_linear_bn_weights(
-                    linear.weight!, linear.bias,
-                    batchNorm1d.running_mean!, batchNorm1d.running_var!,
-                    bn_eps: 1, batchNorm1d.weight!, batchNorm1d.bias!);
+            (var weight, var bias) = nn.utils.fuse_linear_bn_weights(
+                linear.weight!, linear.bias,
+                batchNorm1d.running_mean!, batchNorm1d.running_var!,
+                bn_eps: 1, batchNorm1d.weight!, batchNorm1d.bias!);
 
-                var newLinear = nn.Linear(20, 5);
-                newLinear.eval();
-                newLinear.weight = weight;
-                newLinear.bias = bias;
+            var newLinear = nn.Linear(20, 5);
+            newLinear.eval();
+            newLinear.weight = weight;
+            newLinear.bias = bias;
 
-                AssertRelativelyEqual(
-                    batchNorm1d.call(linear.call(x)),
-                    newLinear.call(x));
-            }
+            AssertRelativelyEqual(
+                batchNorm1d.call(linear.call(x)),
+                newLinear.call(x));
 
-            {
-                // conv
-                var x = rand([20, 20, 20, 20]) * 100;
-                var conv = nn.Conv2d(20, 5, 3);
-                conv.eval();
-                SetRandomParameter(conv, x => x.weight!);
-                SetRandomParameter(conv, x => x.bias!);
+            // conv
+            x = rand([20, 20, 20, 20]) * 100;
+            var conv = nn.Conv2d(20, 5, 3);
+            conv.eval();
+            SetRandomParameter(conv, x => x.weight!);
+            SetRandomParameter(conv, x => x.bias!);
 
-                var batchNorm2d = nn.BatchNorm2d(5, eps: 13);
-                batchNorm2d.eval();
-                SetRandomParameter(batchNorm2d, x => x.weight!);
-                SetRandomParameter(batchNorm2d, x => x.bias!);
-                SetRandomTensor(batchNorm2d, x => x.running_mean!);
-                SetRandomTensor(batchNorm2d, x => x.running_var!);
+            var batchNorm2d = nn.BatchNorm2d(5, eps: 13);
+            batchNorm2d.eval();
+            SetRandomParameter(batchNorm2d, x => x.weight!);
+            SetRandomParameter(batchNorm2d, x => x.bias!);
+            SetRandomTensor(batchNorm2d, x => x.running_mean!);
+            SetRandomTensor(batchNorm2d, x => x.running_var!);
 
-                (var weight, var bias) = nn.utils.fuse_conv_bn_weights(
-                    conv.weight!, conv.bias,
-                    batchNorm2d.running_mean!, batchNorm2d.running_var!,
-                    bn_eps: 13, batchNorm2d.weight!, batchNorm2d.bias!);
+            (weight, bias) = nn.utils.fuse_conv_bn_weights(
+                conv.weight!, conv.bias,
+                batchNorm2d.running_mean!, batchNorm2d.running_var!,
+                bn_eps: 13, batchNorm2d.weight!, batchNorm2d.bias!);
 
-                var newConv = nn.Conv2d(20, 5, 3);
-                newConv.eval();
-                newConv.weight = weight;
-                newConv.bias = bias;
+            var newConv = nn.Conv2d(20, 5, 3);
+            newConv.eval();
+            newConv.weight = weight;
+            newConv.bias = bias;
 
-                AssertRelativelyEqual(
-                    batchNorm2d.call(conv.call(x)),
-                    newConv.call(x));
-            }
+            AssertRelativelyEqual(
+                batchNorm2d.call(conv.call(x)),
+                newConv.call(x));
         }
 
         [Fact(Skip = "Intermittently fails")]

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -278,62 +278,66 @@ namespace TorchSharp
                 Assert.InRange(maxDifference, -tolerance, tolerance);
             }
 
-            // linear
-            var x = rand([20, 20]) * 100;
+            {
+                // linear
+                var x = rand(new long[] { 20, 20 }) * 100;
 
-            var linear = nn.Linear(20, 5);
-            linear.eval();
-            SetRandomParameter(linear, x => x.weight!);
-            SetRandomParameter(linear, x => x.bias!);
+                var linear = nn.Linear(20, 5);
+                linear.eval();
+                SetRandomParameter(linear, x => x.weight!);
+                SetRandomParameter(linear, x => x.bias!);
 
-            var batchNorm1d = nn.BatchNorm1d(5, eps: 1);
-            batchNorm1d.eval();
-            SetRandomParameter(batchNorm1d, x => x.weight!);
-            SetRandomParameter(batchNorm1d, x => x.bias!);
-            SetRandomTensor(batchNorm1d, x => x.running_mean!);
-            SetRandomTensor(batchNorm1d, x => x.running_var!);
+                var batchNorm1d = nn.BatchNorm1d(5, eps: 1);
+                batchNorm1d.eval();
+                SetRandomParameter(batchNorm1d, x => x.weight!);
+                SetRandomParameter(batchNorm1d, x => x.bias!);
+                SetRandomTensor(batchNorm1d, x => x.running_mean!);
+                SetRandomTensor(batchNorm1d, x => x.running_var!);
 
-            (var weight, var bias) = nn.utils.fuse_linear_bn_weights(
-                linear.weight!, linear.bias,
-                batchNorm1d.running_mean!, batchNorm1d.running_var!,
-                bn_eps: 1, batchNorm1d.weight!, batchNorm1d.bias!);
+                (var weight, var bias) = nn.utils.fuse_linear_bn_weights(
+                    linear.weight!, linear.bias,
+                    batchNorm1d.running_mean!, batchNorm1d.running_var!,
+                    bn_eps: 1, batchNorm1d.weight!, batchNorm1d.bias!);
 
-            var newLinear = nn.Linear(20, 5);
-            newLinear.eval();
-            newLinear.weight = weight;
-            newLinear.bias = bias;
+                var newLinear = nn.Linear(20, 5);
+                newLinear.eval();
+                newLinear.weight = weight;
+                newLinear.bias = bias;
 
-            AssertRelativelyEqual(
-                batchNorm1d.call(linear.call(x)),
-                newLinear.call(x));
+                AssertRelativelyEqual(
+                    batchNorm1d.call(linear.call(x)),
+                    newLinear.call(x));
+            }
 
-            // conv
-            x = rand([20, 20, 20, 20]) * 100;
-            var conv = nn.Conv2d(20, 5, 3);
-            conv.eval();
-            SetRandomParameter(conv, x => x.weight!);
-            SetRandomParameter(conv, x => x.bias!);
+            {
+                // conv
+                var x = rand(new long[] { 20, 20, 20, 20 }) * 100;
+                var conv = nn.Conv2d(20, 5, 3);
+                conv.eval();
+                SetRandomParameter(conv, x => x.weight!);
+                SetRandomParameter(conv, x => x.bias!);
 
-            var batchNorm2d = nn.BatchNorm2d(5, eps: 13);
-            batchNorm2d.eval();
-            SetRandomParameter(batchNorm2d, x => x.weight!);
-            SetRandomParameter(batchNorm2d, x => x.bias!);
-            SetRandomTensor(batchNorm2d, x => x.running_mean!);
-            SetRandomTensor(batchNorm2d, x => x.running_var!);
+                var batchNorm2d = nn.BatchNorm2d(5, eps: 13);
+                batchNorm2d.eval();
+                SetRandomParameter(batchNorm2d, x => x.weight!);
+                SetRandomParameter(batchNorm2d, x => x.bias!);
+                SetRandomTensor(batchNorm2d, x => x.running_mean!);
+                SetRandomTensor(batchNorm2d, x => x.running_var!);
 
-            (weight, bias) = nn.utils.fuse_conv_bn_weights(
-                conv.weight!, conv.bias,
-                batchNorm2d.running_mean!, batchNorm2d.running_var!,
-                bn_eps: 13, batchNorm2d.weight!, batchNorm2d.bias!);
+                (var weight, var bias) = nn.utils.fuse_conv_bn_weights(
+                    conv.weight!, conv.bias,
+                    batchNorm2d.running_mean!, batchNorm2d.running_var!,
+                    bn_eps: 13, batchNorm2d.weight!, batchNorm2d.bias!);
 
-            var newConv = nn.Conv2d(20, 5, 3);
-            newConv.eval();
-            newConv.weight = weight;
-            newConv.bias = bias;
+                var newConv = nn.Conv2d(20, 5, 3);
+                newConv.eval();
+                newConv.weight = weight;
+                newConv.bias = bias;
 
-            AssertRelativelyEqual(
-                batchNorm2d.call(conv.call(x)),
-                newConv.call(x));
+                AssertRelativelyEqual(
+                    batchNorm2d.call(conv.call(x)),
+                    newConv.call(x));
+            }
         }
 
         [Fact(Skip = "Intermittently fails")]

--- a/test/TorchSharpTest/TestTorchSharp.cs
+++ b/test/TorchSharpTest/TestTorchSharp.cs
@@ -239,7 +239,7 @@ namespace TorchSharp
         [Fact]
         public void UtilsFusion()
         {
-            static void FillRandom<T>(
+            static void SetRandomParameter<T>(
                 T module,
                 Expression<Func<T, Modules.Parameter>> parameterProperty)
             {
@@ -254,7 +254,7 @@ namespace TorchSharp
                 property.SetValue(module, newParameter);
             }
 
-            static void FillRandomTensor<T>(
+            static void SetRandomTensor<T>(
                 T module,
                 Expression<Func<T, Tensor>> tensorProperty)
             {
@@ -284,15 +284,15 @@ namespace TorchSharp
 
                 var linear = nn.Linear(20, 5);
                 linear.eval();
-                FillRandom(linear, x => x.weight!);
-                FillRandom(linear, x => x.bias!);
+                SetRandomParameter(linear, x => x.weight!);
+                SetRandomParameter(linear, x => x.bias!);
 
                 var batchNorm1d = nn.BatchNorm1d(5, eps: 1);
                 batchNorm1d.eval();
-                FillRandom(batchNorm1d, x => x.weight!);
-                FillRandom(batchNorm1d, x => x.bias!);
-                FillRandomTensor(batchNorm1d, x => x.running_mean!);
-                FillRandomTensor(batchNorm1d, x => x.running_var!);
+                SetRandomParameter(batchNorm1d, x => x.weight!);
+                SetRandomParameter(batchNorm1d, x => x.bias!);
+                SetRandomTensor(batchNorm1d, x => x.running_mean!);
+                SetRandomTensor(batchNorm1d, x => x.running_var!);
 
                 (var weight, var bias) = nn.utils.fuse_linear_bn_weights(
                     linear.weight!, linear.bias,
@@ -301,8 +301,8 @@ namespace TorchSharp
 
                 var newLinear = nn.Linear(20, 5);
                 newLinear.eval();
-                newLinear.weight = new Modules.Parameter(weight);
-                newLinear.bias = new Modules.Parameter(bias);
+                newLinear.weight = weight;
+                newLinear.bias = bias;
 
                 AssertRelativelyEqual(
                     batchNorm1d.call(linear.call(x)),
@@ -314,15 +314,15 @@ namespace TorchSharp
                 var x = rand([20, 20, 20, 20]) * 100;
                 var conv = nn.Conv2d(20, 5, 3);
                 conv.eval();
-                FillRandom(conv, x => x.weight!);
-                FillRandom(conv, x => x.bias!);
+                SetRandomParameter(conv, x => x.weight!);
+                SetRandomParameter(conv, x => x.bias!);
 
                 var batchNorm2d = nn.BatchNorm2d(5, eps: 13);
                 batchNorm2d.eval();
-                FillRandom(batchNorm2d, x => x.weight!);
-                FillRandom(batchNorm2d, x => x.bias!);
-                FillRandomTensor(batchNorm2d, x => x.running_mean!);
-                FillRandomTensor(batchNorm2d, x => x.running_var!);
+                SetRandomParameter(batchNorm2d, x => x.weight!);
+                SetRandomParameter(batchNorm2d, x => x.bias!);
+                SetRandomTensor(batchNorm2d, x => x.running_mean!);
+                SetRandomTensor(batchNorm2d, x => x.running_var!);
 
                 (var weight, var bias) = nn.utils.fuse_conv_bn_weights(
                     conv.weight!, conv.bias,
@@ -331,8 +331,8 @@ namespace TorchSharp
 
                 var newConv = nn.Conv2d(20, 5, 3);
                 newConv.eval();
-                newConv.weight = new Modules.Parameter(weight);
-                newConv.bias = new Modules.Parameter(bias);
+                newConv.weight = weight;
+                newConv.bias = bias;
 
                 AssertRelativelyEqual(
                     batchNorm2d.call(conv.call(x)),


### PR DESCRIPTION
Hello! I've tried to add two methods `fuse_conv_bn_weights` and `fuse_linear_bn_weights` in `torch.nn.utils`. 

Since it's my first pull request that modifies the code, could someone please give me some advice? In fact I'm not sure about the following things:

- Am I required to add a high coverage unit test? Meanwhile, where could I put some tests?
    - I've found some similar methods like `clip_grad_value_` does not have a related unit test, and `parameters_to_vector`'s tests are placed in `TestTorchSharp` and named `UtilsPtoV`, so I'm a bit confused with that.
    - (Actually I haven't check whether the two methods could work correctly, although I believe they do, since what I have done is just translating the python codes into csharp.)
- Should I always dispose all the temporary tensors, or just leave it there (and wait for GC or dispose together with the outer dispose scope if there is one)?
    - I've found many methods does not deal with this, especially in `torchaudio.transform`. Meanwhile most functions just invoke the native code and returns the result without any extra tensors. So I'm not sure whether `torchaudio` is an exception or it is recommend to leave these tensors aside.
- Should I check the arguments and throw exception in advance (like whether they are null, or whether a tensor' shape is expected), or just let it continue until there is an inner exception thrown?