### PR TITLE
Call `Tensor::alias()` when concatenating a list of count 1

### DIFF
--- a/src/TorchSharp/Tensor/torch.IndexingSlicingJoiningMutatingOps.cs
+++ b/src/TorchSharp/Tensor/torch.IndexingSlicingJoiningMutatingOps.cs
@@ -40,7 +40,7 @@ namespace TorchSharp
             switch (tensors.Count)
             {
                 case <=0: throw new ArgumentException(nameof(tensors));
-                case 1: return tensors[0];
+                case 1: return tensors[0].alias();
             }
 
             using var parray = new PinnedArray<IntPtr>();


### PR DESCRIPTION
This ensures that disposing the result has the same impact as it would with a different size.