### PR TITLE
more properties of modules

### DIFF
--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -18,21 +18,8 @@ namespace TorchSharp
             {
             }
 
-            public long in_features {
-                get {
-                    var weight = this.weight;
-                    Debug.Assert(weight is not null);
-                    return weight.size(1);
-                }
-            }
-
-            public long out_features {
-                get {
-                    var weight = this.weight;
-                    Debug.Assert(weight is not null);
-                    return weight.size(0);
-                }
-            }
+            public long in_features => weight!.size(1);
+            public long out_features => weight!.size(0);
 
             public override Tensor forward(Tensor tensor)
             {

--- a/src/TorchSharp/NN/Linear.cs
+++ b/src/TorchSharp/NN/Linear.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using static TorchSharp.PInvoke.NativeMethods;
@@ -15,6 +16,22 @@ namespace TorchSharp
         {
             internal Linear(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
             {
+            }
+
+            public long in_features {
+                get {
+                    var weight = this.weight;
+                    Debug.Assert(weight is not null);
+                    return weight.size(1);
+                }
+            }
+
+            public long out_features {
+                get {
+                    var weight = this.weight;
+                    Debug.Assert(weight is not null);
+                    return weight.size(0);
+                }
             }
 
             public override Tensor forward(Tensor tensor)

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -26,13 +26,7 @@ namespace TorchSharp
                 this.track_running_stats = track_running_stats;
             }
 
-            public long num_features {
-                get {
-                    var weight = this.weight;
-                    Debug.Assert(weight is not null);
-                    return weight.size(0);
-                }
-            }
+            public long num_features => weight!.size(0);
 
             public double eps { get; }
             public double momentum { get; }
@@ -145,7 +139,7 @@ namespace TorchSharp
                 unsafe {
                     var handle = THSNN_BatchNorm1d_ctor(features, eps, momentum, affine, track_running_stats, out var boxedHandle);
                     if (handle == IntPtr.Zero) { torch.CheckForErrors(); }
-                    return new BatchNorm1d(handle, boxedHandle).MoveModule<BatchNorm1d>(device, dtype);
+                    return new BatchNorm1d(handle, boxedHandle, eps, momentum, affine, track_running_stats).MoveModule<BatchNorm1d>(device, dtype);
                 }
             }
         }

--- a/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
+++ b/src/TorchSharp/NN/Normalization/BatchNorm1D.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics;
 using static TorchSharp.torch;
 using static TorchSharp.PInvoke.NativeMethods;
 
@@ -15,9 +16,28 @@ namespace TorchSharp
         /// </summary>
         public sealed class BatchNorm1d : torch.nn.Module<Tensor, Tensor>
         {
-            internal BatchNorm1d(IntPtr handle, IntPtr boxedHandle) : base(handle, boxedHandle)
+            internal BatchNorm1d(IntPtr handle, IntPtr boxedHandle,
+                double eps, double momentum, bool affine, bool track_running_stats)
+                : base(handle, boxedHandle)
             {
+                this.eps = eps;
+                this.momentum = momentum;
+                this.affine = affine;
+                this.track_running_stats = track_running_stats;
             }
+
+            public long num_features {
+                get {
+                    var weight = this.weight;
+                    Debug.Assert(weight is not null);
+                    return weight.size(0);
+                }
+            }
+
+            public double eps { get; }
+            public double momentum { get; }
+            public bool affine { get; }
+            public bool track_running_stats { get; }
 
             public override Tensor forward(Tensor tensor)
             {


### PR DESCRIPTION
Hello! The problem happens when I was trying to deal with `fuse_linear_bn_eval`.

In PyTorch, it requires `copy.deepcopy` to copy the layers. We don't have that in csharp and my idea is just to use `torch.nn.Linear` to create a new one. (I think that could always work since `Linear` is a sealed class so it's impossible for the users to pass me some other customized things. That's great.)

To create it, I should provide `inputSize`, `outputSize`, `hasBias` and also `device` and `dtype`. However, those values cannot be directly get from the given `Linear`. Of course, for `Linear`, I could infer them from its `weight`, but meanwhile I also want the `eps` of a `BatchNorm1d`, which seems completely inaccessible currently.

So I'm creating this pull request to show a possible solution, with adding some properties in the module class. In the codes I prefer to infer the values from a tensor, and if cannot, it have to ask for an extra parameter in the constructor. (Actually I suggest to always use the latter way, keeping more things in csharp level.)

However this may touch some basic designs of TorchSharp, like whether other modules should also add similar properties, which may lead to a great amount of work. Thus the pull request is more for finding a solution, and is not that prepared to be merged.