### PR TITLE
Fixing Tensor.backward's function signature

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,9 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 
 # NuGet Version 0.103.1
 
+__Breaking Changes__:
+#1376 `torch.Tensor.backward`'s function signature has been updated to match PyTorch's implementation. Previously, passing `create_graph` or `retain_graph` by position would work like PyTorch's `torch.Tensor.backward`, but not if passing by name (`create_graph`'s value was swapped with `retain_graph`). This has been corrected; however, this means any code that passes `create_graph` or `retain_graph` by name needs to be updated to reflect the intended functionality.<br/>
+
 __Bug Fixes__:
 
 #1383 `torch.linalg.vector_norm`: Make `ord`-argument optional, as specified in docs<br/>

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -697,8 +697,8 @@ namespace TorchSharp
                 }
             }
 
-            public void backward(IList<Tensor>? grad_tensors = null, bool create_graph = false, bool retain_graph = false, IList<Tensor>? inputs = null) =>
-                torch.autograd.backward(new[] { this }, grad_tensors, create_graph, retain_graph, inputs);
+            public void backward(IList<Tensor>? grad_tensors = null, bool retain_graph = false, bool create_graph = false, IList<Tensor>? inputs = null) =>
+                torch.autograd.backward(new[] { this }, grad_tensors, retain_graph, create_graph, inputs);
 
             /// <summary>
             /// Creates a tensor by loading it from a file.


### PR DESCRIPTION
Fixes #692 

TLDR: `Tensor.backward` has a different parameter order compared to PyTorch and also swaps `retain_graph` and `create_graph` in its internal function call.

See https://pytorch.org/docs/stable/generated/torch.Tensor.backward.html for backward's function signature:
`Tensor.backward(gradient=None, retain_graph=None, create_graph=False, inputs=None)`

The current TorchSharp version's function signature is:
`Tensor.backward(grad_tensors=null, create_graph=false, retain_graph=false, inputs=null)`

Note the difference between the ordering of `retain_graph` and `create_graph`. `Tensor.backward` is just a wrapper to `torch.autograd.backward` which has a function signature of:
`autograd.backward(tensors, grad_tensors=null, retain_graph=null, create_graph=false, inputs=null)`

This means calling `Tensor.backward(retain_graph: true)` in TorchSharp is actually `Tensor.backward(create_graph:true)` in PyTorch. Same thing for `Tensor.backward(create_graph: true)` actually being `Tensor.backward(retain_graph:true)`.

The proposed fix is breaking and would change the `Tensor.backward` function signature to match PyTorch. However, nobody noticed for like 2 years anyway and imo `retain_graph` should actually mean `retain_graph` (and same for `create_graph`) 🙂. 