### PR TITLE
Add torchvision.transforms.Resize interpolation and antialias.

### DIFF
--- a/src/Native/LibTorchSharp/THSNN.cpp
+++ b/src/Native/LibTorchSharp/THSNN.cpp
@@ -109,6 +109,8 @@ void ApplyInterpolateMode(T& opts, const int8_t mode)
         opts = opts.mode(torch::kTrilinear);
     if (mode == 5)
         opts = opts.mode(torch::kArea);
+    if (mode == 6)
+        opts = opts.mode(torch::kNearestExact);
 }
 
 template<typename T>
@@ -176,13 +178,14 @@ Tensor THSNN_affine_grid(const Tensor theta, const int64_t* size, const int size
 }
 
 
-EXPORT_API(Tensor) THSNN_interpolate(const Tensor input, const int64_t* size, const int size_len, const double* scale_factor, const int scale_factor_len, const int8_t mode, const int8_t align_corners, const bool recompute_scale_factor, NNAnyModule* outAsAnyModule)
+EXPORT_API(Tensor) THSNN_interpolate(const Tensor input, const int64_t* size, const int size_len, const double* scale_factor, const int scale_factor_len, const int8_t mode, const int8_t align_corners, const bool recompute_scale_factor, const bool antialias, NNAnyModule* outAsAnyModule)
 {
     auto opts = torch::nn::functional::InterpolateFuncOptions().recompute_scale_factor(recompute_scale_factor);
     // align_corners -- 0=None, 1=true, 2=false
     if (align_corners != 0)
         opts.align_corners(align_corners == 1);
     ApplyInterpolateMode(opts, mode);
+    opts.antialias(antialias);
 
     if (size_len > 0) {
         std::vector<int64_t> sizes;

--- a/src/Native/LibTorchSharp/THSNN.h
+++ b/src/Native/LibTorchSharp/THSNN.h
@@ -71,7 +71,7 @@ EXPORT_API(Tensor)   THSNN_pixel_unshuffle(const Tensor tensor, const int64_t do
 // Vision -- Functions
 
 EXPORT_API(Tensor) THSNN_pad(const Tensor input, const int64_t* pad, const int pad_length, const int8_t mode, const double value);
-EXPORT_API(Tensor) THSNN_interpolate(const Tensor input, const int64_t* size, const int size_len, const double* scale_factor, const int scale_factor_len, const int8_t mode, const int8_t align_corners, const bool recompute_scale_factor, NNAnyModule* outAsAnyModule);
+EXPORT_API(Tensor) THSNN_interpolate(const Tensor input, const int64_t* size, const int size_len, const double* scale_factor, const int scale_factor_len, const int8_t mode, const int8_t align_corners, const bool recompute_scale_factor, const bool antialias, NNAnyModule* outAsAnyModule);
 EXPORT_API(Tensor) THSNN_grid_sample(const Tensor input, const Tensor grid, const int8_t mode, const int8_t padding_mode, const int8_t align_corners);
 EXPORT_API(Tensor) THSNN_affine_grid(const Tensor theta, const int64_t* size, const int size_len, const bool align_corners);
 

--- a/src/TorchSharp/PInvoke/LibTorchSharp.THSNN.cs
+++ b/src/TorchSharp/PInvoke/LibTorchSharp.THSNN.cs
@@ -44,7 +44,7 @@ namespace TorchSharp.PInvoke
 
         [DllImport("LibTorchSharp")]
         // align_corners -- 0=None, 1=true, 2=false
-        internal static extern IntPtr THSNN_interpolate(IntPtr input, IntPtr size, int size_len, IntPtr scale_factor, int scale_factor_len, byte mode, byte align_corners, [MarshalAs(UnmanagedType.U1)] bool recompute_scale_factor);
+        internal static extern IntPtr THSNN_interpolate(IntPtr input, IntPtr size, int size_len, IntPtr scale_factor, int scale_factor_len, byte mode, byte align_corners, [MarshalAs(UnmanagedType.U1)] bool recompute_scale_factor, [MarshalAs(UnmanagedType.U1)] bool antialias);
 
         [DllImport("LibTorchSharp")]
         // align_corners -- 0=None, 1=true, 2=false

--- a/src/TorchVision/Resize.cs
+++ b/src/TorchVision/Resize.cs
@@ -8,20 +8,24 @@ namespace TorchSharp
     {
         internal class Resize : ITransform
         {
-            internal Resize(int height, int width, int? maxSize)
+            internal Resize(int height, int width, InterpolationMode interpolation, int? maxSize, bool antialias)
             {
                 this.height = height;
                 this.width = width;
+                this.interpolation = interpolation;
                 this.maxSize = maxSize;
+                this.antialias = antialias;
             }
 
             public Tensor call(Tensor input)
             {
-                return transforms.functional.resize(input, height, width, maxSize);
+                return transforms.functional.resize(input, height, width, interpolation, maxSize, antialias);
             }
 
             private int height, width;
+            private InterpolationMode interpolation;
             private int? maxSize;
+            private bool antialias;
         }
 
         public static partial class transforms
@@ -31,20 +35,45 @@ namespace TorchSharp
             /// </summary>
             /// <param name="height">Desired output height</param>
             /// <param name="width">Desired output width</param>
+            /// <param name="interpolation">
+            /// Desired interpolation enum defined by TorchSharp.torch.InterpolationMode.
+            /// Default is InterpolationMode.Nearest; not InterpolationMode.Bilinear (incompatible to Python's torchvision v0.17 or later for historical reasons).
+            /// Only InterpolationMode.Nearest, InterpolationMode.NearestExact, InterpolationMode.Bilinear and InterpolationMode.Bicubic are supported.
+            /// </param>
+            /// <param name="maxSize">The maximum allowed for the longer edge of the resized image.</param>
+            /// <param name="antialias">
+            /// Whether to apply antialiasing.
+            /// It only affects bilinear or bicubic modes and it is ignored otherwise.
+            /// Possible values are:
+            /// * true: will apply antialiasing for bilinear or bicubic modes. Other mode aren't affected. This is probably what you want to use.
+            /// * false (default, incompatible to Python's torchvision v0.17 or later for historical reasons): will not apply antialiasing on any mode.
+            /// </param>
             /// <returns></returns>
-            static public ITransform Resize(int height, int width)
+            static public ITransform Resize(int height, int width, InterpolationMode interpolation = InterpolationMode.Nearest, int? maxSize = null, bool antialias = false)
             {
-                return new Resize(height, width, null);
+                return new Resize(height, width, interpolation, maxSize, antialias);
             }
 
             /// <summary>
             /// Resize the input image to the given size.
             /// </summary>
             /// <param name="size">Desired output size</param>
-            /// <param name="maxSize">Max size</param>
-            static public ITransform Resize(int size, int? maxSize = null)
+            /// <param name="interpolation">
+            /// Desired interpolation enum defined by TorchSharp.torch.InterpolationMode.
+            /// Default is InterpolationMode.Nearest; not InterpolationMode.Bilinear (incompatible to Python's torchvision v0.17 or later for historical reasons).
+            /// Only InterpolationMode.Nearest, InterpolationMode.NearestExact, InterpolationMode.Bilinear and InterpolationMode.Bicubic are supported.
+            /// </param>
+            /// <param name="maxSize">The maximum allowed for the longer edge of the resized image.</param>
+            /// <param name="antialias">
+            /// Whether to apply antialiasing.
+            /// It only affects bilinear or bicubic modes and it is ignored otherwise.
+            /// Possible values are:
+            /// * true: will apply antialiasing for bilinear or bicubic modes. Other mode aren't affected. This is probably what you want to use.
+            /// * false (default, incompatible to Python's torchvision v0.17 or later for historical reasons): will not apply antialiasing on any mode.
+            /// </param>
+            static public ITransform Resize(int size, InterpolationMode interpolation = InterpolationMode.Nearest, int? maxSize = null, bool antialias = false)
             {
-                return new Resize(size, -1, maxSize);
+                return new Resize(size, -1, interpolation, maxSize, antialias);
             }
         }
     }

--- a/test/TorchSharpTest/NN.cs
+++ b/test/TorchSharpTest/NN.cs
@@ -6669,6 +6669,18 @@ namespace TorchSharp
         }
 
         [Fact]
+        public void TestInterpolateNearestExact()
+        {
+            foreach (var device in TestUtils.AvailableDevices()) {
+                using (Tensor input = torch.arange(1, 5, float32, device: device).view(1, 1, 2, 2))
+                using (var res = interpolate(input, scale_factor: new double[] { 2, 2 }, mode: InterpolationMode.NearestExact)) {
+                    Assert.Equal(device.type, res.device_type);
+                    Assert.Equal(new long[] { 1, 1, 4, 4 }, res.shape);
+                }
+            }
+        }
+
+        [Fact]
         public void TestUpsampleNearest()
         {
             foreach (var device in TestUtils.AvailableDevices()) {

--- a/test/TorchSharpTest/TestTorchVision.cs
+++ b/test/TorchSharpTest/TestTorchVision.cs
@@ -938,7 +938,7 @@ namespace TorchVision
             int size = 20;
             int? maxSize = 30;
             var input = torch.randn(1, 3, 256, 256);
-            var transform = Resize(size, maxSize);
+            var transform = Resize(size, maxSize: maxSize);
 
             //Act
             var result = transform.call(input);
@@ -1345,7 +1345,7 @@ namespace TorchVision
             int? maxSize = 8;
 
             // Act + Assert
-            Assert.Throws<System.ArgumentException>(() => functional.resize(input, height, -1, maxSize));
+            Assert.Throws<System.ArgumentException>(() => functional.resize(input, height, -1, maxSize: maxSize));
         }
 
         [Fact]
@@ -1357,7 +1357,7 @@ namespace TorchVision
             int? maxSize = 10;
 
             // Act + Assert
-            functional.resize(input, height, -1, maxSize);
+            functional.resize(input, height, -1, maxSize: maxSize);
         }
 
 


### PR DESCRIPTION
`torchvision.transforms.Resize` forced nearest `interpolation` and no `antialias`, but shouln't.
Based on my understanding, original `torchvision.transforms.Resize `calls like;
- `torchvision.transforms.Resize`
  - `torchvision.transforms.functional.resize`
    - `torchvision.transforms._functional_pil.resize`
      - `PIL.Image.Image.resize`
    - `torchvision.transforms._functional_tensor.resize`
      - `torch.nn.functional.interpolate`
 
Note, this PR still keeps nearest `interpolation` and no `antialias` by default for `torchvision.transforms.Resize` to maximize compatibility for existing code using TorchSharp and results in incompatible to original `torchvision.transforms.Resize` default, however, it would be up to the upstream decision.
See also;
* https://pytorch.org/vision/main/generated/torchvision.transforms.Resize.html
* https://pytorch.org/vision/main/generated/torchvision.transforms.functional.resize.html
* https://pytorch.org/docs/stable/generated/torch.nn.functional.interpolate.html