### PR TITLE
Fix memory leaks in .ToTensor,  resolves #1392

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,7 +12,8 @@ __Bug Fixes__:
 #1383 `torch.linalg.vector_norm`: Make `ord`-argument optional, as specified in docs<br/>
 #1385 PackedSequence now participates in the DisposeScope system at the same level as Tensor objects.<br/>
 #1387 Attaching tensor to a DisposeScope no longer makes Statistics.DetachedFromScopeCount go negative.<br/>
-#1390 DisposeScopeManager.Statistics now includes DisposedOutsideScopeCount and AttachedToScopeCount. ThreadTotalLiveCount is now exact instead of approximate. ToString gives a useful debug string, and documentation is added for how to troubleshoot memory leaks. Also DisposeScopeManager.Statistics.TensorStatistics and DisposeScopeManager.Statistics.PackedSequenceStatistics provide separate metrics for these objects.
+#1390 DisposeScopeManager.Statistics now includes DisposedOutsideScopeCount and AttachedToScopeCount. ThreadTotalLiveCount is now exact instead of approximate. ToString gives a useful debug string, and documentation is added for how to troubleshoot memory leaks. Also DisposeScopeManager.Statistics.TensorStatistics and DisposeScopeManager.Statistics.PackedSequenceStatistics provide separate metrics for these objects.<br/>
+#1392 ToTensor() extension method memory leaks fixed.<br/>
 
 # NuGet Version 0.103.0
 

--- a/src/TorchSharp/Tensor/Factories/tensor_Complex.cs
+++ b/src/TorchSharp/Tensor/Factories/tensor_Complex.cs
@@ -18,9 +18,7 @@ namespace TorchSharp
             device = InitializeDevice(device);
             var handle = THSTensor_newComplexFloat64Scalar(scalar.Real, scalar.Imaginary, (int)device.type, device.index, requires_grad);
             if (handle == IntPtr.Zero) { CheckForErrors(); }
-            var tensor = new Tensor(handle);
-            tensor = dtype.HasValue ? tensor.to(dtype.Value, device) : tensor.to(device);
-            return tensor;
+            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
         }
 
         /// <summary>

--- a/src/TorchSharp/Tensor/Factories/tensor_double.cs
+++ b/src/TorchSharp/Tensor/Factories/tensor_double.cs
@@ -26,10 +26,7 @@ namespace TorchSharp
         /// </summary>
         public static Tensor tensor((double Real, double Imaginary) scalar, ScalarType? dtype = null, Device? device = null, bool requires_grad = false)
         {
-            device = InitializeDevice(device);
-            var handle = THSTensor_newComplexFloat64Scalar(scalar.Real, scalar.Imaginary, (int)device.type, device.index, requires_grad);
-            if (handle == IntPtr.Zero) { CheckForErrors(); }
-            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
+            return tensor(scalar.Real, scalar.Imaginary, dtype, device, requires_grad);
         }
 
         /// <summary>
@@ -37,7 +34,11 @@ namespace TorchSharp
         /// </summary>
         public static Tensor tensor(double real, double imaginary, ScalarType? dtype = null, Device? device = null, bool requires_grad = false)
         {
-            return tensor((real, imaginary), dtype, device, requires_grad);
+
+            device = InitializeDevice(device);
+            var handle = THSTensor_newComplexFloat64Scalar(real, imaginary, (int)device.type, device.index, requires_grad);
+            if (handle == IntPtr.Zero) { CheckForErrors(); }
+            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
         }
 
         /// <summary>

--- a/src/TorchSharp/Tensor/Factories/tensor_double.cs
+++ b/src/TorchSharp/Tensor/Factories/tensor_double.cs
@@ -18,43 +18,26 @@ namespace TorchSharp
             device = InitializeDevice(device);
             var handle = THSTensor_newFloat64Scalar(scalar, (int)device.type, device.index, requires_grad);
             if (handle == IntPtr.Zero) { CheckForErrors(); }
-            var tensor = new Tensor(handle);
-            tensor = dtype.HasValue ? tensor.to(dtype.Value, device) : tensor.to(device);
-            return tensor;
+            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
         }
 
         /// <summary>
-        /// Create a scalar tensor from a single value
+        /// Create a scalar complex number tensor from a tuple of (real, imaginary)
         /// </summary>
         public static Tensor tensor((double Real, double Imaginary) scalar, ScalarType? dtype = null, Device? device = null, bool requires_grad = false)
         {
             device = InitializeDevice(device);
             var handle = THSTensor_newComplexFloat64Scalar(scalar.Real, scalar.Imaginary, (int)device.type, device.index, requires_grad);
             if (handle == IntPtr.Zero) { CheckForErrors(); }
-            var tensor = new Tensor(handle);
-            if (device is { }) {
-                tensor = dtype.HasValue ? tensor.to(dtype.Value, device) : tensor.to(device);
-            } else if (dtype.HasValue) {
-                tensor = tensor.to_type(dtype.Value);
-            }
-            return tensor;
+            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
         }
 
         /// <summary>
-        /// Create a scalar tensor from a single value
+        /// Create a scalar complex number tensor from independent real and imaginary components
         /// </summary>
         public static Tensor tensor(double real, double imaginary, ScalarType? dtype = null, Device? device = null, bool requires_grad = false)
         {
-            device = InitializeDevice(device);
-            var handle = THSTensor_newComplexFloat64Scalar(real, imaginary, (int)device.type, device.index, requires_grad);
-            if (handle == IntPtr.Zero) { CheckForErrors(); }
-            var tensor = new Tensor(handle);
-            if (device is { }) {
-                tensor = dtype.HasValue ? tensor.to(dtype.Value, device) : tensor.to(device);
-            } else if (dtype.HasValue) {
-                tensor = tensor.to_type(dtype.Value);
-            }
-            return tensor;
+            return tensor((real, imaginary), dtype, device, requires_grad);
         }
 
         /// <summary>

--- a/src/TorchSharp/Tensor/Factories/tensor_float.cs
+++ b/src/TorchSharp/Tensor/Factories/tensor_float.cs
@@ -26,7 +26,10 @@ namespace TorchSharp
         /// </summary>
         public static Tensor tensor(float real, float imaginary, ScalarType? dtype = null, Device? device = null, bool requires_grad = false)
         {
-            return tensor((real, imaginary), dtype: dtype, device: device);
+            device = InitializeDevice(device);
+            var handle = THSTensor_newComplexFloat32Scalar(real, imaginary, (int)device.type, device.index, requires_grad);
+            if (handle == IntPtr.Zero) { CheckForErrors(); }
+            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
         }
 
         /// <summary>
@@ -34,10 +37,7 @@ namespace TorchSharp
         /// </summary>
         public static Tensor tensor((float Real, float Imaginary) scalar, ScalarType? dtype = null, Device? device = null, bool requires_grad = false)
         {
-            device = InitializeDevice(device);
-            var handle = THSTensor_newComplexFloat32Scalar(scalar.Real, scalar.Imaginary, (int)device.type, device.index, requires_grad);
-            if (handle == IntPtr.Zero) { CheckForErrors(); }
-            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
+            return tensor(scalar.Real, scalar.Imaginary, dtype: dtype, device: device);
         }
 
         /// <summary>

--- a/src/TorchSharp/Tensor/Factories/tensor_float.cs
+++ b/src/TorchSharp/Tensor/Factories/tensor_float.cs
@@ -22,37 +22,22 @@ namespace TorchSharp
         }
 
         /// <summary>
-        /// Create a scalar tensor from a single value
+        /// Create a scalar complex number tensor from independent real and imaginary components
         /// </summary>
         public static Tensor tensor(float real, float imaginary, ScalarType? dtype = null, Device? device = null, bool requires_grad = false)
         {
-            device = InitializeDevice(device);
-            var handle = THSTensor_newComplexFloat32Scalar(real, imaginary, (int)device.type, device.index, requires_grad);
-            if (handle == IntPtr.Zero) { CheckForErrors(); }
-            var tensor = new Tensor(handle);
-            if (device is { }) {
-                tensor = dtype.HasValue ? tensor.to(dtype.Value, device) : tensor.to(device);
-            } else if (dtype.HasValue) {
-                tensor = tensor.to_type(dtype.Value);
-            }
-            return tensor;
+            return tensor((real, imaginary), dtype: dtype, device: device);
         }
 
         /// <summary>
-        /// Create a scalar tensor from a single value
+        /// Create a scalar complex number tensor from a tuple of (real, imaginary)
         /// </summary>
         public static Tensor tensor((float Real, float Imaginary) scalar, ScalarType? dtype = null, Device? device = null, bool requires_grad = false)
         {
             device = InitializeDevice(device);
             var handle = THSTensor_newComplexFloat32Scalar(scalar.Real, scalar.Imaginary, (int)device.type, device.index, requires_grad);
             if (handle == IntPtr.Zero) { CheckForErrors(); }
-            var tensor = new Tensor(handle);
-            if (device is { }) {
-                tensor = dtype.HasValue ? tensor.to(dtype.Value, device) : tensor.to(device);
-            } else if (dtype.HasValue) {
-                tensor = tensor.to_type(dtype.Value);
-            }
-            return tensor;
+            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
         }
 
         /// <summary>

--- a/src/TorchSharp/Tensor/Factories/tensor_long.cs
+++ b/src/TorchSharp/Tensor/Factories/tensor_long.cs
@@ -18,13 +18,7 @@ namespace TorchSharp
             device = InitializeDevice(device);
             var handle = THSTensor_newInt64Scalar(scalar, (int)device.type, device.index, requires_grad);
             if (handle == IntPtr.Zero) { CheckForErrors(); }
-            var tensor = new Tensor(handle);
-            if (device is { }) {
-                tensor = dtype.HasValue ? tensor.to(dtype.Value, device) : tensor.to(device);
-            } else if (dtype.HasValue) {
-                tensor = tensor.to_type(dtype.Value);
-            }
-            return tensor;
+            return InstantiateTensorWithLeakSafeTypeChange(handle, dtype);
         }
 
         /// <summary>

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -7402,5 +7402,15 @@ namespace TorchSharp
             var result = expr();
             return result.MoveToOuterDisposeScope();
         }
+        internal static Tensor InstantiateTensorWithLeakSafeTypeChange(IntPtr handle, ScalarType? dtype)
+        {
+            var tensor = new Tensor(handle);
+            if (dtype.HasValue) {
+                var typed = tensor.to_type(dtype.Value);
+                tensor.Dispose();
+                return typed;
+            }
+            return tensor;
+        }
     }
 }

--- a/src/TorchSharp/Tensor/Tensor.cs
+++ b/src/TorchSharp/Tensor/Tensor.cs
@@ -7405,7 +7405,7 @@ namespace TorchSharp
         internal static Tensor InstantiateTensorWithLeakSafeTypeChange(IntPtr handle, ScalarType? dtype)
         {
             var tensor = new Tensor(handle);
-            if (dtype.HasValue) {
+            if (dtype.HasValue && tensor.dtype != dtype.Value) {
                 var typed = tensor.to_type(dtype.Value);
                 tensor.Dispose();
                 return typed;

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsTensor.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsTensor.cs
@@ -73,26 +73,5 @@ namespace TorchSharp
             AssertTensorCounts(0, 0, 1, 0, 0, 1, 1);
             AssertTotalsCounts(0, 0, 1, 0, 0, 1, 1);
         }
-
-        [Fact]
-        public void ToTensorCreatesOrphanedTensorButDisposeScopeCleansItUp()
-        {
-            //Defect: This needs fixing but is unrelated to the commit that discovered
-            //it - adding better lifetime statistics. ToTensor() leaks 1 tensor
-            //every time it is called.
-            var scope = torch.NewDisposeScope();
-            var stats = DisposeScopeManager.Statistics;
-            stats.Reset();
-            var a1 = 1.ToTensor();
-            Assert.Equal(2, stats.CreatedInScopeCount);
-            //Should be 1, or can remain 0 if CreatedInScope becomes 1.
-            Assert.Equal(0, stats.DisposedInScopeCount);
-            a1.Dispose();
-            Assert.Equal(1, stats.DisposedInScopeCount);
-
-            //Should not need this if no orphan.
-            scope.Dispose();
-            Assert.Equal(2, stats.DisposedInScopeCount);
-        }
     }
 }

--- a/test/TorchSharpTest/TestDisposeScopesStatisticsTensorUnscoped.cs
+++ b/test/TorchSharpTest/TestDisposeScopesStatisticsTensorUnscoped.cs
@@ -114,23 +114,5 @@ namespace TorchSharp
             AssertTensorCounts(1, 0, 0, 0, 1, 0, 1);
             AssertTotalsCounts(1, 0, 0, 0, 1, 0, 1);
         }
-
-        [Fact]
-        public void ToTensorCreatesOrphanedTensor()
-        {
-            //Defect: This needs fixing but is unrelated to the commit that discovered
-            //it - adding better lifetime statistics. ToTensor() leaks 1 tensor
-            // //every time it is called.
-            var stats = DisposeScopeManager.Statistics;
-            stats.Reset();
-            var a1 = 1.ToTensor();
-            //Should be 1 ideally. If it remains two...
-            Assert.Equal(2, stats.CreatedOutsideScopeCount);
-            // ... this should be 1
-            Assert.Equal(0, stats.DisposedOutsideScopeCount);
-            a1.Dispose();
-            //... and this should also be 2
-            Assert.Equal(1, stats.DisposedOutsideScopeCount);
-        }
     }
 }


### PR DESCRIPTION
This resolved the orphan tensor issue. 

Please note for tensor creation, I removed branches that were checking if device was supplied - this branch would always take precedence over the else branch that was checking dtype, because of the `InitializeDevice` call at the beginning. Not sure why that branch was there, since the tensor is being created on the correct device initially.

Since there was much duplication related to managing disposing the initial tensor when a dtype conversion was necessary, I've created new internal factory method `Tensor.InstantiateTensorWithLeakSafeTypeChange` to manage this. I can't say I love the name, but it's accurate, suggestions welcome. Also if there is a better place to put that method am happy to move it.

In the case of complex numbers, there were overloads that excepted a tuple (real, imaginary) and another that accepted them separately. I updated on to delegate to the other to reduce duplication since the implementations were identical. Release notes updated too.

Lastly I removed the two tests I added on the prior commit that capture the leak behavior, since there are now new and better tests that cover a broader range of scenarios.