### PR TITLE
`torch.linalg.vector_norm` : Set `ord` default as specified in docs

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,12 @@
 
 Releases, starting with 9/2/2021, are listed with the most recent release at the top.
 
+# NuGet Version 0.103.1
+
+__Bug Fixes__:
+
+#1383 `torch.linalg.vector_norm`: Make `ord`-argument optional, as specified in docs
+
 # NuGet Version 0.103.0
 
 Move to libtorch 2.4.0.
@@ -115,8 +121,8 @@ Any code that checks whether a device is 'CUDA' and does something rather than c
 
 __API Changes__:
 
-#652: Apple Silicon support .<br/> 
-#1219: Added support for loading and saving tensors that are >2GB.<br/> 
+#652: Apple Silicon support .<br/>
+#1219: Added support for loading and saving tensors that are >2GB.<br/>
 
 __Bug Fixes__:
 
@@ -930,7 +936,7 @@ Added '_' to the torch.nn.init functions. They overwrite the input tensor, so th
 
 __Fixed Bugs:__
 
-#399 Data<T>() returns span that must be indexed using strides. 
+#399 Data<T>() returns span that must be indexed using strides.
 
 This was a major bug, affecting any code that pulled data out of a tensor view.
 

--- a/src/TorchSharp/LinearAlgebra.cs
+++ b/src/TorchSharp/LinearAlgebra.cs
@@ -703,7 +703,7 @@ namespace TorchSharp
             /// <param name="dims">Dimensions over which to compute the norm.</param>
             /// <param name="keepdim">If set to true, the reduced dimensions are retained in the result as dimensions with size one. </param>
             /// <returns></returns>
-            public static Tensor vector_norm(Tensor input, double ord, long[]? dims = null, bool keepdim = false)
+            public static Tensor vector_norm(Tensor input, double ord = 2d, long[]? dims = null, bool keepdim = false)
             {
                 unsafe {
                     fixed (long* pdims = dims) {

--- a/test/TorchSharpTest/LinearAlgebra.cs
+++ b/test/TorchSharpTest/LinearAlgebra.cs
@@ -641,6 +641,12 @@ namespace TorchSharp
 
                 Assert.Equal(5.4344883f, b.item<float>());
                 Assert.Equal(5.4344883f, c.item<float>());
+
+                var d = linalg.vector_norm(a, ord: 2);
+                var e = linalg.vector_norm(a);
+
+                Assert.Equal(7.7459669f, d.item<float>());
+                Assert.Equal(7.7459669f, e.item<float>());
             }
         }
 


### PR DESCRIPTION
The docs of this method specify:

```
<param name="ord">Order of norm. Default: 2</param>
```

Said default was however not actually implemented