### PR TITLE
in exportsd.py, call detach() before numpy()

### DIFF
--- a/src/Python/exportsd.py
+++ b/src/Python/exportsd.py
@@ -37,7 +37,7 @@ def _write_tensor(t, stream):
     stream.write(leb128.u.encode(len(t.shape)))
     for s in t.shape:
         stream.write(leb128.u.encode(s))
-    stream.write(t.numpy().tobytes())
+    stream.write(t.detach().numpy().tobytes())
 
 def write_tensor(t, file_name):
     f = open(file_name, "wb")

--- a/src/Python/exportsd.py
+++ b/src/Python/exportsd.py
@@ -37,7 +37,7 @@ def _write_tensor(t, stream):
     stream.write(leb128.u.encode(len(t.shape)))
     for s in t.shape:
         stream.write(leb128.u.encode(s))
-    stream.write(t.detach().numpy().tobytes())
+    stream.write(t.detach().cpu().numpy().tobytes())
 
 def write_tensor(t, file_name):
     f = open(file_name, "wb")


### PR DESCRIPTION
An error occurred when trying to save the downloaded pretained model:

```python
states = weight.get_state_dict()
exportsd.save_state_dict(states, file)
```

(where `weight` is something like `torchvision.models.AlexNet_Weights.IMAGENET1K_V1`)

([full codes here](https://huggingface.co/spaces/yueyinqiu/vision-TorchSharp-generator/tree/main))