### PR TITLE
Fix LinearLR end_factor default.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,8 @@ Releases, starting with 9/2/2021, are listed with the most recent release at the
 __Bug Fixes__:
 
 #1426 Sequential.eval() does not put model into eval mode<br/>
+`torch.optim.lr_scheduler.LinearLR` `end_factor` default has been corrected, is now 1.0.<br/>
+
 # NuGet Version 0.105.0
 
 Move to libtorch 2.5.1. As with the 2.4.0 release, MacOS / Intel is no longer supported by libtorch, so TorchSharp doesn, either.

--- a/src/TorchSharp/Optimizers/LRScheduler.cs
+++ b/src/TorchSharp/Optimizers/LRScheduler.cs
@@ -1398,7 +1398,7 @@ namespace TorchSharp
                 /// </param>
                 /// <param name="verbose">If true, prints a message to stdout for each update. Default: false.</param>
                 /// <returns>A scheduler</returns>
-                public static LRScheduler LinearLR(Optimizer optimizer, double start_factor = 1.0 / 3, double end_factor = 5, int total_iters = 5, int last_epoch = -1, bool verbose = false)
+                public static LRScheduler LinearLR(Optimizer optimizer, double start_factor = 1.0 / 3, double end_factor = 1.0, int total_iters = 5, int last_epoch = -1, bool verbose = false)
                 {
                     return new impl.LinearLR(optimizer, start_factor, end_factor, total_iters, last_epoch, verbose);
                 }


### PR DESCRIPTION
`torch.optim.lr_scheduler.LinearLR` `end_factor` default was `5`, but should be `1.0`.
Most probably, it would be a typo influenced from `total_iters` default (`5`).
See also https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.LinearLR.html