### PR TITLE
leaf normal

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,7 @@ __API Changes__:
 
 __Bug Fixes__:
 
+- `torch.normal` will now correctly return a leaf tensor.
 
 # NuGet Version 0.102.4
 

--- a/src/TorchSharp/Tensor/Factories/Tensor.Factories.cs
+++ b/src/TorchSharp/Tensor/Factories/Tensor.Factories.cs
@@ -116,7 +116,8 @@ namespace TorchSharp
         /// <returns></returns>
         public static Tensor normal(double mean, double std, ReadOnlySpan<long> size, ScalarType? dtype = null, Device? device = null, bool requires_grad = false, Generator? generator = null, string[]? names = null)
         {
-            return randn(size, dtype: dtype, device: device, requires_grad: requires_grad, generator: generator) * std + mean;
+            return randn(size, dtype, device, requires_grad: false, generator, names)
+                .mul_(std).add_(mean).requires_grad_(requires_grad);
         }
 
         /// <summary>


### PR DESCRIPTION
`torch.normal` is returning a non-leaf tensor (and also no names).