### PR TITLE
Make GetTargetPath return valid path for nupkgprojs

### DIFF
--- a/pkg/Directory.Build.targets
+++ b/pkg/Directory.Build.targets
@@ -5,4 +5,13 @@
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>$(PreviousPackageVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>
+
+  <Target Name="GetTargetPath" Returns="@(_updatedTargetPath)">
+    <!-- Repoint up the TargetPath to represent the a matching file from PackagePreparationPath if it exists, otherwise don't return a target path
+         This fakes what the project output would be if we were using real projects (and not package projects) to represent these libraries. -->
+    <ItemGroup>
+      <_targetPathUnderPackagePrep Include="@(TargetPathWithTargetPlatformMoniker->'$(PackagePreparationPath)$(PackageIdFolderName)\lib\$(TargetFramework)\%(FileName)%(Extension)')" />
+      <_updatedTargetPath Include="@(_targetPathUnderPackagePrep)" Condition="Exists('%(Identity)')" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
This is needed for APICompat which loads references when comparing assemblies.  It get's those references from the project's resolved references (packages / projects) and the nupkgproj's were returning a bogus path.  This target makes them return a path from the prep folder where they grab their content -- if it exists.