### PR TITLE
Resolves #1387 and backfill tests for ThreadDisposeScopeStatistics

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,6 +11,7 @@ __Bug Fixes__:
 
 #1383 `torch.linalg.vector_norm`: Make `ord`-argument optional, as specified in docs<br/>
 #1385 PackedSequence now participates in the DisposeScope system at the same level as Tensor objects.<br/>
+#1387 Attaching tensor to a DisposeScope no longer makes Statistics.DetachedFromScopeCount go negative.<br/>
 
 # NuGet Version 0.103.0
 

--- a/src/TorchSharp/DisposeScope.cs
+++ b/src/TorchSharp/DisposeScope.cs
@@ -237,17 +237,6 @@ namespace TorchSharp
 
             var result = new List<IDisposable>();
             foreach (var disposable in disposables) {
-                if (disposable is torch.Tensor tensor) {
-                    if (tensor.OwningDisposeScope == null && !tensor.IsInvalid) {
-                        _disposeScopeManager.StatisticsInstance.DetachedFromScopeCount--;
-                    }
-                }
-                else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
-                    if (sequence.OwningDisposeScope == null && !sequence.IsInvalid) {
-                        _disposeScopeManager.StatisticsInstance.DetachedFromScopeCount--;
-                    }
-                }
-
                 AddToOther(this, disposable);
                 result.Add(disposable);
             }

--- a/src/TorchSharp/ThreadDisposeScopeStatistics.cs
+++ b/src/TorchSharp/ThreadDisposeScopeStatistics.cs
@@ -27,7 +27,7 @@ namespace TorchSharp
         public long DetachedFromScopeCount { get; internal set; }
 
         /// <summary>
-        /// The number of disposables that are currently live on the current thread. If a It's aproximate, see
+        /// The number of disposables that are currently live on the current thread. It's approximate, see
         /// Tensor.TotalCount. Disposables that weren't created within a DisposeScope, or detached from the dispose
         /// scope, will not be counted as alive.
         /// </summary>

--- a/test/TorchSharpTest/TestDisposeScopesPackedSequence.cs
+++ b/test/TorchSharpTest/TestDisposeScopesPackedSequence.cs
@@ -1,121 +1,82 @@
 using System.Reflection;
-using TorchSharp;
 using Xunit;
 
-namespace TorchSharpTest;
-
-public class TestDisposeScopesPackedSequence
+namespace TorchSharp
 {
-    [Fact]
-    public void MoveDisposeScope()
+    [Collection("Sequential")]
+    public class TestDisposeScopesPackedSequence
     {
-        var sequences = CreateTestSequences();
-        torch.nn.utils.rnn.PackedSequence packed_sequence;
-        var otherScope = torch.NewDisposeScope();
-        using (torch.NewDisposeScope())
+        [Fact]
+        public void MoveDisposeScope()
         {
-            using (torch.NewDisposeScope())
-            {
-                packed_sequence = torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: false);
+            var sequences = CreateTestSequences();
+            torch.nn.utils.rnn.PackedSequence packed_sequence;
+            var otherScope = torch.NewDisposeScope();
+            using (torch.NewDisposeScope()) {
+                using (torch.NewDisposeScope()) {
+                    packed_sequence = torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: false);
+                    AssertPackedSequenceValid(packed_sequence);
+
+                    packed_sequence.MoveToOuterDisposeScope();
+                }
+
                 AssertPackedSequenceValid(packed_sequence);
 
-                packed_sequence.MoveToOuterDisposeScope();
+                packed_sequence.MoveToOtherDisposeScope(otherScope);
             }
-            AssertPackedSequenceValid(packed_sequence);
 
-            packed_sequence.MoveToOtherDisposeScope(otherScope);
+            AssertPackedSequenceValid(packed_sequence);
+            otherScope.Dispose();
+
+            Assert.True(GetPackedSequenceIsInvalid(packed_sequence));
+            Assert.True(packed_sequence.data.IsInvalid);
         }
 
-        AssertPackedSequenceValid(packed_sequence);
-        otherScope.Dispose();
-
-        Assert.True(GetPackedSequenceIsInvalid(packed_sequence));
-        Assert.True(packed_sequence.data.IsInvalid);
-    }
-
-    [Fact]
-    public void DisposablesValidityWhenNotSorted()
-    {
-        var sequences = CreateTestSequences();
-        using var scope = torch.NewDisposeScope();
-        var packed = torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: false);
-        Assert.Equal(1, scope.DisposablesCount);
-        AssertPackedSequenceValid(packed);
-    }
-
-    [Fact]
-    public void DisposablesValidityWhenSorted()
-    {
-        var sequences = CreateTestSequences();
-        using var scope = torch.NewDisposeScope();
-        var packed = torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: true);
-        Assert.Equal(1, scope.DisposablesCount);
-        Assert.False(GetPackedSequenceIsInvalid(packed));
-        Assert.False(packed.batch_sizes.IsInvalid);
-        Assert.False(packed.data.IsInvalid);
-        Assert.True(packed.sorted_indices.IsInvalid);
-        Assert.True(packed.unsorted_indices.IsInvalid);
-    }
-
-    [Fact]
-    public void DisposeScopeStatistics()
-    {
-        DisposeScopeManager.Statistics.Reset();
-        AssertStatCounts(0, 0, 0, 0, 0);
-        var sequences = CreateTestSequences();
-        AssertStatCounts(0, 2, 0, 0, 0);
-        var outOfScope = torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: true);
-        AssertStatCounts(0, 7, 0, 0, 0);
-        using var scope = torch.NewDisposeScope();
-        AssertStatCounts(0, 7, 0, 0, 0);
-
-        var inScope = torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: true);
-        AssertStatCounts(5, 7, 4, 0, 1);
-
-        scope.Attach(outOfScope);
-        //Possible subtle bug. When attaching an object that isn't owned by any scope, the count subtracts.
-        AssertStatCounts( 5, 7, 3, 0, 2);
-
-        scope.Detach(inScope);
-        AssertStatCounts( 5, 7, 4, 0, 1);
-
-        outOfScope.Dispose();
-        AssertStatCounts( 5, 7, 4, 5, -4);
-
-    }
-
-    private static void AssertStatCounts(long createdInScope, long createdOutsideScope, long detachedFrom, long disposedIn, long threadTotalLive)
-    {
-        var stats = DisposeScopeManager.Statistics;
-        Assert.Equal(createdInScope, stats.CreatedInScopeCount);
-        Assert.Equal(createdOutsideScope, stats.CreatedOutsideScopeCount);
-        Assert.Equal(detachedFrom, stats.DetachedFromScopeCount);
-        Assert.Equal(disposedIn, stats.DisposedInScopeCount);
-        Assert.Equal(threadTotalLive, stats.ThreadTotalLiveCount);
-    }
-
-    private static torch.Tensor[] CreateTestSequences()
-    {
-        return new[]
+        [Fact]
+        public void DisposablesValidityWhenNotSorted()
         {
-            torch.tensor(new long[] { 1, 2, 3, 4 }),
-            torch.tensor(new long[] { 5, 6 }),
-        };
-    }
+            var sequences = CreateTestSequences();
+            using var scope = torch.NewDisposeScope();
+            var packed = torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: false);
+            Assert.Equal(1, scope.DisposablesCount);
+            AssertPackedSequenceValid(packed);
+        }
 
-    private static void AssertPackedSequenceValid(torch.nn.utils.rnn.PackedSequence packed_sequence)
-    {
-        Assert.False(GetPackedSequenceIsInvalid(packed_sequence));
-        Assert.False(packed_sequence.batch_sizes.IsInvalid);
-        Assert.False(packed_sequence.data.IsInvalid);
-        Assert.False(packed_sequence.sorted_indices.IsInvalid);
-        Assert.False(packed_sequence.unsorted_indices.IsInvalid);
-    }
+        [Fact]
+        public void DisposablesValidityWhenSorted()
+        {
+            var sequences = CreateTestSequences();
+            using var scope = torch.NewDisposeScope();
+            var packed = torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: true);
+            Assert.Equal(1, scope.DisposablesCount);
+            Assert.False(GetPackedSequenceIsInvalid(packed));
+            Assert.False(packed.batch_sizes.IsInvalid);
+            Assert.False(packed.data.IsInvalid);
+            Assert.True(packed.sorted_indices.IsInvalid);
+            Assert.True(packed.unsorted_indices.IsInvalid);
+        }
 
-    private static bool GetPackedSequenceIsInvalid(torch.nn.utils.rnn.PackedSequence packed_sequence)
-    {
-        //HACK: reflection to avoid exposing internal method IsInvalid in API.
-        var getter = typeof(torch.nn.utils.rnn.PackedSequence).GetProperty("IsInvalid", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        return (bool)getter.GetValue(packed_sequence)!;
+        private static torch.Tensor[] CreateTestSequences()
+        {
+            return new[] { torch.tensor(new long[] { 1, 2, 3, 4 }), torch.tensor(new long[] { 5, 6 }), };
+        }
+
+        private static void AssertPackedSequenceValid(torch.nn.utils.rnn.PackedSequence packed_sequence)
+        {
+            Assert.False(GetPackedSequenceIsInvalid(packed_sequence));
+            Assert.False(packed_sequence.batch_sizes.IsInvalid);
+            Assert.False(packed_sequence.data.IsInvalid);
+            Assert.False(packed_sequence.sorted_indices.IsInvalid);
+            Assert.False(packed_sequence.unsorted_indices.IsInvalid);
+        }
+
+        private static bool GetPackedSequenceIsInvalid(torch.nn.utils.rnn.PackedSequence packed_sequence)
+        {
+            //HACK: reflection to avoid exposing internal method IsInvalid in API.
+            var getter =
+                typeof(torch.nn.utils.rnn.PackedSequence).GetProperty("IsInvalid",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (bool)getter.GetValue(packed_sequence)!;
+        }
     }
 }

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsBase.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsBase.cs
@@ -1,0 +1,23 @@
+using Xunit;
+
+namespace TorchSharp
+{
+    public class TestDisposeScopesStatisticsBase
+    {
+        protected static void ResetStats()
+        {
+            DisposeScopeManager.Statistics.Reset();
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        protected static void AssertStatCounts(long createdInScope, long createdOutsideScope, long detachedFrom, long disposedIn, long threadTotalLive)
+        {
+            var stats = DisposeScopeManager.Statistics;
+            Assert.True(createdInScope == stats.CreatedInScopeCount, $"CreatedInScope: Expected({createdInScope})!={stats.CreatedInScopeCount}");
+            Assert.True(createdOutsideScope == stats.CreatedOutsideScopeCount, $"CreatedOutsideScopeCount: Expected({createdOutsideScope})!={stats.CreatedOutsideScopeCount}");
+            Assert.True(detachedFrom == stats.DetachedFromScopeCount, $"DetachedFromScopeCount: Expected({detachedFrom})!={stats.DetachedFromScopeCount}");
+            Assert.True(disposedIn == stats.DisposedInScopeCount, $"DisposedInScopeCount: Expected({disposedIn})!={stats.DisposedInScopeCount}");
+            Assert.True(threadTotalLive == stats.ThreadTotalLiveCount, $"ThreadTotalLiveCount: Expected({threadTotalLive})!={stats.ThreadTotalLiveCount}");
+        }
+    }
+}

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsPackedSequence.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsPackedSequence.cs
@@ -1,0 +1,80 @@
+using TorchSharp;
+using Xunit;
+
+namespace TorchSharp
+{
+    [Collection("Sequential")]
+    public class TestDisposeScopesStatisticsPackedSequenceScoped : TestDisposeScopesStatisticsBase
+    {
+
+        //When reviewing these tests, refer first to TestDisposeScopesStatisticsTensor. The tests here are
+        //essentially identical, except that the numbers all look weird because a PackedSequence is constructed
+        //from Tensors, and contains Tensors that it detaches from any scope and manages itself.
+
+
+        [Fact]
+        public void CreatingIncrementsCreatedInScope()
+        {
+            using var scope = torch.NewDisposeScope();
+            ResetStats();
+            var ps = TestDisposeScopesStatisticsPackedSequenceUnscoped.Create();
+            //CreatedInScope = 2 tensors (source data) + 4 internal PackedSequence tensors, + the PackedSequence
+            //DetachedFromScope = the 4 internal PackedSequenceTensors
+            AssertStatCounts(7, 0, 4, 0, 3);
+        }
+
+        [Fact]
+        public void AttachingIncrementsNothing()
+        {
+            using var scope = torch.NewDisposeScope();
+            var ps = TestDisposeScopesStatisticsPackedSequenceUnscoped.Create();
+            ResetStats();
+            scope.Attach(ps);
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        [Fact]
+        public void DetachingIncrementsDetached()
+        {
+            using var scope = torch.NewDisposeScope();
+            var ps = TestDisposeScopesStatisticsPackedSequenceUnscoped.Create();
+            ResetStats();
+            scope.Detach(ps);
+            AssertStatCounts(0, 0, 1, 0, -1);
+        }
+
+        [Fact]
+        public void DisposingIncrementsDisposed()
+        {
+            using var scope = torch.NewDisposeScope();
+            var ps = TestDisposeScopesStatisticsPackedSequenceUnscoped.Create();
+            ResetStats();
+            ps.Dispose();
+            //DisposedInScope = The PackedSequence + the 4 internal tensors
+            AssertStatCounts(0, 0, 0, 5, -5);
+        }
+
+        [Fact]
+        public void DisposingScopeIncrementsDisposed()
+        {
+            var scope = torch.NewDisposeScope();
+            var ps = TestDisposeScopesStatisticsPackedSequenceUnscoped.Create();
+            ResetStats();
+            scope.Dispose();
+            //DisposedInScope = The PackedSequence and the 2 source data tensors. The internal tensors and not on the scope.
+            AssertStatCounts(0, 0, 0, 3, -3);
+        }
+
+        [Fact]
+        public void DisposingScopeAfterDetachingCountsOnlyTheSourceDataTensors()
+        {
+            var scope = torch.NewDisposeScope();
+            var ps = TestDisposeScopesStatisticsPackedSequenceUnscoped.Create();
+            scope.Detach(ps);
+            ResetStats();
+            scope.Dispose();
+            //DisposedInScope just the two source data tensors.
+            AssertStatCounts(0, 0, 0, 2, -2);
+        }
+    }
+}

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsPackedSequenceUnscoped.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsPackedSequenceUnscoped.cs
@@ -1,0 +1,104 @@
+using TorchSharp;
+using Xunit;
+
+namespace TorchSharp
+{
+    [Collection("Sequential")]
+    public class TestDisposeScopesStatisticsPackedSequenceUnscoped : TestDisposeScopesStatisticsBase
+    {
+
+        //When reviewing these tests, refer first to TestDisposeScopesStatisticsTensor. The tests here are
+        //essentially identical, except that the numbers all look weird because a PackedSequence is constructed
+        //from Tensors, and contains Tensors that it detaches from any scope and manages itself.
+
+        public static torch.nn.utils.rnn.PackedSequence Create()
+        {
+            var sequences = new[] { torch.tensor(new long[] { 1, 2, 3, 4 }), torch.tensor(new long[] { 5, 6 }), };
+            return torch.nn.utils.rnn.pack_sequence(sequences, enforce_sorted: true);
+        }
+
+        [Fact]
+        public void CreatingIncrementsCreatedOutsideScope()
+        {
+            ResetStats();
+            var _ = Create();
+            //7 = The PackedSequence, it's 4 internal tensors, and the 2 source data tensors
+            AssertStatCounts(0, 7, 0, 0, 0);
+        }
+
+        [Fact]
+        public void AttachingIncrementsNothing()
+        {
+            var ps = Create();
+            ResetStats();
+            using var scope = torch.NewDisposeScope();
+            scope.Attach(ps);
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        [Fact]
+        public void DetachingIncrementsNothing()
+        {
+            var ps = Create();
+            ResetStats();
+            using var scope = torch.NewDisposeScope();
+            scope.Detach(ps);
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        [Fact]
+        public void DisposingIncrementsNothing()
+        {
+            var ps = Create();
+            ResetStats();
+            ps.Dispose();
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        [Fact]
+        public void DisposingAttachedIncrementsDisposed()
+        {
+            var ps = Create();
+            using var scope = torch.NewDisposeScope();
+            scope.Attach(ps);
+            ResetStats();
+            ps.Dispose();
+            //5 = the PackedSequence and it's 4 internal tensors
+            AssertStatCounts(0, 0, 0, 5, -5);
+        }
+
+        [Fact]
+        public void DisposingScopeWithAttachedIncrementsDisposed()
+        {
+            var ps = Create();
+            var scope = torch.NewDisposeScope();
+            scope.Attach(ps);
+            ResetStats();
+            scope.Dispose();
+            AssertStatCounts(0, 0, 0, 1, -1);
+        }
+
+        [Fact]
+        public void DetachingAttachedIncrementsDetached()
+        {
+            var ps = Create();
+            using var scope = torch.NewDisposeScope();
+            scope.Attach(ps);
+            ResetStats();
+            scope.Detach(ps);
+            AssertStatCounts(0, 0, 1, 0, -1);
+        }
+
+        [Fact]
+        public void DisposingScopeAfterDetachingDoesNothing()
+        {
+            var ps = Create();
+            var scope = torch.NewDisposeScope();
+            scope.Attach(ps);
+            scope.Detach(ps);
+            ResetStats();
+            scope.Dispose();
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+    }
+}

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsTensor.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsTensor.cs
@@ -1,0 +1,68 @@
+using Xunit;
+
+namespace TorchSharp
+{
+    [Collection("Sequential")]
+    public class TestDisposeScopesStatisticsTensorScoped : TestDisposeScopesStatisticsBase
+    {
+        [Fact]
+        public void CreatingIncrementsCreatedInScopeOnce()
+        {
+            using var scope = torch.NewDisposeScope();
+            ResetStats();
+            var t = torch.tensor(3);
+            AssertStatCounts(1, 0, 0, 0, 1);
+        }
+
+        [Fact]
+        public void AttachingIncrementsNothing()
+        {
+            using var scope = torch.NewDisposeScope();
+            var t = torch.tensor(3);
+            ResetStats();
+            scope.Attach(t);
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        [Fact]
+        public void DetachingIncrementsDetachedOnce()
+        {
+            using var scope = torch.NewDisposeScope();
+            var t = torch.tensor(3);
+            ResetStats();
+            scope.Detach(t);
+            AssertStatCounts(0, 0, 1, 0, -1);
+        }
+
+        [Fact]
+        public void DisposingIncrementsDisposedOnce()
+        {
+            using var scope = torch.NewDisposeScope();
+            var t = torch.tensor(3);
+            ResetStats();
+            t.Dispose();
+            AssertStatCounts(0, 0, 0, 1, -1);
+        }
+
+        [Fact]
+        public void DisposingScopeIncrementsDisposedOnce()
+        {
+            var scope = torch.NewDisposeScope();
+            var t = torch.tensor(3);
+            ResetStats();
+            scope.Dispose();
+            AssertStatCounts(0, 0, 0, 1, -1);
+        }
+
+        [Fact]
+        public void DisposingScopeAfterDetachingDoesNothing()
+        {
+            var scope = torch.NewDisposeScope();
+            var t = torch.tensor(3);
+            scope.Detach(t);
+            ResetStats();
+            scope.Dispose();
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+    }
+}

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsTensorUnscoped.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsTensorUnscoped.cs
@@ -1,0 +1,91 @@
+using Xunit;
+
+namespace TorchSharp
+{
+    [Collection("Sequential")]
+    public class TestDisposeScopesStatisticsTensorUnscoped : TestDisposeScopesStatisticsBase
+    {
+
+        [Fact]
+        public void CreatingIncrementsCreatedOutsideScope()
+        {
+            ResetStats();
+            var t = torch.tensor(3);
+            AssertStatCounts(0, 1, 0, 0, 0);
+        }
+
+        [Fact]
+        public void AttachingIncrementsNothing()
+        {
+            var t = torch.tensor(3);
+            ResetStats();
+            using var scope = torch.NewDisposeScope();
+            scope.Attach(t);
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        [Fact]
+        public void DetachingIncrementsNothing()
+        {
+            var t = torch.tensor(3);
+            ResetStats();
+            using var scope = torch.NewDisposeScope();
+            scope.Detach(t);
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        [Fact]
+        public void DisposingIncrementsNothing()
+        {
+            var t = torch.tensor(3);
+            ResetStats();
+            t.Dispose();
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+
+        [Fact]
+        public void DisposingAttachedIncrementsDisposed()
+        {
+            var t = torch.tensor(3);
+            using var scope = torch.NewDisposeScope();
+            scope.Attach(t);
+            ResetStats();
+            t.Dispose();
+            AssertStatCounts(0, 0, 0, 1, -1);
+        }
+
+        [Fact]
+        public void DisposingScopeWithAttachedIncrementsDisposed()
+        {
+            var t = torch.tensor(3);
+            var scope = torch.NewDisposeScope();
+            scope.Attach(t);
+            ResetStats();
+            scope.Dispose();
+            AssertStatCounts(0, 0, 0, 1, -1);
+        }
+
+        [Fact]
+        public void DetachingAttachedIncrementsDetached()
+        {
+            var t = torch.tensor(3);
+            using var scope = torch.NewDisposeScope();
+            scope.Attach(t);
+            ResetStats();
+            scope.Detach(t);
+            AssertStatCounts(0, 0, 1, 0, -1);
+        }
+
+        [Fact]
+        public void DisposingScopeAfterDetachingDoesNothing()
+        {
+            var t = torch.tensor(3);
+            var scope = torch.NewDisposeScope();
+            scope.Attach(t);
+            scope.Detach(t);
+            ResetStats();
+            scope.Dispose();
+            AssertStatCounts(0, 0, 0, 0, 0);
+        }
+    }
+}


### PR DESCRIPTION
Added test to verify that attaching an unscoped Tensor or PackedSequence no longer decrements DetachedFromScopeCount, making it possibly become negative. Note also removed the scope counting tests from TestDisposeScopesPackedSequence, which now only tests disposal behavior. Metrics are now all tested in a dedicated set of test fixtures.

Added additional tests to document behavior and improve test coverage for both Tensor and PackedSequence objects, in scenarios for both scoped and unscoped instances of these objects (total of 4 new fixtures). This should help future changes as one can see what the system does to count the statistics.

Tests reflect the expected behavior based on the doc comments for ThreadDisposeScopeStatistics. Note that the ThreadTotalLiveCount property is still "approximate" and can go negative, not changes to this behavior were made. 

Let me know if I've added too much here. I really wasn't sure what was supposed to be counted when, so I just went though it incrementally and added the tests to document it.