### PR TITLE
Better metrics

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,6 +12,7 @@ __Bug Fixes__:
 #1383 `torch.linalg.vector_norm`: Make `ord`-argument optional, as specified in docs<br/>
 #1385 PackedSequence now participates in the DisposeScope system at the same level as Tensor objects.<br/>
 #1387 Attaching tensor to a DisposeScope no longer makes Statistics.DetachedFromScopeCount go negative.<br/>
+#1390 DisposeScopeManager.Statistics now includes DisposedOutsideScopeCount and AttachedToScopeCount. ThreadTotalLiveCount is now exact instead of approximate. ToString gives a useful debug string, and documentation is added for how to troubleshoot memory leaks. Also DisposeScopeManager.Statistics.TensorStatistics and DisposeScopeManager.Statistics.PackedSequenceStatistics provide separate metrics for these objects.
 
 # NuGet Version 0.103.0
 

--- a/docfx/articles/memory leak troubleshooting.md
+++ b/docfx/articles/memory leak troubleshooting.md
@@ -1,0 +1,81 @@
+# Memory Leak Troubleshooting
+
+If suspect you are leaking memory this is your guide. First be sure to be familiar with the [Memory Management Techniques](memory.md).
+
+## Verifying you have a leak
+
+The `DisposeScopeManager.Statistics` property defines thread level statistics of objects captured
+in TorchSharp as objects are created and moved between DisposeScopes. Normally deal directly
+with only this property.
+
+To see where code may be leaking objects, it is easiest to modify the training loop.
+Use a DisposeScope, reset the global statistics to have a known starting point, then take
+some action and look at the statistics to see what's still around.
+
+```csharp
+	//Training Loop, 10 epochs
+	for (int i = 0; i < 10; i++) {
+		//Clear the statistics
+		DisposeScopeManager.Statistics.Reset();
+		//Take action. In this case it is inside a DisposeScope, so
+		//when this code block is done, there should be no new live objects.
+		using (NewDisposeScope()) {
+			var eval = model.call(x);
+			// ... other model execution code
+			optimizer.step();
+		}
+		//Examine what happened
+		Console.WriteLine(DisposeScopeManager.Statistics);
+	}
+```
+
+If on every iteration the number of live objects is increasing, there is a leak. In the following
+example note that the number of live objects increases by 200 every iteration. It can also be
+seen these objects were created on a DisposeScope, but were eventually detached. In this specific
+case, look for where the code is detaching the tensors, and then determine how
+to correctly manage the lifetime of these objects.
+```csharp
+ThreadTotalLiveCount: 548; CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; CreatedInScopeCount: 200; DisposedInScopeCount: 2; AttachedToScopeCount: 0; DetachedFromScopeCount: 200"
+ThreadTotalLiveCount: 748; CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; CreatedInScopeCount: 200; DisposedInScopeCount: 2; AttachedToScopeCount: 0; DetachedFromScopeCount: 200"
+ThreadTotalLiveCount: 948; CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; CreatedInScopeCount: 200; DisposedInScopeCount: 2; AttachedToScopeCount: 0; DetachedFromScopeCount: 200"
+```
+
+It is not necessary to leave this code in place for production implementations after fixing a leak. It may be removed so the code looks more Pythonic if needed.
+
+## Identifying the leak
+This is where the leg work is. Look at each line of code where Tensor or PackedSequence objects are created.
+Ensure they are eventually disposed either manually or by a DisposeScope. One can also print the statistics to
+the debugger while stepping code for an interactive approach.
+
+Be aware that TorchSharp also creates tensors for itself and uses them in various
+ways. Just because one finds a tensor that is created by TorchSharp isn't being disposed, it likely isn't caused
+by TorchSharp. A good example is the Adam optimizer. It creates tensors internally to manage it's parameters,
+and detaches them from any DisposeScope that is in use. If it didn't, it would fail doing gradients and back
+propagation as it's tensors would have been disposed. These are eventually cleaned up when the optimizer is
+properly disposed after training. Faliure of the client code to dispose is the most likely cause of memory leaks.
+
+## Working with RNNs
+One may want to drill down to `DisposeScopeManager.Statistics.TensorStatistics` or
+`DisposeScopeManager.Statistics.PackedSequenceStatistics`, these track Tensors and
+PackedSequence usages independently.
+
+Additionally, a PackedSequence uses some tensors internally. These tensors show up in the creation statistics,
+and are immediately detached from any scope if there is one in context and will
+increment the DetachedFromScopeCount property. When a PackedSequence is disposed, it will also Dispose
+it's tensors. The differences in counts can be seen in the following, which represents output within an IDE
+debug window where all three levels of statistics were observed at the same execution time. Note the first two
+sum to the totals on the last line.
+
+```
+  DisposeScopeManager.Statistics.TensorStatistics.ToString()
+  "ThreadTotalLiveCount: 4; CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; CreatedInScopeCount: 6; DisposedInScopeCount: 2; AttachedToScopeCount: 0; DetachedFromScopeCount: 4"
+
+  DisposeScopeManager.Statistics.PackedSequenceStatistics.ToString()
+  "ThreadTotalLiveCount: 1; CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; CreatedInScopeCount: 1; DisposedInScopeCount: 0; AttachedToScopeCount: 0; DetachedFromScopeCount: 0"
+
+  DisposeScopeManager.Statistics.ToString()
+  "ThreadTotalLiveCount: 5; CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; CreatedInScopeCount: 7; DisposedInScopeCount: 2; AttachedToScopeCount: 0; DetachedFromScopeCount: 4"
+
+```
+
+

--- a/src/TorchSharp/DisposeScope.cs
+++ b/src/TorchSharp/DisposeScope.cs
@@ -154,9 +154,13 @@ namespace TorchSharp
         {
             if (this._disposeScopeManager is null)
                 throw new ObjectDisposedException(this.GetType().FullName);
-            foreach (var disposable in disposables) {
-                if (Disposables.Remove(disposable)) {
-                    AddToOther(scope, disposable);
+            if (scope == null) {
+                Detach(disposables);
+            } else {
+                foreach (var disposable in disposables) {
+                    if (Disposables.Remove(disposable)) {
+                        AddToOther(scope, disposable);
+                    }
                 }
             }
         }
@@ -209,11 +213,11 @@ namespace TorchSharp
                 throw new ObjectDisposedException(this.GetType().FullName);
             foreach (var disposable in disposables) {
                 if (Disposables.Remove(disposable)) {
-                    _disposeScopeManager.StatisticsInstance.DetachedFromScopeCount++;
                     if (disposable is torch.Tensor tensor) {
+                        _disposeScopeManager.StatisticsInstance._TensorStatistics.DetachedFromScopeCount++;
                         tensor.OwningDisposeScope = null;
-                    }
-                    else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
+                    } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
+                        _disposeScopeManager.StatisticsInstance._PackedSequenceStatistics.DetachedFromScopeCount++;
                         sequence.OwningDisposeScope = null;
                     }
                 }
@@ -237,7 +241,13 @@ namespace TorchSharp
 
             var result = new List<IDisposable>();
             foreach (var disposable in disposables) {
-                AddToOther(this, disposable);
+                if (AddToOther(this, disposable)) {
+                    if (disposable is torch.Tensor tensor) {
+                        _disposeScopeManager.StatisticsInstance._TensorStatistics.AttachedToScopeCount++;
+                    } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
+                        _disposeScopeManager.StatisticsInstance._PackedSequenceStatistics.AttachedToScopeCount++;
+                    }
+                }
                 result.Add(disposable);
             }
 
@@ -265,22 +275,6 @@ namespace TorchSharp
             foreach (var disposable in oldList) {
                 if (Disposables.Contains(disposable)) {
                     continue;
-                }
-
-                if (disposable is torch.Tensor tensor) {
-                    // No need to have the disposable call back to the scope
-                    tensor.OwningDisposeScope = null;
-                    if (!tensor.IsInvalid) {
-                        _disposeScopeManager.StatisticsInstance.DisposedInScopeCount++;
-                    }
-                } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
-                    // No need to have the disposable call back to the scope
-                    sequence.OwningDisposeScope = null;
-                    if (!sequence.IsInvalid) {
-                        _disposeScopeManager.StatisticsInstance.DisposedInScopeCount++;
-                    }
-                } else {
-                    _disposeScopeManager.StatisticsInstance.DisposedInScopeCount++;
                 }
 
                 disposable.Dispose();
@@ -358,7 +352,7 @@ namespace TorchSharp
         {
             if (this._disposeScopeManager is null)
                 throw new ObjectDisposedException(this.GetType().FullName);
-            _disposeScopeManager.StatisticsInstance.DisposedInScopeCount++;
+
             Disposables.Remove(disposable);
             if (disposable is torch.Tensor tensor) {
                 tensor.OwningDisposeScope = null;
@@ -375,33 +369,45 @@ namespace TorchSharp
         /// <returns></returns>
         public bool Contains(IDisposable disposable) => Disposables.Contains(disposable);
 
-        private void AddToOther(DisposeScope? scope, IDisposable disposable)
+        private bool AddToOther(DisposeScope scope, IDisposable disposable)
         {
             if (this._disposeScopeManager is null)
                 throw new ObjectDisposedException(this.GetType().FullName);
-            if (scope != null) {
-                scope.Disposables.Add(disposable);
+
+            DisposeScope? oldScope;
+            if (disposable is torch.Tensor t) {
+                oldScope = t.OwningDisposeScope;
+            } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
+                oldScope = sequence.OwningDisposeScope;
             } else {
-                _disposeScopeManager.StatisticsInstance.DetachedFromScopeCount++;
+                throw new InvalidOperationException("DisposeScope can only manage Tensor or PackedSequence");
+            }
+
+            if (scope == oldScope) return false;
+
+            scope.Disposables.Add(disposable);
+            if (oldScope != null) {
+                oldScope.Disposables.Remove(disposable);
             }
 
             if (disposable is torch.Tensor tensor) {
                 tensor.OwningDisposeScope = scope;
-            }
-            else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
+            } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
                 sequence.OwningDisposeScope = scope;
             }
+
+            return true;
         }
 
         internal HashSet<IDisposable> DetachAllAndDispose()
         {
             var disposables = this.Disposables;
             foreach (var disposable in this.Disposables) {
-                this._disposeScopeManager!.StatisticsInstance.DetachedFromScopeCount++;
                 if (disposable is torch.Tensor tensor) {
+                    this._disposeScopeManager!.StatisticsInstance._TensorStatistics.DetachedFromScopeCount++;
                     tensor.OwningDisposeScope = null;
-                }
-                else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
+                } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
+                    this._disposeScopeManager!.StatisticsInstance._PackedSequenceStatistics.DetachedFromScopeCount++;
                     sequence.OwningDisposeScope = null;
                 }
             }

--- a/src/TorchSharp/DisposeScope.cs
+++ b/src/TorchSharp/DisposeScope.cs
@@ -214,10 +214,10 @@ namespace TorchSharp
             foreach (var disposable in disposables) {
                 if (Disposables.Remove(disposable)) {
                     if (disposable is torch.Tensor tensor) {
-                        _disposeScopeManager.StatisticsInstance._TensorStatistics.DetachedFromScopeCount++;
+                        _disposeScopeManager.StatisticsInstance.TensorStatistics.DetachedFromScopeCount++;
                         tensor.OwningDisposeScope = null;
                     } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
-                        _disposeScopeManager.StatisticsInstance._PackedSequenceStatistics.DetachedFromScopeCount++;
+                        _disposeScopeManager.StatisticsInstance.PackedSequenceStatistics.DetachedFromScopeCount++;
                         sequence.OwningDisposeScope = null;
                     }
                 }
@@ -243,9 +243,9 @@ namespace TorchSharp
             foreach (var disposable in disposables) {
                 if (AddToOther(this, disposable)) {
                     if (disposable is torch.Tensor tensor) {
-                        _disposeScopeManager.StatisticsInstance._TensorStatistics.AttachedToScopeCount++;
+                        _disposeScopeManager.StatisticsInstance.TensorStatistics.AttachedToScopeCount++;
                     } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
-                        _disposeScopeManager.StatisticsInstance._PackedSequenceStatistics.AttachedToScopeCount++;
+                        _disposeScopeManager.StatisticsInstance.PackedSequenceStatistics.AttachedToScopeCount++;
                     }
                 }
                 result.Add(disposable);
@@ -404,10 +404,10 @@ namespace TorchSharp
             var disposables = this.Disposables;
             foreach (var disposable in this.Disposables) {
                 if (disposable is torch.Tensor tensor) {
-                    this._disposeScopeManager!.StatisticsInstance._TensorStatistics.DetachedFromScopeCount++;
+                    this._disposeScopeManager!.StatisticsInstance.TensorStatistics.DetachedFromScopeCount++;
                     tensor.OwningDisposeScope = null;
                 } else if (disposable is torch.nn.utils.rnn.PackedSequence sequence) {
-                    this._disposeScopeManager!.StatisticsInstance._PackedSequenceStatistics.DetachedFromScopeCount++;
+                    this._disposeScopeManager!.StatisticsInstance.PackedSequenceStatistics.DetachedFromScopeCount++;
                     sequence.OwningDisposeScope = null;
                 }
             }

--- a/src/TorchSharp/DisposeScopeManager.cs
+++ b/src/TorchSharp/DisposeScopeManager.cs
@@ -18,18 +18,42 @@ namespace TorchSharp
         internal ThreadDisposeScopeStatistics StatisticsInstance { get; } = new ThreadDisposeScopeStatistics();
         internal DisposeScope? CurrentDisposeScope { get; private set; } = null;
 
-        internal DisposeScope? RegisterOnCurrentDisposeScope(IDisposable tensor)
+        internal DisposeScope? RegisterOnCurrentDisposeScope(IDisposable item)
         {
             if (this.CurrentDisposeScope is null) {
-                StatisticsInstance.CreatedOutsideScopeCount++;
+                if (item is torch.Tensor t) {
+                    StatisticsInstance._TensorStatistics.CreatedOutsideScopeCount++;
+                } else if (item is torch.nn.utils.rnn.PackedSequence p) {
+                    StatisticsInstance._PackedSequenceStatistics.CreatedOutsideScopeCount++;
+                }
                 return null;
+            } else {
+                if (item is torch.Tensor t) {
+                    StatisticsInstance._TensorStatistics.CreatedInScopeCount++;
+                } else if (item is torch.nn.utils.rnn.PackedSequence p) {
+                    StatisticsInstance._PackedSequenceStatistics.CreatedInScopeCount++;
+                }
+                this.CurrentDisposeScope.Disposables.Add(item);
+                return CurrentDisposeScope;
             }
-
-            StatisticsInstance.CreatedInScopeCount++;
-            this.CurrentDisposeScope.Disposables.Add(tensor);
-            return CurrentDisposeScope;
         }
 
+        internal void DisposingOnCurrentScope(torch.Tensor item)
+        {
+            if (item.OwningDisposeScope == null) {
+                StatisticsInstance._TensorStatistics.DisposedOutsideScopeCount++;
+            } else {
+                StatisticsInstance._TensorStatistics.DisposedInScopeCount++;
+            }
+        }
+        internal void DisposingOnCurrentScope(torch.nn.utils.rnn.PackedSequence item)
+        {
+            if (item.OwningDisposeScope == null) {
+                StatisticsInstance._PackedSequenceStatistics.DisposedOutsideScopeCount++;
+            } else {
+                StatisticsInstance._PackedSequenceStatistics.DisposedInScopeCount++;
+            }
+        }
         internal void RemoveDisposeScope(DisposeScope disposeScope)
         {
             var scope = this.CurrentDisposeScope;

--- a/src/TorchSharp/DisposeScopeManager.cs
+++ b/src/TorchSharp/DisposeScopeManager.cs
@@ -22,16 +22,16 @@ namespace TorchSharp
         {
             if (this.CurrentDisposeScope is null) {
                 if (item is torch.Tensor t) {
-                    StatisticsInstance._TensorStatistics.CreatedOutsideScopeCount++;
+                    StatisticsInstance.TensorStatistics.CreatedOutsideScopeCount++;
                 } else if (item is torch.nn.utils.rnn.PackedSequence p) {
-                    StatisticsInstance._PackedSequenceStatistics.CreatedOutsideScopeCount++;
+                    StatisticsInstance.PackedSequenceStatistics.CreatedOutsideScopeCount++;
                 }
                 return null;
             } else {
                 if (item is torch.Tensor t) {
-                    StatisticsInstance._TensorStatistics.CreatedInScopeCount++;
+                    StatisticsInstance.TensorStatistics.CreatedInScopeCount++;
                 } else if (item is torch.nn.utils.rnn.PackedSequence p) {
-                    StatisticsInstance._PackedSequenceStatistics.CreatedInScopeCount++;
+                    StatisticsInstance.PackedSequenceStatistics.CreatedInScopeCount++;
                 }
                 this.CurrentDisposeScope.Disposables.Add(item);
                 return CurrentDisposeScope;
@@ -41,17 +41,17 @@ namespace TorchSharp
         internal void DisposingOnCurrentScope(torch.Tensor item)
         {
             if (item.OwningDisposeScope == null) {
-                StatisticsInstance._TensorStatistics.DisposedOutsideScopeCount++;
+                StatisticsInstance.TensorStatistics.DisposedOutsideScopeCount++;
             } else {
-                StatisticsInstance._TensorStatistics.DisposedInScopeCount++;
+                StatisticsInstance.TensorStatistics.DisposedInScopeCount++;
             }
         }
         internal void DisposingOnCurrentScope(torch.nn.utils.rnn.PackedSequence item)
         {
             if (item.OwningDisposeScope == null) {
-                StatisticsInstance._PackedSequenceStatistics.DisposedOutsideScopeCount++;
+                StatisticsInstance.PackedSequenceStatistics.DisposedOutsideScopeCount++;
             } else {
-                StatisticsInstance._PackedSequenceStatistics.DisposedInScopeCount++;
+                StatisticsInstance.PackedSequenceStatistics.DisposedInScopeCount++;
             }
         }
         internal void RemoveDisposeScope(DisposeScope disposeScope)

--- a/src/TorchSharp/NN/Utils/PackedSequence.cs
+++ b/src/TorchSharp/NN/Utils/PackedSequence.cs
@@ -100,16 +100,15 @@ namespace TorchSharp
                         /// </summary>
                         public void Dispose()
                         {
-                            this.data.Dispose();
-                            this.batch_sizes.Dispose();
-                            this.sorted_indices.Dispose();
-                            this.unsorted_indices.Dispose();
-                            OwningDisposeScope?.MarkAsDisposed(this);
-
                             if (handle != null && !handle.IsInvalid) {
+                                this.data.Dispose();
+                                this.batch_sizes.Dispose();
+                                this.sorted_indices.Dispose();
+                                this.unsorted_indices.Dispose();
+                                DisposeScopeManager.ThreadSingleton.DisposingOnCurrentScope(this);
+                                OwningDisposeScope?.MarkAsDisposed(this);
                                 handle.Dispose();
                                 handle.SetHandleAsInvalid();
-
                             }
                         }
                         /// <summary>

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -84,9 +84,9 @@ namespace TorchSharp
             /// </summary>
             protected virtual void Dispose(bool disposing)
             {
-                OwningDisposeScope?.MarkAsDisposed(this);
-
                 if (handle != IntPtr.Zero) {
+                    DisposeScopeManager.ThreadSingleton.DisposingOnCurrentScope(this);
+                    OwningDisposeScope?.MarkAsDisposed(this);
                     System.Threading.Interlocked.Decrement(ref _totalCount);
                     NativeMethods.THSTensor_dispose(handle);
                     handle = IntPtr.Zero;
@@ -417,7 +417,7 @@ namespace TorchSharp
                 _validate(0);
 
                 long totalSize = NumberOfElements * ElementSize;
-                
+
                 unsafe {
                     var ptr = NativeMethods.THSTensor_data(handle);
                     if (ptr == IntPtr.Zero) { CheckForErrors(); }
@@ -451,7 +451,7 @@ namespace TorchSharp
                 long totalSize = NumberOfElements * ElementSize;
 
                 // Validate that this tensor matches the conditions for reading the bytes - pass 0 as total size
-                // since we don't need to check that condition. 
+                // since we don't need to check that condition.
                 _validate(0);
 
                 unsafe {
@@ -471,7 +471,7 @@ namespace TorchSharp
                         // Copy the contents over to the span
                         var span = new Span<byte>((void*)ptr, bytesRead);
                         buffer.AsSpan(0, bytesRead).CopyTo(span);
-                        
+
                         // Increment our pointer and decrease the total size of elements we have to write
                         ptr += bytesRead;
                         totalSize -= bytesRead;
@@ -793,7 +793,7 @@ namespace TorchSharp
                 return new Tensor(res);
 
             }
-            
+
             /// <summary>
             /// Returns a copy of this object in CUDA memory.
             /// If this object is already in CUDA memory and on the correct device, then no copy is performed and the original object is returned.
@@ -3277,14 +3277,14 @@ namespace TorchSharp
             /// <summary>
             /// Creates a tensor whose diagonals of certain 2D planes (specified by dim1 and dim2) are filled by input.
             /// To facilitate creating batched diagonal matrices, the 2D planes formed by the last two dimensions of the returned tensor are chosen by default.
-            /// 
+            ///
             /// The argument offset controls which diagonal to consider:
             ///   If offset is equal to 0, it is the main diagonal.
             ///   If offset is greater than 0, it is above the main diagonal.
             ///   If offset is less than 0, it is below the main diagonal.
-            ///   
+            ///
             /// The size of the new matrix will be calculated to make the specified diagonal of the size of the last input dimension.Note that for offset other than 0,
-            /// 
+            ///
             /// the order of dim1 and dim2 matters.Exchanging them is equivalent to changing the sign of offset.
             /// </summary>
             /// <param name="offset">Which diagonal to consider.</param>
@@ -3354,7 +3354,7 @@ namespace TorchSharp
             public Tensor erf_()
             {
                 NativeMethods.THSTensor_erf_(Handle);
-                CheckForErrors(); 
+                CheckForErrors();
                 return this;
             }
 

--- a/src/TorchSharp/ThreadDisposeScopeStatistics.cs
+++ b/src/TorchSharp/ThreadDisposeScopeStatistics.cs
@@ -1,48 +1,141 @@
 #nullable enable
+using System.Text;
+using TorchSharp;
+
 namespace TorchSharp
 {
-    /// <summary>
-    /// Keeps track of statistics for a dispose scope. Can be queried to figure out performance/memory issues.
-    /// </summary>
-    public class ThreadDisposeScopeStatistics
+    public interface ILifetimeStatistics
     {
         /// <summary>
         /// The number of disposables that were created on this thread, but weren't captured by a DisposeScope.
         /// </summary>
-        public long CreatedOutsideScopeCount { get; internal set; }
-
+        long CreatedOutsideScopeCount { get; }
+        /// <summary>
+        /// The number of disposables that were Disposed on this thread, but weren't captured by a DisposeScope.
+        /// </summary>
+        long DisposedOutsideScopeCount { get; }
         /// <summary>
         /// The number of disposables that were created on this thread and were captured by a DisposeScope.
         /// </summary>
-        public long CreatedInScopeCount { get; internal set; }
-
+        long CreatedInScopeCount { get; }
         /// <summary>
         /// The number of disposables that were disposed on this thread and were disposed while in a DisposeScope.
         /// </summary>
-        public long DisposedInScopeCount { get; internal set; }
-
+        long DisposedInScopeCount { get; }
+        /// <summary>
+        /// The number of disposables that were created on this thread outside a DisposeScope, and then
+        /// eventually were attached to one.
+        /// </summary>
+        long AttachedToScopeCount { get; }
         /// <summary>
         /// Number of disposables that were once included in the scope, but were subsequently detached.
         /// </summary>
-        public long DetachedFromScopeCount { get; internal set; }
-
+        long DetachedFromScopeCount { get; }
         /// <summary>
-        /// The number of disposables that are currently live on the current thread. It's approximate, see
-        /// Tensor.TotalCount. Disposables that weren't created within a DisposeScope, or detached from the dispose
-        /// scope, will not be counted as alive.
+        /// The number of disposables that are currently live on the current thread.
         /// </summary>
-        public long ThreadTotalLiveCount => CreatedInScopeCount - DisposedInScopeCount - DetachedFromScopeCount;
-
+        long ThreadTotalLiveCount { get; }
         /// <summary>
         /// Resets the counts for the current thread. See ThreadTotalLiveCount etc. Mainly used in tests to make sure
         /// we get a clean slate on the thread.
         /// </summary>
+        void Reset();
+        /// <summary>
+        /// A debug printout of all the properties and their values, suitable for a log or console output
+        /// </summary>
+        /// <returns></returns>
+        string ToString();
+    }
+
+    /// <summary>
+    /// Keeps track of the combined Tensor and PackedSequence statistics for the current thread. Can be queried to figure out performance/memory issues.
+    /// </summary>
+    public class ThreadDisposeScopeStatistics: ILifetimeStatistics
+    {
+        public long CreatedOutsideScopeCount => _TensorStatistics.CreatedOutsideScopeCount +
+                                                _PackedSequenceStatistics.CreatedOutsideScopeCount;
+
+        public long DisposedOutsideScopeCount => _TensorStatistics.DisposedOutsideScopeCount +
+                                                _PackedSequenceStatistics.DisposedOutsideScopeCount;
+        public long CreatedInScopeCount => _TensorStatistics.CreatedInScopeCount +
+                                           _PackedSequenceStatistics.CreatedInScopeCount;
+
+        public long DisposedInScopeCount => _TensorStatistics.DisposedInScopeCount +
+                                            _PackedSequenceStatistics.DisposedInScopeCount;
+
+        public long AttachedToScopeCount=> _TensorStatistics.AttachedToScopeCount +
+                                             _PackedSequenceStatistics.AttachedToScopeCount;
+
+        public long DetachedFromScopeCount=> _TensorStatistics.DetachedFromScopeCount +
+                                             _PackedSequenceStatistics.DetachedFromScopeCount;
+
+        public long ThreadTotalLiveCount => _TensorStatistics.ThreadTotalLiveCount +
+                                            _PackedSequenceStatistics.ThreadTotalLiveCount;
+
+        public void Reset()
+        {
+            _TensorStatistics.Reset();
+            _PackedSequenceStatistics.Reset();
+        }
+
+        public override string ToString()
+        {
+            return LifetimeStatisticsUtil.DebugString(this);
+        }
+        /// <summary>
+        /// Keeps track of the Tensor statistics for the current thread. Can be queried to figure out performance/memory issues.
+        /// </summary>
+        public ILifetimeStatistics TensorStatistics => _TensorStatistics;
+        internal LifetimeStatistics _TensorStatistics { get; set; } = new LifetimeStatistics();
+        /// <summary>
+        /// Keeps track of the PackedSequence statistics for the current thread. Can be queried to figure out performance/memory issues.
+        /// </summary>
+        public ILifetimeStatistics PackedSequenceStatistics => _PackedSequenceStatistics;
+        internal LifetimeStatistics _PackedSequenceStatistics { get; set; } = new LifetimeStatistics();
+    }
+
+    public class LifetimeStatistics : ILifetimeStatistics
+    {
+        public long CreatedOutsideScopeCount { get; internal set; }
+        public long DisposedOutsideScopeCount { get; internal set; }
+        public long CreatedInScopeCount { get; internal set; }
+        public long DisposedInScopeCount { get; internal set; }
+        public long AttachedToScopeCount { get; internal set; }
+        public long DetachedFromScopeCount { get; internal set; }
+        /// <summary>
+        /// Exact number of objects that are still live. Is the difference of all created objects
+        /// minus all disposed objects.
+        /// </summary>
+        public long ThreadTotalLiveCount => (CreatedInScopeCount - DisposedInScopeCount) + (CreatedOutsideScopeCount - DisposedOutsideScopeCount);
+
         public void Reset()
         {
             CreatedOutsideScopeCount = 0;
+            DisposedOutsideScopeCount = 0;
             CreatedInScopeCount = 0;
             DisposedInScopeCount = 0;
+            AttachedToScopeCount = 0;
             DetachedFromScopeCount = 0;
+        }
+        public override string ToString()
+        {
+            return LifetimeStatisticsUtil.DebugString(this);
+        }
+    }
+    static class LifetimeStatisticsUtil
+    {
+        public static string DebugString(this ILifetimeStatistics statistics)
+        {
+            var sb = new StringBuilder();
+            sb.Append("ThreadTotalLiveCount: " + statistics.ThreadTotalLiveCount);
+            sb.Append("; CreatedOutsideScopeCount: " + statistics.CreatedOutsideScopeCount);
+            sb.Append("; DisposedOutsideScopeCount: " + statistics.DisposedOutsideScopeCount);
+            sb.Append("; CreatedInScopeCount: " + statistics.CreatedInScopeCount);
+            sb.Append("; DisposedInScopeCount: " + statistics.DisposedInScopeCount);
+            sb.Append("; AttachedToScopeCount: " + statistics.AttachedToScopeCount);
+            sb.Append("; DetachedFromScopeCount: " + statistics.DetachedFromScopeCount);
+            return sb.ToString();
         }
     }
 }
+

--- a/test/TorchSharpTest/TestDisposeScopes.cs
+++ b/test/TorchSharpTest/TestDisposeScopes.cs
@@ -22,10 +22,10 @@ namespace TorchSharp
         {
             DisposeScopeManager.Statistics.Reset();
             using (var scope1 = torch.NewDisposeScope()) {
-                var a1 = 1.ToTensor(); // This one is caught
-                var a2 = 2.ToTensor().DetachFromDisposeScope(); // This one is lost
-                var a3 = 3.ToTensor().MoveToOuterDisposeScope(); // This one is lost also
-                using var a4 = 4.ToTensor(); // This one was manually disposed
+                var a1 = torch.tensor(1); // This one is caught
+                var a2 = torch.tensor(2).DetachFromDisposeScope(); // This one is lost
+                var a3 = torch.tensor(3).MoveToOuterDisposeScope(); // This one is lost also
+                using var a4 = torch.tensor(4); // This one was manually disposed
                 var disposables = scope1.DisposablesView;
                 Assert.Multiple(
                     () => Assert.True(Contains(disposables, a1)),
@@ -36,10 +36,9 @@ namespace TorchSharp
             }
 
             Assert.Multiple(
-                () => Assert.Equal(0, DisposeScopeManager.Statistics.ThreadTotalLiveCount),
-                // These numbers are higher than I expected them to be.
-                // () => Assert.Equal(4, DisposeScopeManager.Statistics.CreatedInScopeCount),
-                // () => Assert.Equal(2, DisposeScopeManager.Statistics.DisposedInScopeCount),
+                () => Assert.Equal(2, DisposeScopeManager.Statistics.ThreadTotalLiveCount),
+                () => Assert.Equal(4, DisposeScopeManager.Statistics.CreatedInScopeCount),
+                () => Assert.Equal(2, DisposeScopeManager.Statistics.DisposedInScopeCount),
                 () => Assert.Equal(2, DisposeScopeManager.Statistics.DetachedFromScopeCount),
                 () => Assert.Equal(0, DisposeScopeManager.Statistics.CreatedOutsideScopeCount)
             );
@@ -218,9 +217,10 @@ namespace TorchSharp
                 _testOutputHelper.WriteLine($"Undisposed Tensors inside DisposeScope: {d.DisposablesCount}");
             }
 
-            Assert.Equal(0, DisposeScopeManager.Statistics.ThreadTotalLiveCount);
             _testOutputHelper.WriteLine(
                 $"Undisposed Tensors after DisposeScope: {DisposeScopeManager.Statistics.ThreadTotalLiveCount}");
+
+            Assert.Equal(0, DisposeScopeManager.Statistics.ThreadTotalLiveCount);
             DisposeScopeManager.Statistics.Reset();
         }
 

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsBase.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsBase.cs
@@ -39,15 +39,20 @@ namespace TorchSharp
             long detached,
             long threadTotalLive)
         {
-            AssertStatCounts(createdOutside, disposedOutside,
-                createdIn, disposedIn,
-                attached, detached, threadTotalLive, DisposeScopeManager.Statistics);
+            var stats = DisposeScopeManager.Statistics;
+            Assert.True(createdOutside == stats.CreatedOutsideScopeCount, $"CreatedOutsideScopeCount: Expected({createdOutside})!={stats.CreatedOutsideScopeCount}");
+            Assert.True(disposedOutside == stats.DisposedOutsideScopeCount, $"DisposedOutsideScopeCount: Expected({disposedOutside})!={stats.DisposedOutsideScopeCount}");
+            Assert.True(createdIn == stats.CreatedInScopeCount, $"CreatedInScope: Expected({createdIn})!={stats.CreatedInScopeCount}");
+            Assert.True(disposedIn == stats.DisposedInScopeCount, $"DisposedInScopeCount: Expected({disposedIn})!={stats.DisposedInScopeCount}");
+            Assert.True(attached == stats.AttachedToScopeCount, $"AttachedToScopeCount: Expected({attached})!={stats.AttachedToScopeCount}");
+            Assert.True(detached == stats.DetachedFromScopeCount, $"DetachedFromScopeCount: Expected({detached})!={stats.DetachedFromScopeCount}");
+            Assert.True(threadTotalLive == stats.ThreadTotalLiveCount, $"ThreadTotalLiveCount: Expected({threadTotalLive})!={stats.ThreadTotalLiveCount}");
         }
 
         protected static void AssertStatCounts(long createdOutside, long disposedOutside,
             long createdIn, long disposedIn,
             long attached, long detached,
-            long threadTotalLive, ILifetimeStatistics stats)
+            long threadTotalLive, LifetimeStatistics stats)
         {
             Assert.True(createdOutside == stats.CreatedOutsideScopeCount, $"CreatedOutsideScopeCount: Expected({createdOutside})!={stats.CreatedOutsideScopeCount}");
             Assert.True(disposedOutside == stats.DisposedOutsideScopeCount, $"DisposedOutsideScopeCount: Expected({disposedOutside})!={stats.DisposedOutsideScopeCount}");

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsBase.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsBase.cs
@@ -7,16 +7,54 @@ namespace TorchSharp
         protected static void ResetStats()
         {
             DisposeScopeManager.Statistics.Reset();
-            AssertStatCounts(0, 0, 0, 0, 0);
+            AssertPackedCounts(0, 0, 0, 0, 0, 0, 0);
+            AssertTensorCounts(0, 0, 0, 0, 0, 0, 0);
+            AssertTotalsCounts(0, 0, 0, 0, 0, 0, 0);
         }
 
-        protected static void AssertStatCounts(long createdInScope, long createdOutsideScope, long detachedFrom, long disposedIn, long threadTotalLive)
+        protected static void AssertTensorCounts(long createdOutside, long disposedOutside,
+            long createdIn, long disposedIn,
+            long attached, long detached,
+            long threadTotalLive)
         {
-            var stats = DisposeScopeManager.Statistics;
-            Assert.True(createdInScope == stats.CreatedInScopeCount, $"CreatedInScope: Expected({createdInScope})!={stats.CreatedInScopeCount}");
-            Assert.True(createdOutsideScope == stats.CreatedOutsideScopeCount, $"CreatedOutsideScopeCount: Expected({createdOutsideScope})!={stats.CreatedOutsideScopeCount}");
-            Assert.True(detachedFrom == stats.DetachedFromScopeCount, $"DetachedFromScopeCount: Expected({detachedFrom})!={stats.DetachedFromScopeCount}");
+            AssertStatCounts(createdOutside, disposedOutside,
+                createdIn, disposedIn,
+                attached, detached, threadTotalLive, DisposeScopeManager.Statistics.TensorStatistics);
+        }
+
+        protected static void AssertPackedCounts(long createdOutside, long disposedOutside,
+            long createdIn, long disposedIn,
+            long attached, long detached,
+            long threadTotalLive)
+        {
+            AssertStatCounts(createdOutside, disposedOutside,
+                createdIn, disposedIn,
+                attached, detached, threadTotalLive, DisposeScopeManager.Statistics.PackedSequenceStatistics);
+        }
+
+        protected static void AssertTotalsCounts(long createdOutside,
+            long disposedOutside,
+            long createdIn, long disposedIn,
+            long attached,
+            long detached,
+            long threadTotalLive)
+        {
+            AssertStatCounts(createdOutside, disposedOutside,
+                createdIn, disposedIn,
+                attached, detached, threadTotalLive, DisposeScopeManager.Statistics);
+        }
+
+        protected static void AssertStatCounts(long createdOutside, long disposedOutside,
+            long createdIn, long disposedIn,
+            long attached, long detached,
+            long threadTotalLive, ILifetimeStatistics stats)
+        {
+            Assert.True(createdOutside == stats.CreatedOutsideScopeCount, $"CreatedOutsideScopeCount: Expected({createdOutside})!={stats.CreatedOutsideScopeCount}");
+            Assert.True(disposedOutside == stats.DisposedOutsideScopeCount, $"DisposedOutsideScopeCount: Expected({disposedOutside})!={stats.DisposedOutsideScopeCount}");
+            Assert.True(createdIn == stats.CreatedInScopeCount, $"CreatedInScope: Expected({createdIn})!={stats.CreatedInScopeCount}");
             Assert.True(disposedIn == stats.DisposedInScopeCount, $"DisposedInScopeCount: Expected({disposedIn})!={stats.DisposedInScopeCount}");
+            Assert.True(attached == stats.AttachedToScopeCount, $"AttachedToScopeCount: Expected({attached})!={stats.AttachedToScopeCount}");
+            Assert.True(detached == stats.DetachedFromScopeCount, $"DetachedFromScopeCount: Expected({detached})!={stats.DetachedFromScopeCount}");
             Assert.True(threadTotalLive == stats.ThreadTotalLiveCount, $"ThreadTotalLiveCount: Expected({threadTotalLive})!={stats.ThreadTotalLiveCount}");
         }
     }

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsTensor.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsTensor.cs
@@ -5,33 +5,38 @@ namespace TorchSharp
     [Collection("Sequential")]
     public class TestDisposeScopesStatisticsTensorScoped : TestDisposeScopesStatisticsBase
     {
+        public TestDisposeScopesStatisticsTensorScoped()
+        {
+            ResetStats();
+        }
+
         [Fact]
         public void CreatingIncrementsCreatedInScopeOnce()
         {
             using var scope = torch.NewDisposeScope();
-            ResetStats();
-            var t = torch.tensor(3);
-            AssertStatCounts(1, 0, 0, 0, 1);
+            using var t = torch.tensor(3);
+            AssertTensorCounts(0, 0, 1, 0, 0, 0, 1);
+            AssertTotalsCounts(0, 0, 1, 0, 0, 0, 1);
         }
 
         [Fact]
-        public void AttachingIncrementsNothing()
+        public void AttachingToScopeAlreadyAttachedToIncrementsNothing()
         {
             using var scope = torch.NewDisposeScope();
-            var t = torch.tensor(3);
-            ResetStats();
+            using var t = torch.tensor(3);
             scope.Attach(t);
-            AssertStatCounts(0, 0, 0, 0, 0);
+            AssertTensorCounts(0, 0, 1, 0, 0, 0, 1);
+            AssertTotalsCounts(0, 0, 1, 0, 0, 0, 1);
         }
 
         [Fact]
         public void DetachingIncrementsDetachedOnce()
         {
             using var scope = torch.NewDisposeScope();
-            var t = torch.tensor(3);
-            ResetStats();
+            using var t = torch.tensor(3);
             scope.Detach(t);
-            AssertStatCounts(0, 0, 1, 0, -1);
+            AssertTensorCounts(0, 0, 1, 0, 0, 1, 1);
+            AssertTotalsCounts(0, 0, 1, 0, 0, 1, 1);
         }
 
         [Fact]
@@ -39,30 +44,55 @@ namespace TorchSharp
         {
             using var scope = torch.NewDisposeScope();
             var t = torch.tensor(3);
-            ResetStats();
             t.Dispose();
-            AssertStatCounts(0, 0, 0, 1, -1);
+            AssertTensorCounts(0, 0, 1, 1, 0, 0, 0);
+            AssertTotalsCounts(0, 0, 1, 1, 0, 0, 0);
+
+            t.Dispose();
+            //Ensuring the count doesn't increment again (no re-entry)
+            AssertTensorCounts(0, 0, 1, 1, 0, 0, 0);
         }
 
         [Fact]
         public void DisposingScopeIncrementsDisposedOnce()
         {
             var scope = torch.NewDisposeScope();
-            var t = torch.tensor(3);
-            ResetStats();
+            using var t = torch.tensor(3);
             scope.Dispose();
-            AssertStatCounts(0, 0, 0, 1, -1);
+            AssertTensorCounts(0, 0, 1, 1, 0, 0, 0);
+            AssertTotalsCounts(0, 0, 1, 1, 0, 0, 0);
         }
 
         [Fact]
         public void DisposingScopeAfterDetachingDoesNothing()
         {
             var scope = torch.NewDisposeScope();
-            var t = torch.tensor(3);
+            using var t = torch.tensor(3);
             scope.Detach(t);
-            ResetStats();
             scope.Dispose();
-            AssertStatCounts(0, 0, 0, 0, 0);
+            AssertTensorCounts(0, 0, 1, 0, 0, 1, 1);
+            AssertTotalsCounts(0, 0, 1, 0, 0, 1, 1);
+        }
+
+        [Fact]
+        public void ToTensorCreatesOrphanedTensorButDisposeScopeCleansItUp()
+        {
+            //Defect: This needs fixing but is unrelated to the commit that discovered
+            //it - adding better lifetime statistics. ToTensor() leaks 1 tensor
+            //every time it is called.
+            var scope = torch.NewDisposeScope();
+            var stats = DisposeScopeManager.Statistics;
+            stats.Reset();
+            var a1 = 1.ToTensor();
+            Assert.Equal(2, stats.CreatedInScopeCount);
+            //Should be 1, or can remain 0 if CreatedInScope becomes 1.
+            Assert.Equal(0, stats.DisposedInScopeCount);
+            a1.Dispose();
+            Assert.Equal(1, stats.DisposedInScopeCount);
+
+            //Should not need this if no orphan.
+            scope.Dispose();
+            Assert.Equal(2, stats.DisposedInScopeCount);
         }
     }
 }

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsTensorUnscoped.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsTensorUnscoped.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using Tensorboard;
 using Xunit;
 
 namespace TorchSharp
@@ -5,87 +8,129 @@ namespace TorchSharp
     [Collection("Sequential")]
     public class TestDisposeScopesStatisticsTensorUnscoped : TestDisposeScopesStatisticsBase
     {
+        public TestDisposeScopesStatisticsTensorUnscoped()
+        {
+            ResetStats();
+        }
 
         [Fact]
         public void CreatingIncrementsCreatedOutsideScope()
         {
-            ResetStats();
-            var t = torch.tensor(3);
-            AssertStatCounts(0, 1, 0, 0, 0);
+            using var t = torch.tensor(3);
+            AssertTensorCounts(1, 0, 0, 0, 0, 0, 1);
+            AssertTotalsCounts(1, 0, 0, 0, 0, 0, 1);
         }
 
         [Fact]
-        public void AttachingIncrementsNothing()
+        public void AttachingIncrementsAttached()
         {
-            var t = torch.tensor(3);
-            ResetStats();
+            //What about disposing scope was moved from with Attach?
+            using var t = torch.tensor(3);
             using var scope = torch.NewDisposeScope();
             scope.Attach(t);
-            AssertStatCounts(0, 0, 0, 0, 0);
+            AssertTensorCounts(1, 0, 0, 0, 1, 0, 1);
+            AssertTotalsCounts(1, 0, 0, 0, 1, 0, 1);
         }
 
         [Fact]
-        public void DetachingIncrementsNothing()
+        public void DetachingIncrementsNothingBecauseObjectIsNotInAScope()
         {
-            var t = torch.tensor(3);
-            ResetStats();
+            using var t = torch.tensor(3);
             using var scope = torch.NewDisposeScope();
             scope.Detach(t);
-            AssertStatCounts(0, 0, 0, 0, 0);
+            AssertTensorCounts(1, 0, 0, 0, 0, 0, 1);
+            AssertTotalsCounts(1, 0, 0, 0, 0, 0, 1);
         }
 
         [Fact]
-        public void DisposingIncrementsNothing()
+        public void DisposingIncrementsDisposedOutsideScope()
         {
             var t = torch.tensor(3);
-            ResetStats();
             t.Dispose();
-            AssertStatCounts(0, 0, 0, 0, 0);
+            AssertTensorCounts(1, 1, 0, 0, 0, 0, 0);
+            AssertTotalsCounts(1, 1, 0, 0, 0, 0, 0);
+            t.Dispose();
+            //Ensuring the count doesn't increment again (no re-entry)
+            AssertTensorCounts(1, 1, 0, 0, 0, 0, 0);
         }
 
+
         [Fact]
-        public void DisposingAttachedIncrementsDisposed()
+        public void DisposingAttachedIncrementsDisposedInScope()
         {
             var t = torch.tensor(3);
             using var scope = torch.NewDisposeScope();
             scope.Attach(t);
-            ResetStats();
+
             t.Dispose();
-            AssertStatCounts(0, 0, 0, 1, -1);
+            AssertTensorCounts(1, 0, 0, 1, 1, 0, 0);
+            AssertTotalsCounts(1, 0, 0, 1, 1, 0, 0);
         }
 
         [Fact]
         public void DisposingScopeWithAttachedIncrementsDisposed()
         {
-            var t = torch.tensor(3);
+            using var t = torch.tensor(3);
             var scope = torch.NewDisposeScope();
             scope.Attach(t);
-            ResetStats();
             scope.Dispose();
-            AssertStatCounts(0, 0, 0, 1, -1);
+            AssertTensorCounts(1, 0, 0, 1, 1, 0, 0);
+            AssertTotalsCounts(1, 0, 0, 1, 1, 0, 0);
         }
 
         [Fact]
         public void DetachingAttachedIncrementsDetached()
         {
-            var t = torch.tensor(3);
+            using var t = torch.tensor(3);
             using var scope = torch.NewDisposeScope();
             scope.Attach(t);
-            ResetStats();
             scope.Detach(t);
-            AssertStatCounts(0, 0, 1, 0, -1);
+            AssertTensorCounts(1, 0, 0, 0, 1, 1, 1);
+            AssertTotalsCounts(1, 0, 0, 0, 1, 1, 1);
         }
 
         [Fact]
         public void DisposingScopeAfterDetachingDoesNothing()
         {
-            var t = torch.tensor(3);
+            using var t = torch.tensor(3);
             var scope = torch.NewDisposeScope();
             scope.Attach(t);
             scope.Detach(t);
-            ResetStats();
             scope.Dispose();
-            AssertStatCounts(0, 0, 0, 0, 0);
+            AssertTensorCounts(1, 0, 0, 0, 1, 1, 1);
+            AssertTotalsCounts(1, 0, 0, 0, 1, 1, 1);
+        }
+
+        [Fact]
+        public void AttachAgainIsSameAsMoveToOtherAndStatsDoNotChange()
+        {
+            using var t = torch.tensor(3);
+            using var scope = torch.NewDisposeScope();
+            scope.Attach(t);
+            var scope2 = torch.NewDisposeScope();
+            AssertTensorCounts(1, 0, 0, 0, 1, 0, 1);
+            AssertTotalsCounts(1, 0, 0, 0, 1, 0, 1);
+            scope2.Dispose();
+            AssertTensorCounts(1, 0, 0, 0, 1, 0, 1);
+            AssertTotalsCounts(1, 0, 0, 0, 1, 0, 1);
+        }
+
+        [Fact]
+        public void ToTensorCreatesOrphanedTensor()
+        {
+            //Defect: This needs fixing but is unrelated to the commit that discovered
+            //it - adding better lifetime statistics. ToTensor() leaks 1 tensor
+            // //every time it is called.
+            var stats = DisposeScopeManager.Statistics;
+            stats.Reset();
+            var a1 = 1.ToTensor();
+            //Should be 1 ideally. If it remains two...
+            Assert.Equal(2, stats.CreatedOutsideScopeCount);
+            // ... this should be 1
+            Assert.Equal(0, stats.DisposedOutsideScopeCount);
+            a1.Dispose();
+            //... and this should also be 2
+            Assert.Equal(1, stats.DisposedOutsideScopeCount);
         }
     }
 }

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsToString.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsToString.cs
@@ -1,0 +1,50 @@
+using System;
+using Xunit;
+
+namespace TorchSharp
+{
+    [Collection("Sequential")]
+    public class TestDisposeScopesStatisticsToString
+    {
+
+        [Fact]
+        public void TestTensorStatistics()
+        {
+            DisposeScopeManager.Statistics.Reset();
+            using var scope = torch.NewDisposeScope();
+            using var t = torch.tensor(3);
+            Assert.Equal("ThreadTotalLiveCount: 1; " +
+                         "CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; " +
+                         "CreatedInScopeCount: 1; DisposedInScopeCount: 0; " +
+                         "AttachedToScopeCount: 0; DetachedFromScopeCount: 0"
+                , DisposeScopeManager.Statistics.TensorStatistics.ToString());
+        }
+
+        [Fact]
+        public void TestPackedSequenceStatistics()
+        {
+            DisposeScopeManager.Statistics.Reset();
+            using var scope = torch.NewDisposeScope();
+            using var ps = TestDisposeScopesStatisticsPackedSequenceUnscoped.Create();
+            ps.DetachFromDisposeScope();
+            Assert.Equal("ThreadTotalLiveCount: 1; " +
+                         "CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; " +
+                         "CreatedInScopeCount: 1; DisposedInScopeCount: 0; " +
+                         "AttachedToScopeCount: 0; DetachedFromScopeCount: 1"
+                             , DisposeScopeManager.Statistics.PackedSequenceStatistics.ToString());
+        }
+
+        [Fact]
+        public void TestTotalStatistics()
+        {
+            DisposeScopeManager.Statistics.Reset();
+            using var scope = torch.NewDisposeScope();
+            using var ps = TestDisposeScopesStatisticsPackedSequenceUnscoped.Create();
+            Assert.Equal("ThreadTotalLiveCount: 5; " +
+                         "CreatedOutsideScopeCount: 0; DisposedOutsideScopeCount: 0; " +
+                         "CreatedInScopeCount: 7; DisposedInScopeCount: 2; " +
+                         "AttachedToScopeCount: 0; DetachedFromScopeCount: 4"
+                , DisposeScopeManager.Statistics.ToString());
+        }
+   }
+}

--- a/test/TorchSharpTest/TestTraining.cs
+++ b/test/TorchSharpTest/TestTraining.cs
@@ -1893,7 +1893,7 @@ namespace TorchSharp
             var x = torch.randn(new long[] { 64, 3, 28, 28 });
             var y = torch.randn(new long[] { 64, 10 });
 
-            var optimizer = torch.optim.Adam(seq.parameters());
+            using var optimizer = torch.optim.Adam(seq.parameters());
 
             TrainLoop(seq, x, y, optimizer);
         }


### PR DESCRIPTION
Improve visibility of disposables (Tensor and PackedSequence) to make memory leaks easier to troubleshoot. No breaking interface changes. This resolves #1390.

This PR is what I'd actually like to see for object lifetime statitics. It gives complete statistics for object creation and disposables whether in a DisposeScope or not, and accurate Attach/Detach counts. Lastly the ThreadTotalLiveCount is no longer estimated, it is exact. Also added documentation on how to use the statistics for troubleshooting memory leaks.

New Documentation:
memory leak troubleshooting.md - provides practical guidance on how to use the changes of this PR for useful troubleshooting of memory issues.memory.md was also updated to link to this document.

New Interface Members
* DisposedOutsideScopeCount - # of objects .Dispose when not attached to a scope
* AttachedToScopeCount - # of objects attached to a scope via .Attach
* ThreadTotalLiveCount (No longer approximate, is exact)
* ToString - creates a useful debug string for the developer.

Semantic changes: 
None of the statistics are decremented anymore. All statistics are additive only. If an event happens, it is incremented. The original DisposeScopeManager.Statistics object now represents the total combined counts for both PackedSequence and Tensor. It also has individual attributes for .TensorStatistics and .PackedSequenceStatistics where these counts are tracked individually. A common interface ILifetimeStatistics was introduced for these. Additionally the Dispose for both Tensor and PackedSequence were both modified to prevent reentry and double incrementing disposal metrics.

Defects discovered during implementing this:
1. TestDisposeScopes.MinimalDisposeWorks had commented assertions, and actually reveals the prior approximate ThreadTotalLiveCount was not capturing live tensors. It now captures them accurately. This also led to discovery of the next item (the reason for the commented assertions).
2. The .ToTensor method has always leaked a tensor that is never disposed. There are two new tests to capture this behavior as it is currently, both in and out of a DisposeScope, with comments on how they need to change when this defect is fixed. These tests are in different fixtures but both named "ToTensorCreatesOrphanedTensor". I can create a new issue for this if you decide this PR is worth moving forward, or I can try to fix it here in this PR.

I understand this is a larger PR and some siginificant API changes. Given that it provided accurate counts and helped identify defects withing TorchSharp itself, the useful utility provided by these changes is demonstrated. Let me know what you like, hate, or want changed. 

Note dependent on PR #1389 (although maybe not, the commit appears in this PR too so maybe we can close that other one).