### PR TITLE
Disable package validation for libtorch packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,7 +87,7 @@
   <!-- we manually update these -->
   <PropertyGroup Condition="'$(MSBuildProjectName.IndexOf(`libtorch-`))' != '-1'">
     <LibTorchPackageVersion>2.2.1.1</LibTorchPackageVersion>
-    <PreviousPackageVersion>2.2.1.1</PreviousPackageVersion>
+    <EnablePackageValidation>false</EnablePackageValidation>
     <VersionPrefix>$(LibTorchPackageVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>

--- a/pkg/Directory.Build.targets
+++ b/pkg/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Build.targets" />
 
-  <PropertyGroup Condition="'$(IsPackable)' != 'false'">
+  <PropertyGroup Condition="'$(IsPackable)' != 'false' and '$(EnablePackageValidation)' != 'false'">
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>$(PreviousPackageVersion)</PackageValidationBaselineVersion>
   </PropertyGroup>


### PR DESCRIPTION
These don't contain managed surface area so running APICompat doesn't provide much value.  Disable it to reduce the time spent and eliminate the need to record and restore previous versions of libtorch.