### PR TITLE
correct torch.finfo

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,13 @@
 ## TorchSharp Release Notes
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
+
+# NuGet Version 0.102.4
+
+__Breaking Changes__:
+
+Correct `torch.finfo`. (`torch.set_default_dtype`, `Categorical.entropy`, `_CorrCholesky.check`, `Distribution.ClampProbs`, `FisherSnedecor.rsample`, `Gamma.rsample`, `Geometric.rsample`, `distributions.Gumbel`, `Laplace.rsample`, `SigmoidTransform._call` and `SigmoidTransform._inverse` are influenced.)
+
 # NuGet Version 0.102.3
 
 __Breaking Changes__:

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -7226,37 +7226,63 @@ namespace TorchSharp
             public double max;
             public double min;
             public double tiny;
+            public double smallest_normal;
+            public double resolution;
+        }
+
+        public static FInfo finfo()
+        {
+            return finfo(default_dtype);
         }
 
         public static FInfo finfo(ScalarType dtype)
         {
-            if (!is_floating_point(dtype) && !is_complex(dtype))
-                throw new ArgumentException("'dtype' must be floating point or complex");
-
-            if (dtype == ScalarType.ComplexFloat32)
-                dtype = ScalarType.Float32;
-            if (dtype == ScalarType.ComplexFloat64)
-                dtype = ScalarType.Float64;
-
-            FInfo result = new FInfo();
-
             switch (dtype) {
+            case ScalarType.BFloat16:
+                return new FInfo() {
+                    bits = 16,
+                    eps = 0.0078125,
+                    max = 3.3895313892515355e+38,
+                    min = -3.3895313892515355e+38,
+                    tiny = 1.1754943508222875e-38,
+                    smallest_normal = 1.1754943508222875e-38,
+                    resolution = 0.01
+                };
+            case ScalarType.Float16:
+                return new FInfo() {
+                    bits = 16,
+                    eps = 0.0009765625,
+                    max = 65504.0,
+                    min = -65504.0,
+                    tiny = 6.103515625e-05,
+                    smallest_normal = 6.103515625e-05,
+                    resolution = 0.001
+                };
             case ScalarType.Float32:
-                result.bits = 32;
-                result.min = float.MinValue;
-                result.max = float.MaxValue;
-                result.eps = float.Epsilon;
-                result.tiny = float.Epsilon;
-                break;
+            case ScalarType.ComplexFloat32:
+                return new FInfo() {
+                    bits = 32,
+                    eps = 1.1920928955078125e-07,
+                    max = 3.4028234663852886e+38,
+                    min = -3.4028234663852886e+38,
+                    tiny = 1.1754943508222875e-38,
+                    smallest_normal = 1.1754943508222875e-38,
+                    resolution = 1e-06
+                };
             case ScalarType.Float64:
-                result.bits = 64;
-                result.min = double.MinValue;
-                result.max = double.MaxValue;
-                result.eps = double.Epsilon;
-                result.tiny = double.Epsilon;
-                break;
+            case ScalarType.ComplexFloat64:
+                return new FInfo() {
+                    bits = 64,
+                    eps = 2.220446049250313e-16,
+                    max = 1.7976931348623157e+308,
+                    min = -1.7976931348623157e+308,
+                    tiny = 2.2250738585072014e-308,
+                    smallest_normal = 2.2250738585072014e-308,
+                    resolution = 1e-15
+                };
+            default:
+                throw new ArgumentException("'dtype' must be floating point or complex");
             }
-            return result;
         }
 
         public static bool is_integral(ScalarType type)

--- a/src/TorchSharp/Tensor/torch.Tensors.cs
+++ b/src/TorchSharp/Tensor/torch.Tensors.cs
@@ -46,7 +46,13 @@ namespace TorchSharp
         /// The default floating point dtype is initially torch.float32.
         /// </summary>
         /// <param name="dtype"></param>
-        public static void set_default_dtype(ScalarType dtype) { default_dtype = dtype; }
+        public static void set_default_dtype(ScalarType dtype)
+        {
+            if (!dtype.IsFloatingPoint()) {
+                throw new ArgumentException("only floating-point types are supported as the default type");
+            }
+            default_dtype = dtype;
+        }
 
         // https://pytorch.org/docs/stable/generated/torch.get_default_dtype
         /// <summary>


### PR DESCRIPTION
fixes #1279 

1. add support for `Float16` and `BFloat16`
2. correct the result (`eps` should not be equal to c# `Epsilon`, and meanwhile `tiny` is not `eps`.)
3. add more fields in `FInfo`
4. `torch.set_default_dtype` will no longer accept non-floating types

Note: `Categorical.entropy`, `_CorrCholesky.check`, `Distribution.ClampProbs`, `FisherSnedecor.rsample`, `Gamma.rsample`, `Geometric.rsample`, `distributions.Gumbel`, `Laplace.rsample`, `SigmoidTransform._call` and `SigmoidTransform._inverse` are influenced. **I'm not sure whether they could work correctly now.**
