### PR TITLE
concat dataset

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,7 +11,8 @@ A new interface `IDataset<out T>` has been added. (Now `Dataset<T>` implements `
 
 __API Changes__:
 
-The parameter of `DataLoader` has been changed to `IDataset` to accept more kinds of datasets.<br/>
+The parameter of `DataLoader`s has been relaxed to `IDataset`.<br/>
+The parameter of `DataLoader`s' collate functions has been relaxed to `IReadOnlyList`.<br/>
 
 # NuGet Version 0.102.6
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,17 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+# NuGet Version 0.102.7
+
+__Breaking Changes__:
+
+A new interface `IDataset<out T>` has been added. (Now `Dataset<T>` implements `IDataset<T>`; `Dataset` implements both `IDataset<Dictionary<string, Tensor>>` and `IDataset<IReadOnlyDictionary<string, Tensor>>`; `IterableDataset` implements `IDataset<IList<string, Tensor>>` and `IDataset<IEnumerable<string, Tensor>>`.)<br/>
+`torch.utils.data.ConcatDataset` has been added.<br/>
+
+__API Changes__:
+
+The parameter of `DataLoader` has been changed to `IDataset` to accept more kinds of datasets.<br/>
+
 # NuGet Version 0.102.6
 
 __Breaking Changes__:

--- a/src/TorchSharp/ConcatDataset.cs
+++ b/src/TorchSharp/ConcatDataset.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TorchSharp.Modules;
+
+namespace TorchSharp
+{
+    public static partial class torch
+    {
+        public static partial class utils
+        {
+            public static partial class data
+            {
+                public static ConcatDataset<T> ConcatDataset<T>(IEnumerable<IDataset<T>> datasets)
+                {
+                    return new ConcatDataset<T>(datasets);
+                }
+            }
+        }
+    }
+
+    namespace Modules
+    {
+        public class ConcatDataset<T> : torch.utils.data.Dataset<T>
+        {
+            private static IEnumerable<long> Cumsum(
+                IEnumerable<torch.utils.data.IDataset<T>> datasets)
+            {
+                var s = 0L;
+                foreach (var e in datasets) {
+                    s += e.Count;
+                    yield return s;
+                }
+            }
+            private static long bisectRight(long[] a, long x)
+            {
+                var lo = 0;
+                var hi = a.Length;
+                while (lo < hi) {
+                    var mid = (lo + hi) / 2;
+                    if (x < a[mid])
+                        hi = mid;
+                    else
+                        lo = mid + 1;
+                }
+                return lo;
+            }
+
+
+            private readonly torch.utils.data.IDataset<T>[] _datasets;
+            public IReadOnlyList<torch.utils.data.IDataset<T>> datasets => _datasets;
+
+            private readonly long[] _cumulativeSizes;
+            public IReadOnlyList<long> cumulative_sizes => _cumulativeSizes;
+
+            private readonly bool autoDispose;
+
+            public ConcatDataset(
+                IEnumerable<torch.utils.data.IDataset<T>> datasets,
+                bool autoDispose = true)
+            {
+                this._datasets = datasets.ToArray();
+                if (this._datasets.Length is 0)
+                    throw new ArgumentException(
+                        "datasets should not be an empty iterable", nameof(datasets));
+
+                // PyTorch also says 'ConcatDataset does not support IterableDataset'.
+                // But it's not our torch.utils.data.IterableDataset in TorchSharp.
+                this._cumulativeSizes = Cumsum(datasets).ToArray();
+
+                this.autoDispose = autoDispose;
+            }
+
+            public override long Count => this._cumulativeSizes.Last();
+
+            public override T GetTensor(long index)
+            {
+                if (index < 0) {
+                    if (-index > this.Count) {
+                        throw new ArgumentException(
+                            "absolute value of index should not exceed dataset length",
+                            nameof(index));
+                    }
+                    index = this.Count + index;
+                }
+
+                var datasetIdx = bisectRight(this._cumulativeSizes, index);
+                long sampleIdx;
+                if (datasetIdx == 0)
+                    sampleIdx = index;
+                else
+                    sampleIdx = index - this._cumulativeSizes[datasetIdx - 1];
+                return this._datasets[datasetIdx][sampleIdx];
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing && autoDispose) {
+                    foreach (var dataset in this._datasets)
+                        dataset.Dispose();
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/src/TorchSharp/DataLoader.cs
+++ b/src/TorchSharp/DataLoader.cs
@@ -17,9 +17,8 @@ namespace TorchSharp
         {
             public static partial class data
             {
-
                 public static Modules.DataLoader DataLoader(
-                    Dataset dataset,
+                    IDataset<IReadOnlyDictionary<string, torch.Tensor>> dataset,
                     int batchSize, IEnumerable<long> shuffler,
                     Device device = null,
                     int num_worker = 1, bool drop_last = false,
@@ -34,7 +33,7 @@ namespace TorchSharp
                 }
 
                 public static Modules.DataLoader DataLoader(
-                    Dataset dataset,
+                    IDataset<IReadOnlyDictionary<string, torch.Tensor>> dataset,
                     int batchSize, bool shuffle = false,
                     Device device = null, int? seed = null,
                     int num_worker = 1, bool drop_last = false,
@@ -49,7 +48,7 @@ namespace TorchSharp
                 }
 
                 public static Modules.IterableDataLoader DataLoader(
-                    IterableDataset dataset,
+                    IDataset<IEnumerable<Tensor>> dataset,
                     int batchSize, IEnumerable<long> shuffler,
                     Device device = null,
                     int num_worker = 1, bool drop_last = false,
@@ -64,7 +63,7 @@ namespace TorchSharp
                 }
 
                 public static Modules.IterableDataLoader DataLoader(
-                    IterableDataset dataset,
+                    IDataset<IEnumerable<Tensor>> dataset,
                     int batchSize, bool shuffle = false,
                     Device device = null, int? seed = null,
                     int num_worker = 1, bool drop_last = false,
@@ -90,7 +89,8 @@ namespace TorchSharp
         /// Data loader. Combines a dataset and a sampler, and provides an enumerator over the given dataset.
         /// </summary>
         /// <remarks>This class is used for map-style data sets</remarks>
-        public class DataLoader : DataLoader<Dictionary<string, torch.Tensor>, Dictionary<string, torch.Tensor>>
+        public class DataLoader : DataLoader<IReadOnlyDictionary<string, torch.Tensor>,
+            Dictionary<string, torch.Tensor>>
         {
             /// <summary>
             /// Pytorch style dataloader
@@ -111,7 +111,7 @@ namespace TorchSharp
             /// Indicates whether to dispose the dataset when being disposed.
             /// </param>
             public DataLoader(
-                Dataset dataset,
+                IDataset<IReadOnlyDictionary<string, torch.Tensor>> dataset,
                 int batchSize, IEnumerable<long> shuffler,
                 Device device = null,
                 int num_worker = 1, bool drop_last = false,
@@ -144,7 +144,7 @@ namespace TorchSharp
             /// Indicates whether to dispose the dataset when being disposed.
             /// </param>
             public DataLoader(
-                Dataset dataset,
+                IDataset<IReadOnlyDictionary<string, torch.Tensor>> dataset,
                 int batchSize, bool shuffle = false,
                 Device device = null, int? seed = null,
                 int num_worker = 1, bool drop_last = false,
@@ -157,7 +157,8 @@ namespace TorchSharp
             {
             }
 
-            private static Dictionary<string, torch.Tensor> Collate(IEnumerable<Dictionary<string, torch.Tensor>> dic, torch.Device device)
+            private static Dictionary<string, torch.Tensor> Collate(
+                IEnumerable<IReadOnlyDictionary<string, torch.Tensor>> dic, torch.Device device)
             {
                 using (torch.NewDisposeScope()) {
                     Dictionary<string, torch.Tensor> batch = new();
@@ -176,7 +177,8 @@ namespace TorchSharp
         /// Data loader. Combines a dataset and a sampler, and provides an enumerator over the given dataset.
         /// </summary>
         /// <remarks>This class is used for list-style data sets</remarks>
-        public class IterableDataLoader : DataLoader<IList<torch.Tensor>, IList<torch.Tensor>>
+        public class IterableDataLoader :
+            DataLoader<IEnumerable<torch.Tensor>, IList<torch.Tensor>>
         {
             /// <summary>
             /// Pytorch style dataloader
@@ -197,7 +199,7 @@ namespace TorchSharp
             /// Indicates whether to dispose the dataset when being disposed.
             /// </param>
             public IterableDataLoader(
-                IterableDataset dataset,
+                IDataset<IEnumerable<Tensor>> dataset,
                 int batchSize, IEnumerable<long> shuffler,
                 Device device = null,
                 int num_worker = 1, bool drop_last = false,
@@ -230,7 +232,7 @@ namespace TorchSharp
             /// Indicates whether to dispose the dataset when being disposed.
             /// </param>
             public IterableDataLoader(
-                IterableDataset dataset,
+                IDataset<IEnumerable<Tensor>> dataset,
                 int batchSize, bool shuffle = false,
                 Device device = null, int? seed = null,
                 int num_worker = 1, bool drop_last = false,
@@ -243,12 +245,18 @@ namespace TorchSharp
             {
             }
 
-            private static IList<torch.Tensor> Collate(IEnumerable<IList<torch.Tensor>> dic, torch.Device device)
+            private static IList<torch.Tensor> Collate(
+                IReadOnlyList<IEnumerable<torch.Tensor>> dic, torch.Device device)
             {
+                var dicCopy = new List<torch.Tensor[]>();
+                foreach (var e in dic) {
+                    dicCopy.Add(e.ToArray());
+                }
+
                 using (torch.NewDisposeScope()) {
                     List<torch.Tensor> batch = new();
-                    for (var x = 0; x < dic.First().Count; x++) {
-                        var t = cat(dic.Select(k => k[x].unsqueeze(0)).ToArray(), 0);
+                    for (var x = 0; x < dicCopy[0].Length; x++) {
+                        var t = cat(dicCopy.Select(k => k[x].unsqueeze(0)).ToArray(), 0);
                         if (t.device_type != device.type || t.device_index != device.index)
                             t = t.to(device);
                         batch.Add(t.MoveToOuterDisposeScope());
@@ -264,12 +272,12 @@ namespace TorchSharp
         /// </summary>
         public class DataLoader<T, S> : IEnumerable<S>, IDisposable
         {
-            public Dataset<T> dataset { get; }
+            public IDataset<T> dataset { get; }
             public int batch_size { get; }
             public bool drop_last { get; }
             public IEnumerable<long> sampler { get; }
             public int num_workers { get; }
-            public Func<IEnumerable<T>, Device, S> collate_fn { get; }
+            public Func<IReadOnlyList<T>, Device, S> collate_fn { get; }
 
             public Device Device { get; }
             public bool DisposeBatch { get; }
@@ -295,9 +303,9 @@ namespace TorchSharp
             /// Indicates whether to dispose the dataset when being disposed.
             /// </param>
             public DataLoader(
-                Dataset<T> dataset,
+                IDataset<T> dataset,
                 int batchSize,
-                Func<IEnumerable<T>, torch.Device, S> collate_fn,
+                Func<IReadOnlyList<T>, torch.Device, S> collate_fn,
                 IEnumerable<long> shuffler,
                 Device? device = null,
                 int num_worker = 1,
@@ -337,9 +345,9 @@ namespace TorchSharp
             /// Indicates whether to dispose the dataset when being disposed.
             /// </param>
             public DataLoader(
-                Dataset<T> dataset,
+                IDataset<T> dataset,
                 int batchSize,
-                Func<IEnumerable<T>, torch.Device, S> collate_fn,
+                Func<IReadOnlyList<T>, torch.Device, S> collate_fn,
                 bool shuffle = false,
                 Device? device = null,
                 int? seed = null,
@@ -432,7 +440,7 @@ namespace TorchSharp
                         .WithDegreeOfParallelism(loader.num_workers)
                         .ForAll((i) => {
                             using var getTensorScope = torch.NewDisposeScope();
-                            tensors[i] = loader.dataset.GetTensor(indices[i]);
+                            tensors[i] = loader.dataset[indices[i]];
                             getTensorDisposables[i] = getTensorScope.DetachAllAndDispose();
                         });
 

--- a/src/TorchSharp/Dataset.cs
+++ b/src/TorchSharp/Dataset.cs
@@ -14,15 +14,23 @@ namespace TorchSharp
                 /// <summary>
                 /// Map-style data set
                 /// </summary>
-                public abstract class Dataset : Dataset<Dictionary<string, torch.Tensor>>
+                public abstract class Dataset : Dataset<Dictionary<string, Tensor>>,
+                    IDataset<IReadOnlyDictionary<string, Tensor>>
                 {
+                    // Due to covariation, it should naturally be IDataset<IReadOnlyDictionary<string, Tensor>>.
+                    // However FSharp.Examples will break down without this.
+                    IReadOnlyDictionary<string, Tensor> IDataset<IReadOnlyDictionary<string, Tensor>>.this[long index] => this[index];
                 }
 
                 /// <summary>
                 /// Iterable-style data sets
                 /// </summary>
-                public abstract class IterableDataset : Dataset<IList<Tensor>>
+                public abstract class IterableDataset : Dataset<IList<Tensor>>,
+                    IDataset<IEnumerable<Tensor>>
                 {
+                    // Due to covariation, it should naturally be IDataset<IEnumerable<Tensor>>.
+                    // However FSharp.Examples will break down without this.
+                    IEnumerable<Tensor> IDataset<IEnumerable<Tensor>>.this[long index] => this[index];
                 }
 
                 /// <summary>

--- a/src/TorchSharp/Dataset.cs
+++ b/src/TorchSharp/Dataset.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors.  All Rights Reserved.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace TorchSharp
 {
@@ -27,7 +28,7 @@ namespace TorchSharp
                 /// <summary>
                 /// The base nterface for all Datasets.
                 /// </summary>
-                public abstract class Dataset<T> : IDisposable
+                public abstract class Dataset<T> : IDataset<T>, IDisposable
                 {
                     public void Dispose()
                     {
@@ -40,6 +41,12 @@ namespace TorchSharp
                     /// </summary>
                     public abstract long Count { get; }
 
+                    [IndexerName("DatasetItems")]
+                    public T this[long index] => this.GetTensor(index);
+
+                    // GetTensor is kept for compatibility.
+                    // Perhaps we should remove that and make the indexer abstract later.
+
                     /// <summary>
                     /// Get tensor according to index
                     /// </summary>
@@ -49,7 +56,30 @@ namespace TorchSharp
 
                     protected virtual void Dispose(bool disposing)
                     {
+                        IDataset<Dictionary<string, string>> a = null;
+                        IDataset<IReadOnlyDictionary<string, string>> b = a;
                     }
+                }
+
+                /// <summary>
+                /// The base interface for all Datasets.
+                /// </summary>
+                public interface IDataset<out T> : IDisposable
+                {
+                    /// <summary>
+                    /// Size of dataset
+                    /// </summary>
+                    long Count { get; }
+
+                    /// <summary>
+                    /// Get tensor according to index
+                    /// </summary>
+                    /// <param name="index">Index for tensor</param>
+                    /// <returns>Tensors of index. DataLoader will catenate these tensors into batches.</returns>
+                    [IndexerName("DatasetItems")]
+                    T this[long index] { get; }
+
+                    // TODO: support System.Index
                 }
             }
         }

--- a/src/TorchSharp/Utils/TensorDataset.cs
+++ b/src/TorchSharp/Utils/TensorDataset.cs
@@ -41,16 +41,6 @@ namespace TorchSharp
             }
 
             /// <summary>
-            /// Indexer
-            /// </summary>
-            public IList<torch.Tensor> this[long index] {
-
-                get {
-                    return _tensors.Select(t => t[index]).ToList();
-                }
-            }
-
-            /// <summary>
             /// Length of the dataset, i.e. the size of the first dimension.
             /// </summary>
             public override long Count {
@@ -59,7 +49,7 @@ namespace TorchSharp
 
             public override IList<torch.Tensor> GetTensor(long index)
             {
-                return this[index];
+                return _tensors.Select(t => t[index]).ToList();
             }
 
             readonly torch.Tensor[] _tensors;

--- a/test/TorchSharpTest/TestDataLoader.cs
+++ b/test/TorchSharpTest/TestDataLoader.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using TorchSharp.Modules;
 using Xunit;
+using static TorchSharp.torch;
 
 
 namespace TorchSharp
@@ -305,6 +306,18 @@ namespace TorchSharp
             Assert.True(dataset1.Disposed);
             Assert.True(dataset2.Disposed);
             Assert.True(dataset3.Disposed);
+        }
+
+        [Fact]
+        public void ConcatDatasetDataLoader()
+        {
+            using var dataset = torch.utils.data.ConcatDataset<IReadOnlyDictionary<string, Tensor>>(
+                new[] {
+                    new TestDataset(),
+                    new TestDataset(),
+                });
+            var dataloader = torch.utils.data.DataLoader(dataset, 10, false);
+            Assert.Equal(2, dataloader.Count);
         }
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/TorchSharp/discussions/1348#discussioncomment-10035168

- add `torch.utils.data.ConcatDataset`
    - The parameter of `DataLoader`s has been relaxed to `IDataset<out T>` (a new covariant interface), thus accepting the concated dataset
        - now `Dataset<T>` implements `IDataset<T>`
        - `Dataset` implements both `IDataset<Dictionary<string, Tensor>>` and `IDataset<IReadOnlyDictionary<string, Tensor>>`
        - `IterableDataset` implements `IDataset<IList<string, Tensor>>` and `IDataset<IEnumerable<string, Tensor>>`
- parameter of collate functions has been relaxed to `IReadOnlyList`