### PR TITLE
Append unhandled exception message to trace

### DIFF
--- a/src/TorchSharp/Torch.cs
+++ b/src/TorchSharp/Torch.cs
@@ -60,7 +60,8 @@ namespace TorchSharp
                 ok = NativeLibrary.TryLoad(path, out var res);
                 if (!ok)
                     trace.AppendLine($"    Failed to load native component {path}");
-            } catch {
+            } catch (Exception exn) {
+                trace.AppendLine($"    Failed to load native component {path}: {exn.Message}");
                 ok = false;
             }
             return ok;


### PR DESCRIPTION
Improves debugging of native library loading exceptions by printing any unhandled exceptions to the trace log.

Fixes #1310 